### PR TITLE
Don't rewrite history for test result tabs

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -191,7 +191,7 @@ function setCurrentPreview(stepPreviewContainer, force) {
   ) {
     $('.current_preview').removeClass('current_preview');
     hidePreviewContainer();
-    setPageHashAccordingToCurrentTab('', true);
+    setPageHashAccordingToCurrentTab('');
     return;
   }
 
@@ -203,7 +203,7 @@ function setCurrentPreview(stepPreviewContainer, force) {
   if (textResultElement.length) {
     stepPreviewContainer.addClass('current_preview');
     hidePreviewContainer();
-    setPageHashAccordingToCurrentTab(textResultElement.data('href'), true);
+    setPageHashAccordingToCurrentTab(textResultElement.data('href'));
 
     // ensure element is in viewport
     const aOffset = stepPreviewContainer.offset().top;
@@ -225,7 +225,7 @@ function setCurrentPreview(stepPreviewContainer, force) {
   }
   if (link.data('text')) {
     stepPreviewContainer.addClass('current_preview');
-    setPageHashAccordingToCurrentTab(link.attr('href'), true);
+    setPageHashAccordingToCurrentTab(link.attr('href'));
     const text = unescape(link.data('text'));
     previewSuccess(stepPreviewContainer, text, force);
     return;
@@ -234,7 +234,7 @@ function setCurrentPreview(stepPreviewContainer, force) {
     return;
   }
   stepPreviewContainer.addClass('current_preview');
-  setPageHashAccordingToCurrentTab(link.attr('href'), true);
+  setPageHashAccordingToCurrentTab(link.attr('href'));
   $.get({
     url: link.data('url'),
     success: function (data) {
@@ -355,7 +355,7 @@ function handleKeyDownOnTestDetails(e) {
   }
 }
 
-function setPageHashAccordingToCurrentTab(tabNameOrHash, replace) {
+function setPageHashAccordingToCurrentTab(tabNameOrHash) {
   // don't mess with #step hashes within details tab
   const currentHash = window.location.hash;
   if (tabNameOrHash === 'details' && (currentHash.startsWith('#step/') || currentHash.startsWith('#line-'))) {
@@ -367,10 +367,8 @@ function setPageHashAccordingToCurrentTab(tabNameOrHash, replace) {
   if (newHash === currentHash || (newHash === '#' && !currentHash)) {
     return;
   }
-  if (replace && history.replaceState) {
+  if (history.replaceState) {
     history.replaceState(null, null, newHash);
-  } else if (!replace && history.pushState) {
-    history.pushState(null, null, newHash);
   } else {
     window.location.hash = newHash;
   }

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -134,12 +134,16 @@ subtest 'error handling when loading test modules' => sub {
 };
 
 subtest 'tab navigation via history' => sub {
+    $driver->get('/tests');
+    $driver->find_element('a[href="/tests/99982"]')->click();
     is current_tab, 'Details', 'starting on Details tab for completed job';
     $driver->find_element_by_link_text('Settings')->click();
     is current_tab, 'Settings', 'switched to settings tab';
     $driver->go_back();
-    is current_tab, 'Details', 'back to details tab';
+    ok $driver->get_current_url =~ /\/tests$/, 'back to job list';
 };
+
+$driver->get('/tests/99937');
 
 subtest 'show job modules execution time' => sub {
     my $tds = $driver->find_elements('.component');


### PR DESCRIPTION
The user can just click on the desired tab, but rewriting the history will make it hard to access the test overview page.