### PR TITLE
fix: Correct call to console.error

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -745,7 +745,7 @@ function loadEmbeddedLogFiles(filter) {
         logFileElement.dataset.contentsLoaded = true;
       })
       .catch(error => {
-        log.error(error);
+        console.error(error);
         logFileElement.appendChild(document.createTextNode(`Unable to load logfile: ${error}`));
       });
   });


### PR DESCRIPTION
When there was an error, all I got was a amessage that log is not defined.

* Taken from #7462 