### PR TITLE
fix(details view): Align video link the same as the bugref actions

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -72,8 +72,10 @@ sub register ($self, $app, $config) {
         stepvideolink_for => sub ($c, $testid, $file_name, $frametime) {
             my $t = sprintf '&t=%s,%s', $frametime->[0], $frametime->[1];
             my $url = $c->url_for('video', testid => $testid)->query(filename => $file_name) . $t;
-            my $class = 'step_action fa-regular fa-file-video fa-lg';
-            return $c->link_to($url => (title => 'Jump to video', class => $class) => sub { '' });
+            my $icon = 'fa-file-video';
+            my $icons = $c->t(i => (class => "fa-regular fa-lg fa-stack-1x $icon"));
+            my $content = $c->t(span => (class => 'fa-stack') => sub { $icons });
+            return $c->link_to($url => (title => 'Jump to video', class => 'step_action') => sub { $content });
         });
 
     $app->helper(rendered_refs_no_shortening => sub ($c, $text) { render_escaped_refs($text) });

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -483,17 +483,19 @@ subtest 'render video link if frametime is available' => sub {
     $driver->find_element_by_link_text('Details')->click();
     $driver->find_element('[href="#step/bootloader/1"]')->click();
     wait_for_ajax(msg => 'first step of bootloader test module loaded');
-    my @links = $driver->find_elements('.step_actions .fa-regular.fa-file-video');
+    my @links = $driver->find_elements('.step_actions .fa-file-video');
     is $#links, -1, 'no link without frametime';
 
     $driver->find_element('[href="#step/bootloader/2"]')->click();
     wait_for_ajax(msg => 'second step of bootloader test module loaded');
-    my @video_link_elems = $driver->find_elements('.step_actions .fa-regular.fa-file-video');
-    is $video_link_elems[0]->get_attribute('title'), 'Jump to video', 'video link exists';
-    like $video_link_elems[0]->get_attribute('href'),
-      qr!/tests/99946/video\?filename=video\.ogv&t=0\.00,1\.00!,
-      'video href correct';
-    $video_link_elems[0]->click();
+
+    my @video_link_elems
+      = $driver->find_elements(q{//span[contains(@class, 'step_actions')]//i[contains(@class, 'fa-file-video')]/../..},
+        'xpath');
+    my $link = $video_link_elems[0];
+    is $link->get_attribute('title'), 'Jump to video', 'video link exists';
+    like $link->get_attribute('href'), qr!/tests/99946/video\?filename=video\.ogv&t=0\.00,1\.00!, 'video href correct';
+    $link->click();
     like
       $driver->find_element('video')->get_attribute('src'),
       qr!/tests/99946/file/video\.ogv#t=0!,


### PR DESCRIPTION
Before the video link icon was a bit too close to the other actions, and also a bit higher.

Now it's at the same height, and the space between all links is the same.

Found when working on https://progress.opensuse.org/issues/201840

* Before:
<img width="210" height="119" alt="details-videolink-before" src="https://github.com/user-attachments/assets/12f7bf36-1a52-4be9-94e3-f817d794bca4" />

* After:
<img width="214" height="119" alt="details-videolink-after" src="https://github.com/user-attachments/assets/8b8ca4ca-c003-4845-ad2c-e03e5bbdd802" />
