### PR TITLE
feat: Turn code locations in autoinst-log into links

### DIFF
--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -53,7 +53,8 @@ function createLogLink(module, step) {
   const E = createElement;
   const params = new URLSearchParams({
     filename: 'autoinst-log.txt',
-    filter: `[step:${module.category},${module.name},${step.num}]`
+    filter: `[step:${module.category},${module.name},${step.num}]`,
+    sl: 1
   });
   const currentPath = window.location.pathname.replace(/\/$/, '');
   const logHref = `${currentPath}/logfile?${params.toString()}`;

--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -1,6 +1,8 @@
 // jshint multistr: true
 // jshint esversion: 6
 
+const testGitInfoRe = /TEST_GIT_HASH=([a-fA-F0-9]+) TEST_GIT_URL=([^\p{Cc}]+)/u;
+
 const testStatus = {
   state: null,
   result: null,
@@ -635,6 +637,16 @@ function filterLogLines(input, viaSearchBox = true) {
       return;
     }
     const lines = Array.from(content);
+    if (logFileElement.dataset.showSourceLinks && !logFileElement.dataset.gitBaseUrl) {
+      for (const line of lines) {
+        const found = line.match(testGitInfoRe);
+        if (found) {
+          logFileElement.dataset.gitBaseUrl = found[2] + '/blob/' + found[1];
+          break;
+        }
+      }
+    }
+
     let lineNumber = 0;
     let matchingLines = 0;
     if (string.length > 0) {
@@ -669,6 +681,24 @@ function filterEmbeddedLogFiles() {
   loadEmbeddedLogFiles(filterLogLines.bind(null, searchBox, false));
 }
 
+const stepRe = / \[step:[a-zA-Z0-9-]+,[a-zA-Z0-9-]+,[0-9]+\] /;
+const sourceRe = /(?<= )([a-zA-Z0-9_/.-]+\.p[my]):(\d+)/g;
+function createSourceLinks(logFileElement, lineContentElement) {
+  const E = createElement;
+  const found = lineContentElement.innerHTML.match(stepRe);
+  if (found) {
+    lineContentElement.innerHTML = lineContentElement.innerHTML.replace(sourceRe, (match, filePath, lineNumber) => {
+      const i = E('i', [''], {class: 'fa-regular fa-file-code fa-lg'});
+      const a = E('a', [i, ` ${filePath}:${lineNumber}`], {
+        class: 'source-link',
+        target: '_blank',
+        href: `${logFileElement.dataset.gitBaseUrl}/${filePath}#L${lineNumber}`
+      });
+      return a.outerHTML;
+    });
+  }
+}
+
 function showLogLines(logFileElement, lines, viaSearchBox = false) {
   const tableElement = document.createElement('table');
   const currentHash = document.location.hash;
@@ -700,6 +730,10 @@ function showLogLines(logFileElement, lines, viaSearchBox = false) {
       lineNumberLinkElement.onclick();
     }
     lineContentElement.innerHTML = ansiToHtml(line);
+    if (logFileElement.dataset.gitBaseUrl) {
+      createSourceLinks(logFileElement, lineContentElement);
+    }
+
     lineNumberElement.appendChild(lineNumberLinkElement);
     lineElement.append(lineNumberElement, lineContentElement);
     tableElement.appendChild(lineElement);
@@ -729,10 +763,16 @@ function showLogLines(logFileElement, lines, viaSearchBox = false) {
   window.hasHandlerForUpdatingCurrentLine = true;
 }
 
+const srcRe = /tests\/.*\/file\/autoinst-log\.txt/;
 function loadEmbeddedLogFiles(filter) {
   $('.embedded-logfile').each(function (index, logFileElement) {
     if (logFileElement.dataset.contentsLoaded) {
       return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    const found = logFileElement.dataset.src.match(srcRe);
+    if (found && params.get('sl')) {
+      logFileElement.dataset.showSourceLinks = true;
     }
     fetch(logFileElement.dataset.src)
       .then(response => {

--- a/t/testresults/00099/00099946-opensuse-13.1-DVD-i586-Build0091-textmode/autoinst-log.txt
+++ b/t/testresults/00099/00099946-opensuse-13.1-DVD-i586-Build0091-textmode/autoinst-log.txt
@@ -1281,6 +1281,10 @@ WARNING: read qmp 85 - {"timestamp": {"seconds": 1392728646, "microseconds": 936
  waiting for console read thread to quit...
 WARNING: read qmp 145 - {"timestamp": {"seconds": 1392728646, "microseconds": 936768}, "event": "DEVICE_TRAY_MOVED", "data": {"device": "ide1-cd0", "tray-open": true}}
 
+[2026-06-22T20:28:39.215621+02:00] [debug] [pid:14231] TEST_GIT_HASH=c0ffee TEST_GIT_URL=https://example.org/fortest
+[2026-06-22T20:29:10.379120+02:00] [debug] [pid:14264] [step:installation,bootloader,1] tests/installaton/bootloader.pm:5 called utils::wait_for_desktop -> lib/utils.pm:47 called utils::handle_gui_password
+[2026-06-22T20:29:10.379120+02:00] [debug] [pid:14264] [step:installation,bootloader,2] tests/installaton/bootloader.pm:5 called utils::wait_for_desktop -> lib/utils.pm:47 called utils::handle_gui_password
+
 ALARM: backend.run got deleted! - exiting...
 read HMP failed: 
 management thread exit at 2014-02-18 13:04:07

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -492,8 +492,18 @@ subtest 'render log links from steps' => sub {
             my $link = $log_link_elems[0];
             is $link->get_attribute('title'), 'Jump to logfile', 'log link exists';
             like $link->get_attribute('href'),
-              qr{/tests/99946/logfile\?filename=autoinst-log\.txt&filter=.*step.*installation.*bootloader.*$step},
+              qr{/tests/99946/logfile\?filename=autoinst-log\.txt&filter=.*step.*installation.*bootloader.*$step.*sl=1},
               'log href correct';
+
+            $link->click;
+            wait_for_ajax msg => 'log contents';
+            like $driver->find_element('.embedded-logfile')->get_text,
+              qr/ \[step:installation,bootloader,$step\].* called /, 'test';
+            my @source_links = $driver->find_element_by_class('source-link');
+            my $sl = $source_links[0];
+            is $sl->get_attribute('href'),
+              'https://example.org/fortest/blob/c0ffee/tests/installaton/bootloader.pm#L5', 'source link ok';
+            $driver->go_back;
         };
     }
 };
@@ -579,14 +589,14 @@ subtest 'misc details: title, favicon, go back, go to source view, go to log vie
     like $driver->find_element('.embedded-logfile')->get_text, qr{/usr/bin/qemu-kvm}, 'qemu-kvm is shown in log viewer';
 
     $driver->find_element('#filter-log-file')->send_keys('kate');
-    wait_until(sub { $driver->find_element('#filter-info')->get_text =~ qr{Showing 3 / 1292 lines} },
+    wait_until(sub { $driver->find_element('#filter-info')->get_text =~ qr{Showing 3 / 1296 lines} },
         'Showing filter result info for substring');
     unlike $driver->find_element('.embedded-logfile')->get_text, qr{/usr/bin/qemu-kvm},
       'qemu-kvm is not shown when filtering for something else';
     $driver->find_element('#filter-log-file')->clear;
     wait_until(sub { $driver->find_element('#filter-info')->get_text eq '' }, 'Filter result info cleared');
     $driver->find_element('#filter-log-file')->send_keys('/kate-[12]/');
-    wait_until(sub { $driver->find_element('#filter-info')->get_text =~ qr{Showing 2 / 1292 lines} },
+    wait_until(sub { $driver->find_element('#filter-info')->get_text =~ qr{Showing 2 / 1296 lines} },
         'Showing filter result info for regex');
 
     my $url = Mojo::URL->new($driver->execute_script('return document.location.toString()'));

--- a/templates/webapi/step/viewimg.html.ep
+++ b/templates/webapi/step/viewimg.html.ep
@@ -91,7 +91,7 @@
         % if ($video_file_name && $frametime) {
             %= stepvideolink_for $testid, $video_file_name, $frametime
         % }
-        %= steploglink_for 'Jump to logfile' => url_for('logfile')->query(filename => 'autoinst-log.txt', filter => sprintf("[step:%s,%s,%d]", $module->category, $module->name, param 'stepid')), 'fa-file-lines', 'view_log'
+        %= steploglink_for 'Jump to logfile' => url_for('logfile')->query(filename => 'autoinst-log.txt', filter => sprintf("[step:%s,%s,%d]", $module->category, $module->name, param 'stepid'), sl => 1), 'fa-file-lines', 'view_log'
     </span>
 </div>
 <div id="needle_diff">


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/197177

This will turn the file info in lines like

    [step:install,boot,5] tests/install/boot.pm:5 called utils::wait_for_desktop
      -> lib/utils.pm:48 called testapi::assert_screen

into links to the source on GitHub.

It will only do that if the filename is autoinst-log.txt, and if the page
has the special query parameter `sl=1`, as doing it by default might not
be wanted for long logfiles.

<img width="925" height="182" alt="autoinst-log-with-source-links" src="https://github.com/user-attachments/assets/333e9807-eba2-4d20-98e6-4a7c98526c83" />
