### PR TITLE
feat(BCI): dedicated report template for BCI

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseBCIbug.pm
+++ b/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseBCIbug.pm
@@ -1,0 +1,83 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseBCIbug;
+use Mojo::Base -strict, -signatures;
+use Mojo::Template;
+use Mojo::Loader qw(data_section);
+use Mojo::URL;
+use OpenQA::WebAPI::Plugin::IssueReporter::Context qw(get_context get_regression_links);
+use OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseBugzillaUtils qw(get_bugzilla_url);
+
+sub actions ($c) {
+    my $ctx = get_context($c) or return [];
+    my $job = $ctx->{job};
+    my $raw_distri = $job->DISTRI // '';
+    my $bz_product = 'SUSE Linux Base Container Images';
+    my $bz_url = get_bugzilla_url($raw_distri);
+    my (undef, $last_good) = get_regression_links($c, $job);
+    my $latest = $c->url_for('latest')->query($job->scenario_hash)->to_abs;
+    my ($build, $image) = split /_/, $ctx->{build}, 2;
+
+    my @wanted_keys = qw(BCI_TEST_ENVS CONTAINER_IMAGE_TO_TEST HDD_1 CONTAINER_RUNTIMES);
+    my %is_wanted = map { $_ => 1 } @wanted_keys;
+    my %settings;
+    for my $setting ($job->settings->all) {
+        if ($is_wanted{$setting->key}) {
+            $settings{$setting->key} = $setting->value;
+        }
+    }
+
+    my $bci_bug = _render(
+        'bci_bug.txt.ep',
+        {
+            step_url => $ctx->{step_url},
+            last_good => $last_good,
+            latest => "$latest",
+            image => $settings{CONTAINER_IMAGE_TO_TEST},
+            host_os => $settings{HDD_1},
+            bci_tests => $settings{BCI_TEST_ENVS},
+            cri => $settings{CONTAINER_RUNTIMES}});
+
+    my $url = Mojo::URL->new($bz_url)->query(
+        {
+            short_desc => "[QE][Build $build] $image fails",
+            comment => $bci_bug,
+            product => $bz_product,
+            bug_file_loc => $ctx->{step_url},
+            cf_foundby => 'openQA',
+        });
+
+    return [
+        {
+            id => 'bci_bugs',
+            label => 'Report BCI image bug',
+            icon => 'fa-layer-group',
+            url => "$url",
+        }];
+}
+
+sub _render ($name, $vars) {
+    my $tmpl = data_section(__PACKAGE__, $name);
+    return Mojo::Template->new(vars => 1)->render($tmpl, $vars);
+}
+
+1;
+
+__DATA__
+@@ bci_bug.txt.ep
+## Failed test
+
+<%= $step_url %>
+
+## Test environment
+
+Container image: <%= $image %>
+HostOS: <%= $host_os %>
+BCI tests: <%= $bci_tests %>
+Container runtime: <%= $cri %>
+
+## Useful links
+
+Last good: <%= $last_good %> (or more recent)
+The latest result in this scenario: <%= $latest %>

--- a/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseBCIbug.pm
+++ b/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseBCIbug.pm
@@ -1,0 +1,108 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseBCIbug;
+use Mojo::Base -strict, -signatures;
+use Mojo::Template;
+use Mojo::Loader qw(data_section);
+use Mojo::URL;
+use OpenQA::WebAPI::Plugin::IssueReporter::Context qw(get_context get_regression_links);
+use OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseBugzillaUtils qw(get_bugzilla_url);
+
+sub actions ($c) {
+    my $ctx = get_context($c) or return [];
+    my $job = $ctx->{job};
+    my $raw_distri = $job->DISTRI // '';
+    my $bz_product = 'SUSE Linux Base Container Images';
+    my $bz_url = get_bugzilla_url($raw_distri);
+
+    my (undef, $last_good) = get_regression_links($c, $job);
+    my $latest = $c->url_for('latest')->query($job->scenario_hash)->to_abs;
+    my ($build, $image) = split /_/, $ctx->{build}, 2;
+    $image //= 'NaN';
+
+    # CONTAINER_IMAGE_TO_TEST is required only for sles
+    # opensuse container links are handled internally by BCI framework
+    my @wanted_keys = qw(
+      BCI_TEST_ENVS
+      CONTAINER_IMAGE_TO_TEST
+      HDD_1
+      CONTAINER_RUNTIMES
+      BCI_IMAGE_MARKER
+      BCI_TARGET
+    );
+
+    my %is_wanted = map { $_ => 1 } @wanted_keys;
+    my %settings;
+    for my $setting ($job->settings->all) {
+        if ($is_wanted{$setting->key}) {
+            $settings{$setting->key} = $setting->value;
+        }
+    }
+
+    # BCI exists only for sles and opensuse TW
+    # TW is a special case, it inherits the same build convention as TW host
+    # therefore it has to be extracted from the mandatory BCI marker
+    if ($raw_distri eq 'opensuse') {
+        $bz_product = 'Public ' . $bz_product;
+        $image = $settings{BCI_IMAGE_MARKER} // 'NaN';
+    }
+
+    my $bci_bug = _render(
+        'bci_bug.txt.ep',
+        {
+            image => $settings{CONTAINER_IMAGE_TO_TEST} // 'NaN',
+            host_os => $settings{HDD_1} // 'NaN',
+            bci_tests => $settings{BCI_TEST_ENVS} // 'NaN',
+            cri => $settings{CONTAINER_RUNTIMES} // 'NaN',
+            target => $settings{BCI_TARGET} // 'NaN',
+            marker => $settings{BCI_IMAGE_MARKER} // 'NaN',
+            step_url => $ctx->{step_url},
+            last_good => $last_good,
+            latest => "$latest"
+        });
+
+    my $url = Mojo::URL->new($bz_url)->query(
+        {
+            short_desc => "[QE][Build $build] image $image fails",
+            comment => $bci_bug,
+            product => $bz_product,
+            bug_file_loc => $ctx->{step_url},
+            cf_foundby => 'openQA',
+        });
+
+    return [
+        {
+            id => 'bci_bugs',
+            label => 'Report BCI image bug',
+            icon => 'fa-layer-group',
+            url => "$url",
+        }];
+}
+
+sub _render ($name, $vars) {
+    my $tmpl = data_section(__PACKAGE__, $name);
+    return Mojo::Template->new(vars => 1)->render($tmpl, $vars);
+}
+
+1;
+
+__DATA__
+@@ bci_bug.txt.ep
+## Failed test
+
+<%= $step_url %>
+
+## Test environment
+
+Container image: <%= $image %>
+HostOS: <%= $host_os %>
+BCI tests: <%= $bci_tests %>
+Container runtime: <%= $cri %>
+Marker: <%= $marker %>
+Target: <%= $target %>
+
+## Useful links
+
+Last good: <%= $last_good %> (or more recent)
+The latest result in this scenario: <%= $latest %>

--- a/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseIssueReporter.pm
+++ b/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseIssueReporter.pm
@@ -6,6 +6,7 @@ use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseKernelBug;
 use OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseGenericBug;
+use OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseBCIbug;
 use OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseProgressIssue;
 
 sub register ($self, $app, $config) {
@@ -14,6 +15,7 @@ sub register ($self, $app, $config) {
             return [
                 @{OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseGenericBug::actions($c)},
                 @{OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseKernelBug::actions($c)},
+                @{OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseBCIbug::actions($c)},
                 @{OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseProgressIssue::actions($c)},
             ];
         });

--- a/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseIssueReporter.pm
+++ b/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseIssueReporter.pm
@@ -14,6 +14,7 @@ sub register ($self, $app, $config) {
             return [
                 @{OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseGenericBug::actions($c)},
                 @{OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseKernelBug::actions($c)},
+                @{OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseBCIbug::actions($c)},
                 @{OpenQA::WebAPI::Plugin::IssueReporter::OpenSuseProgressIssue::actions($c)},
             ];
         });

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -237,7 +237,8 @@ sub check_report_links ($failed_module, $failed_step, $container = undef) {
     my @title = map { $_->get_attribute('title') } @report_links;
     is $title[0], 'Report product bug', 'product bug report URL available';
     is $title[1], 'Report kernel product bug', 'product bug report URL available';
-    is $title[2], 'Report test issue', 'test issue report URL available';
+    is $title[2], 'Report BCI image bug', 'product bug report URL available';
+    is $title[3], 'Report test issue', 'test issue report URL available';
     my @url = map { $_->get_attribute('href') } @report_links;
     like $url[0], qr{bugzilla.*enter_bug.*tests%2F99937}, 'bugzilla link referencing current test';
     like $url[0], qr{in\+scenario\+%60opensuse-13\.1-DVD-i586-kde}, 'bugzilla link contains scenario marked verbatim';
@@ -247,9 +248,11 @@ sub check_report_links ($failed_module, $failed_step, $container = undef) {
       qr{[?&]short_desc=%5BQE%5D%5BBuild\+0091%5D\+Kernel\+test\+fails\+in\+bootloader},
       'kernel short_desc correct';
     like $url[1], qr{[?&]comment=}, 'kernel product bug has comment template';
-    like $url[2], qr{progress.*new}, 'progress/redmine link for reporting test issues';
-    like $url[2], qr{in\+scenario\+%60opensuse-13\.1-DVD-i586-kde}, 'progress/redmine link contains scenario';
-    like $url[2],
+    like $url[2], qr{bugzilla.*enter_bug}, 'BCI bug enters bugzilla report';
+    like $url[2], qr{[?&]product=(Public\+)?SUSE\+Linux\+Base\+Container}, 'BCI bug sets product';
+    like $url[3], qr{progress.*new}, 'progress/redmine link for reporting test issues';
+    like $url[3], qr{in\+scenario\+%60opensuse-13\.1-DVD-i586-kde}, 'progress/redmine link contains scenario';
+    like $url[3],
       qr{in.*$failed_module.*$failed_module%2Fsteps%2F$failed_step},
       'progress/redmine link refers to right module/step';
 }


### PR DESCRIPTION
BCI reports are different from the generic sles bugs. The reporter needs to fill manually information that can be easily fetched from openQA.
The bugzilla product is also different and several times reporters accidentally created bugs in the wrong category