### PR TITLE
test: Enable faster re-connects in full scheduler test consistently

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -11,6 +11,11 @@ BEGIN {
     # require the scheduler to be fixed in its actions since tests depends on timing
     $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION} = 10;
     $ENV{OPENQA_SCHEDULER_SCHEDULE_TICK_MS} = 100;
+
+    # avoid delays due to long retry interval of worker
+    $ENV{OPENQA_WORKER_CONNECT_INTERVAL} = 0;
+    $ENV{MOJO_CONNECT_TIMEOUT} = 1;
+
     OpenQA::Utils::reserve_ports;
 }
 
@@ -278,7 +283,6 @@ subtest 'Websocket server - close connection test' => sub {
 
     local $ENV{OPENQA_LOGFILE};
     local $ENV{MOJO_LOG_LEVEL};
-    local $ENV{OPENQA_WORKER_CONNECT_INTERVAL} = 0;
 
     my $log;
     # create unstable ws


### PR DESCRIPTION
This rules out one possibility for the full scheduler being sometimes very slow. Unfortunately, this doesn't completely solve the issue in my local test environment.

I created this change while working on
https://progress.opensuse.org/issues/202803 but that's a different issue.