### PR TITLE
Avoid running into "Address already in use" in fullstack tests

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -137,8 +137,12 @@ our @EXPORT =    ## no critic (Modules::ProhibitAutomaticExportation)
   read_test_modules
   walker
   ensure_timestamp_appended
+  make_listen_url
+  make_access_url
   set_listen_address
+  to_plain_service_port
   service_port
+  raw_service_port
   change_sec_to_word
   find_video_files
   fix_top_level_help
@@ -794,24 +798,40 @@ sub walker ($hash, $callback, $keys = []) {
     }
 }
 
-sub set_listen_address ($port) {
-    return if $ENV{MOJO_LISTEN};
-    # Show IPv6 compatible "localhost" instead of IPv4 loopback 127.0.0.1
-    # Also explicitly bind to 127.0.0.1 to ensure both IPv4 and IPv6 are supported
-    $ENV{MOJO_LISTEN} = "http://localhost:$port?reuse=1,http://127.0.0.1:$port?reuse=1";
+# Show IPv6 compatible "localhost" instead of IPv4 loopback 127.0.0.1
+# Also explicitly bind to 127.0.0.1 to ensure both IPv4 and IPv6 are supported
+sub make_listen_url ($raw_port) {
+    $raw_port =~ m/&fd=(.*)/
+      ? "http://*?fd=$1"
+      : "http://localhost:$raw_port?reuse=1,http://127.0.0.1:$raw_port?reuse=1";
+}
+sub to_plain_service_port ($raw_port) { $raw_port =~ m/^(\d+)/ ? $1 : die "invalid port: $raw_port" }
+sub make_access_url ($raw_port) { 'http://localhost:' . to_plain_service_port($raw_port) }
+sub service_port ($service) { to_plain_service_port(raw_service_port($service)) }
+sub set_listen_address ($service) { $ENV{MOJO_LISTEN} //= make_listen_url(raw_service_port($service)) }
+
+my %SERVICE_OFFSETS = (webui => 0, websocket => 1, livehandler => 2, scheduler => 3, cache_service => 4);
+my %RESERVED_SOCKETS;
+
+sub raw_service_port ($service) {
+    my $base = $ENV{OPENQA_BASE_PORT} ||= DEFAULT_OPENQA_BASE_PORT;
+    if (my $env_port = $ENV{"OPENQA_PORT_\U$service"}) {    # \U uppercases the interpolated variable
+        return $env_port;
+    }
+    croak "Unknown service: $service" unless exists $SERVICE_OFFSETS{$service};
+    return $base + $SERVICE_OFFSETS{$service};
 }
 
-sub service_port ($service) {
-    my $base = $ENV{OPENQA_BASE_PORT} ||= DEFAULT_OPENQA_BASE_PORT;
-    my $offsets = {
-        webui => 0,
-        websocket => 1,
-        livehandler => 2,
-        scheduler => 3,
-        cache_service => 4
-    };
-    croak "Unknown service: $service" unless exists $offsets->{$service};
-    return $base + $offsets->{$service};
+sub reserve_ports () {
+    for my $service (keys %SERVICE_OFFSETS) {
+        my $socket = IO::Socket::IP->new(LocalAddr => '0.0.0.0', Listen => SOMAXCONN, ReuseAddr => 1, ReusePort => 1);
+        die "Failed to reserve port for $service: $!\n" unless $socket;
+        $RESERVED_SOCKETS{$service} = $socket;
+        my $port = $socket->sockport;
+        $ENV{"OPENQA_PORT_\U$service"} = "$port&fd=" . $socket->fileno;
+        log_info "Reserved port for $service: $port";
+    }
+    $ENV{OPENQA_SERVICE_PORT_DELTA} = $RESERVED_SOCKETS{livehandler}->sockport - $RESERVED_SOCKETS{webui}->sockport;
 }
 
 sub random_string ($length = RANDOM_STRING_DEFAULT_LENGTH, $chars = ['a' .. 'z', 'A' .. 'Z', '0' .. '9', '_']) {

--- a/script/openqa
+++ b/script/openqa
@@ -9,7 +9,7 @@ use FindBin;
 use lib "$FindBin::RealBin/../lib";
 
 use OpenQA::WebAPI;
-use OpenQA::Utils qw(service_port set_listen_address fix_top_level_help);
+use OpenQA::Utils qw(set_listen_address fix_top_level_help);
 
 fix_top_level_help;
 
@@ -19,6 +19,6 @@ $ENV{MOJO_INACTIVITY_TIMEOUT} = 300;
 # the default is EV, and this heavily screws with our children handling
 $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
 
-set_listen_address(service_port('webui'));
+set_listen_address('webui');
 OpenQA::WebAPI::run;
 

--- a/script/openqa-livehandler
+++ b/script/openqa-livehandler
@@ -9,12 +9,12 @@ use FindBin;
 use lib "$FindBin::RealBin/../lib";
 
 use OpenQA::LiveHandler;
-use OpenQA::Utils qw(service_port set_listen_address fix_top_level_help);
+use OpenQA::Utils qw(set_listen_address fix_top_level_help);
 
 fix_top_level_help;
 
 # ensure the web socket connection won't timeout
 $ENV{MOJO_INACTIVITY_TIMEOUT} ||= 15 * 60;
 
-set_listen_address(service_port('livehandler'));
+set_listen_address('livehandler');
 OpenQA::LiveHandler::run;

--- a/script/openqa-scheduler
+++ b/script/openqa-scheduler
@@ -9,9 +9,9 @@ use FindBin;
 use lib "$FindBin::RealBin/../lib";
 
 use OpenQA::Scheduler;
-use OpenQA::Utils qw(service_port set_listen_address fix_top_level_help);
+use OpenQA::Utils qw(set_listen_address fix_top_level_help);
 
 fix_top_level_help;
 
-set_listen_address(service_port('scheduler'));
+set_listen_address('scheduler');
 OpenQA::Scheduler::run;

--- a/script/openqa-websockets
+++ b/script/openqa-websockets
@@ -9,9 +9,9 @@ use FindBin;
 use lib "$FindBin::RealBin/../lib";
 
 use OpenQA::WebSockets;
-use OpenQA::Utils qw(service_port set_listen_address fix_top_level_help);
+use OpenQA::Utils qw(set_listen_address fix_top_level_help);
 
 fix_top_level_help;
 
-set_listen_address(service_port('websocket'));
+set_listen_address('websocket');
 OpenQA::WebSockets::run;

--- a/script/openqa-workercache
+++ b/script/openqa-workercache
@@ -9,9 +9,9 @@ use FindBin;
 use lib "$FindBin::RealBin/../lib";
 
 use OpenQA::CacheService;
-use OpenQA::Utils qw(service_port set_listen_address fix_top_level_help);
+use OpenQA::Utils qw(set_listen_address fix_top_level_help);
 
 fix_top_level_help;
 
-set_listen_address(service_port('cache_service'));
+set_listen_address('cache_service');
 exit OpenQA::CacheService::run(@ARGV);

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -50,9 +50,9 @@ subtest 'service ports' => sub {
 
 subtest 'set listen address' => sub {
     local $ENV{MOJO_LISTEN} = undef;
-    set_listen_address(9526);
+    set_listen_address('webui');
     like $ENV{MOJO_LISTEN}, qr/localhost:9526.*127\.0\.0\.1:9526/, 'address set';
-    set_listen_address(9527);
+    set_listen_address('websocket');
     unlike $ENV{MOJO_LISTEN}, qr/localhost:9527.*127\.0\.0\.1:9527/, 'not changed';
 };
 

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -9,7 +9,7 @@
 
 use Test::Most;
 use Test::Warnings ':report_warnings';
-use Mojo::IOLoop::Server;
+use OpenQA::Utils;
 
 BEGIN {
     # require the scheduler to be fixed in its actions since tests depends on timing
@@ -19,13 +19,12 @@ BEGIN {
     # ensure the web socket connection won't timeout
     $ENV{MOJO_INACTIVITY_TIMEOUT} = 10 * 60;
 
-    $ENV{OPENQA_BASE_PORT} ||= Mojo::IOLoop::Server->generate_port;
+    OpenQA::Utils::reserve_ports;
 }
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use Mojo::Base -signatures;
-use Mojo::IOLoop::Server;
 use OpenQA::Test::TimeLimit '200';
 use Test::Mojo;
 use IO::Socket::INET;

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -9,7 +9,7 @@
 #    execution)
 
 use Test::Most;
-use Mojo::IOLoop::Server;
+use OpenQA::Utils;
 
 BEGIN {
     # require the scheduler to be fixed in its actions since tests depends on timing
@@ -21,7 +21,7 @@ BEGIN {
 
     $ENV{OS_AUTOINST_STORAGE_KEEP_FREE_RATIO} = 0;
 
-    $ENV{OPENQA_BASE_PORT} ||= Mojo::IOLoop::Server->generate_port;
+    OpenQA::Utils::reserve_ports;
 }
 
 use Test::Warnings ':report_warnings';
@@ -29,7 +29,6 @@ use Mojo::Base -signatures;
 use List::Util ();
 use Test::Mojo;
 use Test::MockModule;
-use Mojo::IOLoop::Server;
 use autodie ':all';
 use IO::Socket::INET;
 use POSIX '_exit';

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -63,9 +63,10 @@ sub start_driver ($mojoport) {
         # pass options for Chromium via chromeOptions *and* goog:chromeOptions to support all versions of
         # Selenium::Remote::Driver which switched to use goog:chromeOptions in version 1.36
         my @chrome_option_keys = (qw(chromeOptions goog:chromeOptions));
-
+        my $base_url = make_access_url($mojoport);
+        note "Starting Selenium under port $mojoport: $base_url";
         my %opts = (
-            base_url => "http://localhost:$mojoport/",
+            base_url => make_access_url($mojoport),
             default_finder => FIND_METHOD,
             webelement_class => 'Test::Selenium::Remote::WebElement',
             extra_capabilities => {
@@ -99,7 +100,7 @@ sub start_driver ($mojoport) {
         # Scripts are considered stuck after this timeout
         $_DRIVER->set_timeout(script => $ENV{OPENQA_SELENIUM_SCRIPT_TIMEOUT_MS} // 2000);
         $_DRIVER->set_window_size(600, 800);
-        $_DRIVER->get("http://localhost:$mojoport/");
+        $_DRIVER->get($base_url);
 
     }
     catch ($e) { die $e }    # uncoverable statement
@@ -378,7 +379,7 @@ sub kill_driver () {
     }
 }
 
-sub get_mojoport () { $MOJOPORT }
+sub get_mojo_url () { make_access_url($MOJOPORT) }
 
 # uncoverable subroutine
 # uncoverable statement

--- a/t/lib/OpenQA/Test/FullstackUtils.pm
+++ b/t/lib/OpenQA/Test/FullstackUtils.pm
@@ -49,8 +49,7 @@ sub job_setup (%override) {
 }
 
 sub get_connect_args () {
-    my $mojoport = OpenQA::SeleniumTest::get_mojoport;
-    return ['--apikey=1234567890ABCDEF', '--apisecret=1234567890ABCDEF', "--host=http://localhost:$mojoport"];
+    ['--apikey=1234567890ABCDEF', '--apisecret=1234567890ABCDEF', '--host=' . OpenQA::SeleniumTest::get_mojo_url];
 }
 
 sub client_output ($args) { qx{perl ./script/openqa-cli api @{get_connect_args()} $args} }

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -4,7 +4,6 @@ use Mojo::Base -base, -signatures;
 
 use Exporter 'import';
 use FindBin;
-use IO::Socket::INET;
 use Storable qw(lock_store lock_retrieve);
 use Mojolicious;
 use POSIX qw(_exit WNOHANG);
@@ -15,7 +14,7 @@ use OpenQA::App;
 use OpenQA::Constants qw(DEFAULT_WORKER_TIMEOUT);
 use OpenQA::Log qw(log_error log_info log_debug);
 
-use OpenQA::Utils 'service_port';
+use OpenQA::Utils qw(raw_service_port to_plain_service_port make_listen_url make_access_url);
 use OpenQA::WebSockets;
 use OpenQA::WebSockets::Client;
 use OpenQA::Scheduler;
@@ -25,6 +24,7 @@ use Mojo::File qw(path tempfile tempdir);
 use Mojo::Util 'dumper';
 use Mojo::URL;
 use Cwd qw(abs_path getcwd);
+use IO::Socket::IP;
 use IPC::Run qw(start);
 use Mojo::Util qw(b64_decode gzip);
 use Scalar::Util ();
@@ -33,6 +33,7 @@ use Mojo::IOLoop;
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::Server::Daemon;
 use Mojo::IOLoop::Server;
+use Mojo::UserAgent;
 use Test::MockModule;
 use OpenQA::Test::TimeLimit ();
 use Feature::Compat::Try;
@@ -107,9 +108,9 @@ sub cache_worker_service {
             # this service can be very noisy
             require OpenQA::CacheService;    # uncoverable statement
             local $ENV{MOJO_MODE} = 'test';    # uncoverable statement
-            my $port = service_port 'cache_service';    # uncoverable statement
+            my $port = raw_service_port 'cache_service';    # uncoverable statement
             note("Starting worker cache service on port $port");    # uncoverable statement
-            OpenQA::CacheService::run('daemon', '-l', "http://*:$port");    # uncoverable statement
+            OpenQA::CacheService::run('daemon', '-l', make_listen_url($port));    # uncoverable statement
             note("Worker cache service on port $port stopped");    # uncoverable statement
             Devel::Cover::report() if Devel::Cover->can('report');    # uncoverable statement
             _exit(0);    # uncoverable statement
@@ -268,39 +269,37 @@ sub stop_service {
 }
 
 sub create_webapi ($port = undef, $no_cover = undef) {
-    $port //= service_port 'webui';
+    $port //= raw_service_port 'webui';
     note("Starting WebUI service. Port: $port");
 
     my $h = _setup_sigchld_handler 'openqa-webapi', start sub {
         _setup_sub_process 'openqa-webapi';
         local $ENV{MOJO_MODE} = 'test';
 
-        my $daemon = Mojo::Server::Daemon->new(listen => ["http://127.0.0.1:$port"], silent => 1);
+        my $daemon = Mojo::Server::Daemon->new(listen => [make_listen_url($port)], silent => 1);
         $daemon->build_app('OpenQA::WebAPI');
         $daemon->run;
         Devel::Cover::report() if !$no_cover && Devel::Cover->can('report');
     };
     # as this might download assets on first test, we need to wait a while
     my $wait = time + 50;
+    my $ua = Mojo::UserAgent->new(connect_timeout => 1, inactivity_timeout => 1);
+    my $address = make_access_url($port);
     while (time < $wait) {
         my $t = time;
-        my $socket = IO::Socket::INET->new(
-            PeerHost => '127.0.0.1',
-            PeerPort => $port,
-            Proto => 'tcp',
-        );
-        last if $socket;
+        note "Waiting for web UI on $address";
+        last if $ua->get($address)->res->is_success;
         sleep 1 if time - $t < 1;
     }
     return $h;
 }
 
 sub create_websocket_server ($port, $bogus, $with_embedded_scheduler = undef, $no_cover = undef) {
-    OpenQA::WebSockets::Client->singleton->port($port //= service_port 'websocket');
+    OpenQA::WebSockets::Client->singleton->port(to_plain_service_port($port //= raw_service_port('websocket')));
     note "Starting WebSocket service (port: $port, bogus: $bogus)";
     my $h = _setup_sigchld_handler 'openqa-websocket', start sub {
         _setup_sub_process 'openqa-websocket';
-        local $ENV{MOJO_LISTEN} = "http://127.0.0.1:$port";
+        local $ENV{MOJO_LISTEN} = make_listen_url($port);
         local $ENV{MOJO_INACTIVITY_TIMEOUT} = 9999;
 
         use OpenQA::WebSockets;
@@ -339,12 +338,12 @@ sub create_websocket_server ($port, $bogus, $with_embedded_scheduler = undef, $n
     return $h;
 }
 
-sub create_scheduler ($port = service_port 'scheduler') {
+sub create_scheduler ($port = raw_service_port('scheduler')) {
     note("Starting Scheduler service. Port: $port");
-    OpenQA::Scheduler::Client->singleton->port($port);
+    OpenQA::Scheduler::Client->singleton->port(to_plain_service_port($port));
     _setup_sigchld_handler 'openqa-scheduler', start sub {
         _setup_sub_process 'openqa-scheduler';
-        local $ENV{MOJO_LISTEN} = "http://127.0.0.1:$port";
+        local $ENV{MOJO_LISTEN} = make_listen_url($port);
         local $ENV{MOJO_INACTIVITY_TIMEOUT} = 9999;
         local @ARGV = ('daemon');
         OpenQA::Scheduler::run;
@@ -352,12 +351,10 @@ sub create_scheduler ($port = service_port 'scheduler') {
     };
 }
 
-sub create_live_view_handler {
-    my ($port) = @_;
-    $port //= service_port 'livehandler';
+sub create_live_view_handler ($port = raw_service_port 'livehandler') {
     _setup_sigchld_handler 'openqa-livehandler', start sub {
         _setup_sub_process 'openqa-livehandler';
-        my $daemon = Mojo::Server::Daemon->new(listen => ["http://127.0.0.1:$port"], silent => 1);
+        my $daemon = Mojo::Server::Daemon->new(listen => [make_listen_url($port)], silent => 1);
         $daemon->build_app('OpenQA::LiveHandler');
         $daemon->run;
         Devel::Cover::report() if Devel::Cover->can('report');

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -35,7 +35,7 @@ $schema->resultset('Bugs')->create(
 
 driver_missing unless my $driver = call_driver;
 disable_timeout;
-my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+my $url = OpenQA::SeleniumTest::get_mojo_url;
 
 #
 # List with no parameters

--- a/t/ui/15-search.t
+++ b/t/ui/15-search.t
@@ -21,7 +21,7 @@ driver_missing unless my $driver = call_driver;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 # we need to talk to the phantom instance or else we're using wrong database
-my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+my $url = OpenQA::SeleniumTest::get_mojo_url;
 
 subtest 'Perl modules' => sub {
     my $search = $driver->find_element_by_id('global-search');

--- a/t/ui/16-activity-view.t
+++ b/t/ui/16-activity-view.t
@@ -29,7 +29,7 @@ driver_missing unless my $driver = call_driver;
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 # we need to talk to the phantom instance or else we're using the wrong database
-my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+my $url = OpenQA::SeleniumTest::get_mojo_url;
 
 subtest 'Access activity view via the menu' => sub {
     $driver->find_element_by_link_text('Login')->click();

--- a/t/ui/17-product-log.t
+++ b/t/ui/17-product-log.t
@@ -29,7 +29,7 @@ driver_missing unless my $driver = call_driver;
 my $t = client;
 
 # we need to talk to the phantom instance or else we're using wrong database
-my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+my $url = OpenQA::SeleniumTest::get_mojo_url;
 
 # schedule an ISO
 $t->post_ok(

--- a/t/ui/23-audit-log.t
+++ b/t/ui/23-audit-log.t
@@ -37,7 +37,7 @@ sub check_data_table_entries ($expected_entry_count, $test_name) {
 
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 # we need to talk to the phantom instance or else we're using wrong database
-my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+my $url = OpenQA::SeleniumTest::get_mojo_url;
 
 # Scheduled isos are only available to operators and admins
 $t->get_ok($url . '/admin/auditlog')->status_is(302);

--- a/t/ui/28-keys_to_render_as_links.t
+++ b/t/ui/28-keys_to_render_as_links.t
@@ -33,7 +33,7 @@ my $job = $schema->resultset('Jobs')->find($job_id);
 $job->settings->create({key => 'SOME_URLS', value => 'https://foo http://bar http://baz'});
 
 driver_missing unless my $driver = call_driver;
-my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+my $url = OpenQA::SeleniumTest::get_mojo_url;
 
 $t->get_ok($uri_path_from_root_dir)->status_is(200)
   ->content_like(qr|root-test|i, 'setting file source found from the root of the test distribution');

--- a/t/ui/29-create_tests.t
+++ b/t/ui/29-create_tests.t
@@ -14,7 +14,7 @@ use OpenQA::SeleniumTest;
 
 my $schema = OpenQA::Test::Case->new->init_data;
 driver_missing unless my $driver = call_driver;
-my $url = 'http://localhost:' . OpenQA::SeleniumTest::get_mojoport;
+my $url = OpenQA::SeleniumTest::get_mojo_url;
 
 subtest 'navigation to form' => sub {
     $driver->get("$url/tests/create");


### PR DESCRIPTION
* Reserve random ports for all services upfront when running the main and
  developer mode fullstack tests to avoid running into "Address already in
  use"
    * Introduce `OPENQA_PORT_$SERVICE` env variables to set ports of
      individual services
    * Allow passing socket file descriptors so the services can listen on
      an already reserved port via the file descriptor of its socket
* Avoid use of `Mojo::IOLoop::Server->generate_port` when setting up the
  fullstack tests to avoid race conditions

Related ticket: https://progress.opensuse.org/issues/202662