### PR TITLE
test: Avoid race condition when generating ports in many tests

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -822,8 +822,9 @@ sub raw_service_port ($service) {
     return $base + $SERVICE_OFFSETS{$service};
 }
 
-sub reserve_ports () {
-    for my $service (keys %SERVICE_OFFSETS) {
+sub reserve_ports ($services = [keys %SERVICE_OFFSETS], %options) {
+    for my $service (@$services) {
+        next if exists $RESERVED_SOCKETS{$service} && !$options{force};
         my $socket = IO::Socket::IP->new(LocalAddr => '0.0.0.0', Listen => SOMAXCONN, ReuseAddr => 1, ReusePort => 1);
         die "Failed to reserve port for $service: $!\n" unless $socket;
         $RESERVED_SOCKETS{$service} = $socket;
@@ -831,7 +832,12 @@ sub reserve_ports () {
         $ENV{"OPENQA_PORT_\U$service"} = "$port&fd=" . $socket->fileno;
         log_info "Reserved port for $service: $port";
     }
-    $ENV{OPENQA_SERVICE_PORT_DELTA} = $RESERVED_SOCKETS{livehandler}->sockport - $RESERVED_SOCKETS{webui}->sockport;
+    my $webui_socket = $RESERVED_SOCKETS{webui};
+    my $livehandler_socket = $RESERVED_SOCKETS{livehandler};
+    if ($webui_socket && $livehandler_socket) {
+        $ENV{OPENQA_SERVICE_PORT_DELTA} = $livehandler_socket->sockport - $webui_socket->sockport;
+    }
+    return @$services == 1 ? $RESERVED_SOCKETS{$services->[0]} : \%RESERVED_SOCKETS;
 }
 
 sub random_string ($length = RANDOM_STRING_DEFAULT_LENGTH, $chars = ['a' .. 'z', 'A' .. 'Z', '0' .. '9', '_']) {

--- a/script/openqa-load-templates
+++ b/script/openqa-load-templates
@@ -59,7 +59,6 @@ use Data::Dump 'dd';
 use Mojo::Util qw(decamelize);
 use Mojo::URL;
 use OpenQA::Client;
-#use OpenQA::Script::Client;
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 

--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -5,11 +5,13 @@
 
 use Test::Most;
 use Test::Warnings ':report_warnings';
+use OpenQA::Utils;
 
 BEGIN {
     # require the scheduler to be fixed in its actions since tests depends on timing
     $ENV{OPENQA_SCHEDULER_MAX_JOB_ALLOCATION} = 10;
     $ENV{OPENQA_SCHEDULER_SCHEDULE_TICK_MS} = 100;
+    OpenQA::Utils::reserve_ports;
 }
 
 use Test::MockModule;
@@ -27,7 +29,6 @@ use OpenQA::Scheduler::Client;
 use OpenQA::Scheduler::Model::Jobs;
 use OpenQA::WebAPI;
 use OpenQA::Worker::WebUIConnection;
-use OpenQA::Utils;
 require OpenQA::Test::Database;
 use OpenQA::Test::Utils qw(
   setup_mojo_app_with_default_worker_timeout

--- a/t/09-job_clone.t
+++ b/t/09-job_clone.t
@@ -20,7 +20,7 @@ use Test::Output 'combined_like';
 
 OpenQA::Test::Database->new->create(fixtures_glob => '01-jobs.pl');
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
-my $mojoport = Mojo::IOLoop::Server->generate_port;
+my $mojoport = OpenQA::Utils::reserve_ports(['webui'])->sockport;
 my $host = "localhost:$mojoport";
 my @common_options = (host => $host, from => $host, apikey => 'foo', apisecret => 'bar');
 my $webapi = create_webapi($mojoport, sub { });

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -48,7 +48,7 @@ my $jobs = $schema->resultset('Jobs');
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # launch an additional app to serve some file for testing blocking downloads
-my $mojo_port = Mojo::IOLoop::Server->generate_port;
+my $mojo_port = OpenQA::Utils::reserve_ports(['webui'])->sockport;
 my $webapi = OpenQA::Test::Utils::create_webapi($mojo_port, sub { });
 
 # prevent writing to a log file to enable use of combined_like in the following tests

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -110,7 +110,7 @@ $assets_mock->redefine(refresh_assets => sub { });
 my $t = Test::Mojo->new('OpenQA::WebAPI');
 
 # launch an additional app to serve some file for testing blocking downloads
-my $mojo_port = Mojo::IOLoop::Server->generate_port;
+my $mojo_port = OpenQA::Utils::reserve_ports(['webui'])->sockport;
 my $webapi = OpenQA::Test::Utils::create_webapi($mojo_port, sub { });
 
 # define a fix asset_size_limit configuration for this test to be independent of the default value

--- a/t/25-cache-client.t
+++ b/t/25-cache-client.t
@@ -41,7 +41,7 @@ my $client = OpenQA::CacheService::Client->new;
 my $log = Mojo::Log->new(level => 'error');
 my $app = OpenQA::CacheService->new(log => $log);
 my $daemon = Mojo::Server::Daemon->new(
-    silent => 1,
+    silent => $ENV{HARNESS_IS_VERBOSE} ? 0 : 1,
     listen => ['http://127.0.0.1'],
     ioloop => $client->ua->ioloop,
     app => $app

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -64,7 +64,8 @@ my $t = Test::Mojo->new('OpenQA::CacheService');
 my $server_instance = process sub {
     # Connect application with web server and start accepting connections
     my $listen = [make_listen_url($sockets->{webui}->sockport)];
-    Mojo::Server::Daemon->new(app => fake_asset_server, listen => $listen, silent => 1)->run;
+    Mojo::Server::Daemon->new(app => fake_asset_server, listen => $listen, silent => $ENV{HARNESS_IS_VERBOSE} ? 0 : 1)
+      ->run;
     Devel::Cover::report() if Devel::Cover->can('report');
     _exit(0);    # uncoverable statement to ensure proper exit code of complete test at cleanup
   },

--- a/t/25-cache-service.t
+++ b/t/25-cache-service.t
@@ -18,7 +18,6 @@ BEGIN {
     $ENV{OPENQA_RSYNC_RETRY_PERIOD} = 0;
     $ENV{OPENQA_RSYNC_RETRIES} = 1;
     $ENV{OPENQA_METRICS_DOWNLOAD_SIZE} = 1024;
-    $ENV{OPENQA_BASE_PORT} = 20000 + int rand 10000;
     $ENV{OPENQA_TEST_WAIT_INTERVAL} = 0.05;
 
     $tempdir = tempdir;
@@ -39,10 +38,9 @@ use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use Test::Warnings ':report_warnings';
 use Test::Output qw(stderr_like);
 use Test::Mojo;
-use OpenQA::Utils;
+use OpenQA::Utils qw(make_access_url make_listen_url);
 use IO::Socket::INET;
 use Mojo::Server::Daemon;
-use Mojo::IOLoop::Server;
 use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess qw(queue process);
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
@@ -56,10 +54,7 @@ use OpenQA::CacheService::Client;
 use Time::Seconds;
 
 my $cachedir = $ENV{OPENQA_CACHE_DIR};
-my $port = Mojo::IOLoop::Server->generate_port;
-my $host = "http://localhost:$port";
-
-my $cache_client = OpenQA::CacheService::Client->new();
+my ($sockets, $host, $cache_client);
 
 END { session->clean }
 
@@ -68,8 +63,8 @@ my $t = Test::Mojo->new('OpenQA::CacheService');
 
 my $server_instance = process sub {
     # Connect application with web server and start accepting connections
-    my $daemon = Mojo::Server::Daemon->new(app => fake_asset_server, listen => [$host])->silent(1);
-    $daemon->run;
+    my $listen = [make_listen_url($sockets->{webui}->sockport)];
+    Mojo::Server::Daemon->new(app => fake_asset_server, listen => $listen, silent => 1)->run;
     Devel::Cover::report() if Devel::Cover->can('report');
     _exit(0);    # uncoverable statement to ensure proper exit code of complete test at cleanup
   },
@@ -79,6 +74,9 @@ my $server_instance = process sub {
   kill_sleeptime => 0;
 
 sub start_servers () {
+    $sockets = OpenQA::Utils::reserve_ports([qw(webui cache_service)]);
+    $host = make_access_url($sockets->{webui}->sockport);
+    $cache_client = OpenQA::CacheService::Client->new;
     $server_instance->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0)->restart;
     $cache_service->set_pipes(0)->separate_err(0)->blocking_stop(1)->channels(0)->restart;
     perform_minion_jobs($t->app->minion);
@@ -209,6 +207,8 @@ CACHELIMIT = 100");
     is_deeply [OpenQA::CacheService::setup_workers(qw(run))], [qw(run -j 5)], 'minion worker setup with parallel jobs';
 };
 
+start_servers;
+
 subtest 'Cache Requests' => sub {
     my $asset_request = $cache_client->asset_request(id => 922756, asset => 'test', type => 'hdd', host => 'open.qa');
     my $rsync_request = $cache_client->rsync_request(from => 'foo', to => 'bar');
@@ -225,8 +225,6 @@ subtest 'Cache Requests' => sub {
     throws_ok { $base->to_array } qr/to_array\(\) not implemented in OpenQA::CacheService::Request/,
       'to_array() not implemented in base request';
 };
-
-start_servers;
 
 subtest 'Invalid requests' => sub {
     my $url = $cache_client->url('/status/12345');
@@ -302,7 +300,10 @@ subtest 'Job progress (guard against parallel downloads of the same file)' => su
 
 subtest 'Client can check if there are available workers' => sub {
     $cache_service->stop;
+    $cache_client->ua->connect_timeout(1)->inactivity_timeout(1);
     ok !$cache_client->info->available, 'Cache server is not available';
+    OpenQA::Utils::reserve_ports([qw(cache_service)], force => 1);
+    $cache_client = OpenQA::CacheService::Client->new;
     $cache_service->restart;
     perform_minion_jobs($t->app->minion);
     wait_for_or_bail_out { $cache_client->info->available } 'cache service';

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -73,7 +73,7 @@ sub start_server {
         Mojo::Server::Daemon->new(
             app => fake_asset_server,
             listen => [make_listen_url(raw_service_port('test'))],
-            silent => 1
+            silent => $ENV{HARNESS_IS_VERBOSE} ? 0 : 1
         )->run;
         Devel::Cover::report() if Devel::Cover->can('report');
         _exit(0);    # uncoverable statement to ensure proper exit code of complete test at cleanup

--- a/t/25-cache.t
+++ b/t/25-cache.t
@@ -36,9 +36,8 @@ use Carp 'croak';
 use Test::Warnings ':report_warnings';
 use Test::MockModule;
 use Test::Mojo;
-use OpenQA::Utils qw(:DEFAULT base_host);
+use OpenQA::Utils qw(:DEFAULT base_host make_listen_url to_plain_service_port);
 use OpenQA::CacheService;
-use IO::Socket::INET;
 use Mojo::Server::Daemon;
 use Mojo::IOLoop::Server;
 use Mojo::SQLite;
@@ -49,8 +48,8 @@ use IPC::Run qw(start);
 use OpenQA::Test::Utils qw(fake_asset_server stop_service wait_for_or_bail_out);
 use OpenQA::Test::TimeLimit '30';
 
-my $port = Mojo::IOLoop::Server->generate_port;
-my $host = "localhost:$port";
+my $port = 0;
+my $host = 'localhost:0';
 
 # Capture logs
 my $log = Mojo::Log->new;
@@ -64,21 +63,26 @@ $log->on(
 
 END { session->clean }
 
+my $app = OpenQA::CacheService->new(log => $log);
+my $ua = $app->ua->connect_timeout(0.25)->inactivity_timeout(0.25);
+my $cache = $app->cache;
 my $server_instance;
 
 sub start_server {
     $server_instance = start sub {
-        Mojo::Server::Daemon->new(app => fake_asset_server, listen => ["http://$host"], silent => 1)->run;
+        Mojo::Server::Daemon->new(
+            app => fake_asset_server,
+            listen => [make_listen_url(raw_service_port('test'))],
+            silent => 1
+        )->run;
         Devel::Cover::report() if Devel::Cover->can('report');
         _exit(0);    # uncoverable statement to ensure proper exit code of complete test at cleanup
     };
-    wait_for_or_bail_out { IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => $port) } 'cache service';
+    wait_for_or_bail_out { $app->ua->get("http://$host/test")->res->is_success } 'cache service';
 }
 
 END { stop_service($server_instance) }
 
-my $app = OpenQA::CacheService->new(log => $log);
-my $cache = $app->cache;
 is $cache->sqlite->migrations->latest, 5, 'Current version is the latest version';
 is $cache->sqlite->migrations->active, 5, 'Current version is the active version';
 like $cache_log, qr/Creating cache directory tree for "$cachedir"/, 'Cache directory tree created';
@@ -150,8 +154,8 @@ like $cache_log, qr/Downloading "sle-12-SP3-x86_64-0368-textmode\@64bit.qcow2" f
 like $cache_log, qr/failed: Connection refused/, 'Asset download fails with: Connection refused';
 $cache_log = '';
 
-$port = Mojo::IOLoop::Server->generate_port;
-$host = "127.0.0.1:$port";
+$port = OpenQA::Utils::reserve_ports(['test'])->sockport;
+$host = '127.0.0.1:' . to_plain_service_port($port);
 start_server;
 
 $cache->limit(1024);

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -11,20 +11,16 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 
 use OpenQA::Downloader;
-use IO::Socket::INET;
 use Mojo::Server::Daemon;
-use Mojo::IOLoop::Server;
 use Mojo::Log;
 use POSIX '_exit';
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
+use OpenQA::Utils qw(make_listen_url make_access_url to_plain_service_port);
 use OpenQA::Test::Utils qw(fake_asset_server wait_for_or_bail_out);
 use OpenQA::Test::TimeLimit '10';
 use Mojo::File qw(tempdir);
 use Test::MockModule;
-
-my $port = Mojo::IOLoop::Server->generate_port;
-my $host = "127.0.0.1:$port";
 
 # Capture logs
 my $log = Mojo::Log->new;
@@ -40,33 +36,11 @@ $SIG{INT} = sub { session->clean };
 
 END { session->clean }
 
-my $server_instance = process sub {
-    # uncoverable statement
-    Mojo::Server::Daemon->new(app => fake_asset_server, listen => ["http://$host"], silent => 1)->run;
-    Devel::Cover::report() if Devel::Cover->can('report');
-    _exit(0);    # uncoverable statement to ensure proper exit code of complete test at cleanup
-  },
-  max_kill_attempts => 0,
-  blocking_stop => 1,
-  _default_blocking_signal => POSIX::SIGTERM,
-  kill_sleeptime => 0;
-
-sub start_server {
-    $server_instance->set_pipes(0)->start;
-    wait_for_or_bail_out { IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => $port) } 'worker';
-}
-
-sub stop_server {
-    # now kill the worker
-    $server_instance->stop();
-}
-
 my $mojo_tmpdir = tempdir;
 my $downloader = OpenQA::Downloader->new(log => $log, sleep_time => 0.05, attempts => 3, tmpdir => $mojo_tmpdir);
 my $ua = $downloader->ua;
 my $tempdir = tempdir;
 my $to = $tempdir->child('test.qcow');
-
 $ua->connect_timeout(0.25)->inactivity_timeout(0.25);
 
 subtest 'Unable to create temporary directory' => sub {
@@ -76,7 +50,7 @@ subtest 'Unable to create temporary directory' => sub {
 };
 
 subtest 'Connection refused' => sub {
-    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
+    my $from = "http://127.0.0.1:0/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
     like $downloader->download($from, $to), qr/Download of "$to" failed: Connection refused/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
@@ -89,12 +63,24 @@ subtest 'Connection refused' => sub {
     $cache_log = '';
 };
 
-$port = Mojo::IOLoop::Server->generate_port;
-$host = "127.0.0.1:$port";
-start_server;
+my $port = OpenQA::Utils::reserve_ports(['test'])->sockport;
+my $host = make_access_url($port);
+my $server_instance = process sub {
+    # uncoverable statement
+    Mojo::Server::Daemon->new(app => fake_asset_server, listen => [make_listen_url($port)], silent => 1)->run;
+    Devel::Cover::report() if Devel::Cover->can('report');
+    _exit(0);    # uncoverable statement to ensure proper exit code of complete test at cleanup
+  },
+  max_kill_attempts => 0,
+  blocking_stop => 1,
+  _default_blocking_signal => POSIX::SIGTERM,
+  kill_sleeptime => 0;
+$server_instance->set_pipes(0)->start;
+wait_for_or_bail_out { defined $ua->get($host)->res->code } 'worker';
+sub stop_server { $server_instance->stop() }
 
 subtest 'Not found' => sub {
-    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-404@64bit.qcow2";
+    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-404@64bit.qcow2";
     like $downloader->download($from, $to), qr/Download of "$to" failed: 404 Not Found/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
@@ -106,7 +92,7 @@ subtest 'Not found' => sub {
 };
 
 subtest 'Success' => sub {
-    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200@64bit.qcow2";
+    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200@64bit.qcow2";
     is $downloader->download($from, $to), undef, 'Success';
 
     ok -e $to, 'File downloaded';
@@ -119,7 +105,7 @@ subtest 'Success' => sub {
 };
 
 subtest 'Connection closed early' => sub {
-    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_close@64bit.qcow2";
+    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_close@64bit.qcow2";
     like $downloader->download($from, $to), qr/Download of "$to" failed: Premature connection close/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
@@ -132,7 +118,7 @@ subtest 'Connection closed early' => sub {
 };
 
 subtest 'Server error' => sub {
-    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_server_error@64bit.qcow2";
+    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_server_error@64bit.qcow2";
     like $downloader->download($from, $to), qr/Download of "$to" failed: 500 Internal Server Error/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
@@ -145,7 +131,7 @@ subtest 'Server error' => sub {
 };
 
 subtest 'Size differs' => sub {
-    my $from = "http://$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-589@64bit.qcow2";
+    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-589@64bit.qcow2";
     like $downloader->download($from, $to), qr/Size of .* differs, expected \d+ Byte but downloaded \d+ Byte/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
@@ -159,7 +145,7 @@ subtest 'Size differs' => sub {
 
 subtest 'Non-compressed files kept as-is - no complaint about unknown archive format' => sub {
     $to = $tempdir->child('test.txt');
-    my $from = "http://$host/test";
+    my $from = "$host/test";
     # don't check the error message as it is not interesting
     # (it's a generic error message that the archive is invalid)
     is $downloader->download($from, $to, {extract => 1}), undef, 'Success';
@@ -172,7 +158,7 @@ subtest 'Non-compressed files kept as-is - no complaint about unknown archive fo
 
 subtest 'Decompressing file' => sub {
     $to = $tempdir->child('test');
-    my $from = "http://$host/test.gz";
+    my $from = "$host/test.gz";
     is $downloader->download($from, $to, {extract => 1}), undef, 'Success';
     ok -e $to, 'File downloaded and decompressed';
     is $to->slurp, 'This file was compressed!', 'File was decompressed';
@@ -184,7 +170,7 @@ subtest 'Decompressing file' => sub {
 
 subtest 'Decompressing archive' => sub {
     $to = $tempdir->child('test');
-    my $from = "http://$host/test.tar.xz";
+    my $from = "$host/test.tar.xz";
     is $downloader->download($from, $to, {extract => 1}), undef, 'Success';
     ok -d $to, 'File downloaded, uncompressed and extracted';
     is $to->child('test-file')->slurp, "Archived file!\n", 'File was extracted';
@@ -196,7 +182,7 @@ subtest 'Decompressing archive' => sub {
 
 subtest 'Error when decompressing archive' => sub {
     $to = $tempdir->child('fake-archive');
-    my $from = "http://$host/fake-archive.tar.xz";
+    my $from = "$host/fake-archive.tar.xz";
     like $downloader->download($from, $to, {extract => 1}), qr/Unrecognized archive format/, 'Failed';
     ok !-e $to, 'Target not created';
     like $cache_log, qr/Downloading "fake-archive" from "$from"/, 'Download attempt';

--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -67,7 +67,11 @@ my $port = OpenQA::Utils::reserve_ports(['test'])->sockport;
 my $host = make_access_url($port);
 my $server_instance = process sub {
     # uncoverable statement
-    Mojo::Server::Daemon->new(app => fake_asset_server, listen => [make_listen_url($port)], silent => 1)->run;
+    Mojo::Server::Daemon->new(
+        app => fake_asset_server,
+        listen => [make_listen_url($port)],
+        silent => $ENV{HARNESS_IS_VERBOSE} ? 0 : 1
+    )->run;
     Devel::Cover::report() if Devel::Cover->can('report');
     _exit(0);    # uncoverable statement to ensure proper exit code of complete test at cleanup
   },

--- a/t/40-script_load_dump_templates.t
+++ b/t/40-script_load_dump_templates.t
@@ -20,7 +20,6 @@ use OpenQA::Test::Utils qw(run_cmd test_cmd stop_service);
 use Mojo::JSON;    # booleans
 use Cpanel::JSON::XS ();
 
-
 sub test_once (@args) {
     # Report failure at the callsite instead of the test function
     local $Test::Builder::Level = $Test::Builder::Level + 1;
@@ -43,7 +42,7 @@ sub check_property ($schema, $table, $property, $values) {
 test_once '--help', qr/Usage:/, 'help text shown', 0, 'openqa-load-templates with no arguments shows usage';
 test_once '--host', qr/Option host requires an argument/, 'host argument error shown', 1, 'required arguments missing';
 
-my $host = 'testhost:1234';
+my $host = '123.456.789:0';
 my $filename = 't/data/40-templates.pl';
 my $morefilename = 't/data/40-templates-more.pl';
 my $args = "--host $host $filename";

--- a/t/40-script_load_dump_templates.t
+++ b/t/40-script_load_dump_templates.t
@@ -9,6 +9,7 @@ use File::Temp qw(tempfile);
 use Mojo::Base -signatures;
 use Mojo::File qw(path curfile);
 require OpenQA::Test::Database;
+use OpenQA::Utils qw(to_plain_service_port);
 use OpenQA::Test::Utils;
 use Test::Output;
 use Test::Warnings ':report_warnings';
@@ -49,8 +50,8 @@ my $args = "--host $host $filename";
 test_once $args, qr/unknown error code - host $host unreachable?/, 'invalid host error', 22, 'error on invalid host';
 
 $ENV{MOJO_LOG_LEVEL} = 'fatal';
-my $mojoport = Mojo::IOLoop::Server->generate_port;
-$host = "localhost:$mojoport";
+my $mojoport = OpenQA::Utils::reserve_ports(['webui'])->sockport;
+$host = 'localhost:' . to_plain_service_port($mojoport);
 my $schema = OpenQA::Test::Database->new->create(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 my $webapi = OpenQA::Test::Utils::create_webapi($mojoport, sub { });
 END { stop_service $webapi; }

--- a/t/43-scheduling-and-worker-scalability.t
+++ b/t/43-scheduling-and-worker-scalability.t
@@ -33,6 +33,7 @@ BEGIN {
     # set defaults
     $ENV{SCALABILITY_TEST_WORKER_COUNT} //= 5;
     $ENV{SCALABILITY_TEST_WITH_OFFLINE_WEBUI_HOST} //= 1;
+    OpenQA::Utils::reserve_ports;
 }
 
 setup_mojo_app_with_default_worker_timeout;

--- a/t/44-scripts-initdb.t
+++ b/t/44-scripts-initdb.t
@@ -20,7 +20,7 @@ $ENV{OPENQA_DATABASE} = 'test';
 $ENV{OPENQA_DATABASE_SEARCH_PATH} = $schema_name;
 $ENV{OPENQA_SCHEMA_VERSION_OVERRIDE} = $schema_version;
 
-my $schema = OpenQA::Schema::connect_db(deploy => 0, silent => 1, from_script => 1);
+my $schema = OpenQA::Schema::connect_db(deploy => 0, silent => $ENV{HARNESS_IS_VERBOSE} ? 0 : 1, from_script => 1);
 $schema->storage->dbh->do("create schema \"$schema_name\"");
 
 my $tempdir = tempdir;

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -19,7 +19,6 @@ use Carp;
 use Data::Dump 'pp';
 use Feature::Compat::Try;
 use IPC::Run qw(start);
-use Mojo::IOLoop::Server;
 use Mojo::Server::Daemon;
 use Time::HiRes qw(time sleep);
 use OpenQA::WebAPI;
@@ -37,7 +36,8 @@ our $STARTINGPID = 0;
 use constant FIND_METHOD => 'css';
 
 sub _start_app ($args) {
-    $MOJOPORT = $ENV{OPENQA_BASE_PORT} = $args->{mojoport} // $ENV{MOJO_PORT} // Mojo::IOLoop::Server->generate_port;
+    $MOJOPORT = $ENV{OPENQA_BASE_PORT} = $args->{mojoport} // $ENV{MOJO_PORT}
+      // OpenQA::Utils::reserve_ports(['webui'])->sockport;
     $STARTINGPID = $$;
     $WEBAPI = OpenQA::Test::Utils::create_webapi($MOJOPORT);
     return $MOJOPORT;

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -276,7 +276,8 @@ sub create_webapi ($port = undef, $no_cover = undef) {
         _setup_sub_process 'openqa-webapi';
         local $ENV{MOJO_MODE} = 'test';
 
-        my $daemon = Mojo::Server::Daemon->new(listen => [make_listen_url($port)], silent => 1);
+        my $daemon
+          = Mojo::Server::Daemon->new(listen => [make_listen_url($port)], silent => $ENV{HARNESS_IS_VERBOSE} ? 0 : 1);
         $daemon->build_app('OpenQA::WebAPI');
         $daemon->run;
         Devel::Cover::report() if !$no_cover && Devel::Cover->can('report');
@@ -354,7 +355,8 @@ sub create_scheduler ($port = raw_service_port('scheduler')) {
 sub create_live_view_handler ($port = raw_service_port 'livehandler') {
     _setup_sigchld_handler 'openqa-livehandler', start sub {
         _setup_sub_process 'openqa-livehandler';
-        my $daemon = Mojo::Server::Daemon->new(listen => [make_listen_url($port)], silent => 1);
+        my $daemon
+          = Mojo::Server::Daemon->new(listen => [make_listen_url($port)], silent => $ENV{HARNESS_IS_VERBOSE} ? 0 : 1);
         $daemon->build_app('OpenQA::LiveHandler');
         $daemon->run;
         Devel::Cover::report() if Devel::Cover->can('report');

--- a/t/ui/27-plugin_obs_rsync_obs_status.t
+++ b/t/ui/27-plugin_obs_rsync_obs_status.t
@@ -5,13 +5,13 @@ use Test::Most;
 
 use FindBin;
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../../external/os-autoinst-common/lib";
+use OpenQA::Utils qw(make_access_url make_listen_url to_plain_service_port);
 use OpenQA::Test::TimeLimit '30';
 use OpenQA::Test::Utils qw(perform_minion_jobs wait_for_or_bail_out);
 use OpenQA::Test::ObsRsync 'setup_obs_rsync_test';
 use Mojolicious;
 use IO::Socket::INET;
 use Mojo::Server::Daemon;
-use Mojo::IOLoop::Server;
 use Mojo::IOLoop::ReadWriteProcess 'process';
 use Mojo::IOLoop::ReadWriteProcess::Session 'session';
 use Mojo::File qw(path tempfile);
@@ -29,8 +29,8 @@ $SIG{INT} = sub { session->clean };    # uncoverable statement count:2
 
 END { session->clean }
 
-my $port = Mojo::IOLoop::Server->generate_port;
-my $host = "http://127.0.0.1:$port";
+my $port = OpenQA::Utils::reserve_ports(['test'])->sockport;
+my $host = make_access_url($port);
 my $url = "$host/build/%%PROJECT/_result";
 my %fake_response_by_project = (
     Proj3 => '
@@ -122,7 +122,7 @@ my $server_process = sub {
                 return $c->render(status => 200, text => $fake_response_by_project{$project});
             });
     }
-    my $daemon = Mojo::Server::Daemon->new(app => $mock, listen => [$host]);
+    my $daemon = Mojo::Server::Daemon->new(app => $mock, listen => [make_listen_url($port)]);
     $daemon->run;
     note 'Fake API server stopped';
     Devel::Cover::report() if Devel::Cover->can('report');
@@ -138,7 +138,7 @@ my $server_instance = process(
 );
 
 $server_instance->set_pipes(0)->start;
-wait_for_or_bail_out { IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => $port) } 'API';
+wait_for_or_bail_out { IO::Socket::INET->new(PeerAddr => '127.0.0.1', PeerPort => to_plain_service_port($port)) } 'API';
 
 my $ssh_keyfile = tempfile("$FindBin::Script-sshkey-XXXXX");
 # using the key from [0] to have a reproduceable output.


### PR DESCRIPTION
This applies the approach from 4d127b3b3b3584faea0c630505552e44dcd1f1b2 to other tests. Check out individual commit messages for details.

Related ticket: https://progress.opensuse.org/issues/202662