### PR TITLE
feat: throw 404 for nonexistent groups in overview

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -228,6 +228,7 @@ So this works in the same way as the test results overview in the GUI.
 
 sub overview ($self) {
     my ($search_args, $groups) = $self->compose_job_overview_search_args;
+    return undef unless $search_args;
     my $failed_modules = $self->param_hash('failed_modules');
     my $jobs_rs = $self->schema->resultset('Jobs');
     my $latest_job_ids = $jobs_rs->complex_query_latest_ids(%$search_args);

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -680,6 +680,7 @@ sub _render_badge ($self, $badge_text, $badge_color, $status = HTTP_OK) {
 
 sub _gather_overview_results ($self, %args) {
     my ($search_args, $groups) = $self->compose_job_overview_search_args;
+    return undef unless $search_args;
     my $jobs_rs = $self->schema->resultset('Jobs');
     my $latest_job_ids = $jobs_rs->complex_query_latest_ids(%$search_args);
     my $limit = $search_args->{limit};
@@ -701,6 +702,7 @@ sub _gather_overview_results ($self, %args) {
 
 sub overview_badge ($self) {
     my $data = $self->_gather_overview_results(only_aggregated => 1);
+    return undef unless $data;
     my $aggregated = $data->{aggregated};
 
     my $status = (grep { $aggregated->{$_} } OVERVIEW_STATUS_PRIORITY)[0] // 'none';
@@ -978,6 +980,7 @@ sub _add_distri_and_version_to_summary ($array_to_add_parts_to, $distri, $versio
 # A generic query page showing test results in a configurable matrix
 sub overview ($self) {
     my $data = $self->_gather_overview_results;
+    return undef unless $data;
     my $search_args = $data->{search_args};
     my $groups = $data->{groups};
     my $latest_job_ids = $data->{latest_job_ids};

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -408,6 +408,13 @@ sub _compose_job_overview_search_args ($c) {
         my @group_name_search = map { {name => $_} } @{$v->every_param('group')};
         my @search_terms = (@group_id_search, @group_name_search);
         @groups = $schema->resultset('JobGroups')->search(\@search_terms)->all;
+        if (!@groups) {
+            $c->stash(error_message => 'Group does not exist');
+            $c->respond_to(
+                json => {json => {error => 'Group does not exist'}, status => 400},
+                any => sub { $c->render(template => 'main/specific_not_found', status => 400) });
+            return undef;
+        }
     }
 
     else {

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -72,9 +72,9 @@ subtest 'Basic overview display' => sub {
 };
 
 subtest 'Job group selection' => sub {
-    my $form = {distri => 'opensuse', version => '13.1', build => '0091', group => 'opensuse 13.1'};
+    my $form = {distri => 'opensuse', version => '13.1', build => '0091', group => 'opensuse'};
     $t->get_ok('/tests/overview' => form => $form)->status_is(200);
-    like get_summary, qr/Overall Summary of opensuse 13\.1 build 0091/i, 'specifying group parameter';
+    like get_summary, qr/Overall Summary of opensuse build 0091/i, 'specifying group parameter';
 
     $form = {distri => 'opensuse', version => '13.1', build => '0091', groupid => 1001};
     $t->get_ok('/tests/overview' => form => $form)->status_is(200);
@@ -133,6 +133,11 @@ subtest 'Default overview for 13.1' => sub {
 
     $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', groupid => 'a'})->status_is(200);
     like flash_msg, qr/Specified "groupid" is invalid/i, 'error message for invalid groupid';
+};
+
+subtest 'Nonexistent job group' => sub {
+    $t->get_ok('/tests/overview' => form => {groupid => 12345})->status_is(400);
+    $t->get_ok('/tests/overview' => form => {group => 'nonexistent_group'})->status_is(400);
 };
 
 subtest 'Default overview for Factory' => sub {

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -267,6 +267,11 @@ subtest 'job overview' => sub {
         $t->json_is('' => [\%job_99940], 'latest build present');
     };
 
+    subtest 'nonexistent job group in API overview' => sub {
+        $query->query(groupid => '12345');
+        $t->get_ok($query->path_query)->status_is(400)->json_is('/error', 'Group does not exist');
+    };
+
     subtest 'specific build without additional parameters' => sub {
         $query->query(build => '0048');
         $t->get_ok($query->path_query)->status_is(200);


### PR DESCRIPTION
Motivation
When a user specifies a non-existent group ID/name in the test overview
endpoint, openQA silently ignores the parameter and returns all test
results. This causes massive performance overhead and returns confusing jobs.

Design Choices
Check if explicit group parameters are specified but resolve to an empty
list of groups, and respond with a 404 error using the appropriate format.
Update callers to abort gracefully when the search parameters are undefined.

Benefits
This prevents unnecessary database load and provides clear and expected
error responses to users and API clients for non-existent job groups.