### PR TITLE
PART 2: feat: Prioritize cleanup of busiest job groups - After #7574

### DIFF
--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -8,7 +8,8 @@ use OpenQA::Jobs::Constants;
 use OpenQA::Log 'log_debug';
 use OpenQA::ScreenshotDeletion;
 use OpenQA::Utils qw(:DEFAULT resultdir archivedir check_df);
-use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage);
+use OpenQA::Task::Utils
+  qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage is_disk_usage_below_percentage);
 use OpenQA::Task::SignalGuard;
 use Scalar::Util 'looks_like_number';
 use List::Util 'min';
@@ -55,6 +56,16 @@ sub _limit ($job, $args = undef) {
     my $gru = $app->gru;
     my %options = (priority => -20, ttl => 2 * ONE_DAY);
     while (my $group = $groups->next) {
+        if (
+            my $msg = is_disk_usage_below_percentage(
+                job => $job,
+                setting => 'result_cleanup_max_free_percentage',
+                dir => resultdir
+            ))
+        {
+            $job->note(early_abort_results => $msg);
+            last;
+        }
         my @preserved_important_jobs;
         $group->limit_results_and_logs(\@preserved_important_jobs);
 

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -52,7 +52,13 @@ sub _limit ($job, $args = undef) {
     my $schema = $app->schema;
     $schema->resultset('JobGroups')->new({})->limit_results_and_logs;
 
-    my $groups = $schema->resultset('JobGroups');
+    my $groups = $schema->resultset('JobGroups')->search(
+        undef,
+        {
+            join => 'jobs',
+            group_by => ['me.id', 'me.name'],
+            order_by => 'COUNT(jobs.id) DESC'
+        });
     my $gru = $app->gru;
     my %options = (priority => -20, ttl => 2 * ONE_DAY);
     while (my $group = $groups->next) {

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -5,7 +5,7 @@ package OpenQA::Task::Job::Limit;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use OpenQA::Jobs::Constants;
-use OpenQA::Log 'log_debug';
+use OpenQA::Log qw(log_debug log_info);
 use OpenQA::ScreenshotDeletion;
 use OpenQA::Utils qw(:DEFAULT resultdir archivedir check_df);
 use OpenQA::Task::Utils
@@ -63,6 +63,7 @@ sub _limit ($job, $args = undef) {
                 dir => resultdir
             ))
         {
+            log_info "Early abort during job groups loop: $msg";
             $job->note(early_abort_results => $msg);
             last;
         }

--- a/lib/OpenQA/Task/Utils.pm
+++ b/lib/OpenQA/Task/Utils.pm
@@ -5,7 +5,7 @@ package OpenQA::Task::Utils;
 use Mojo::Base -signatures;
 
 use Exporter qw(import);
-use OpenQA::Log qw(log_warning);
+use OpenQA::Log qw(log_warning log_info);
 use OpenQA::Utils qw(check_df);
 use Scalar::Util qw(looks_like_number);
 use Time::Seconds;
@@ -51,6 +51,7 @@ sub is_disk_usage_below_percentage (%args) {
 
 sub finish_job_if_disk_usage_below_percentage (%args) {
     if (my $msg = is_disk_usage_below_percentage(%args)) {
+        log_info $msg;
         $args{job}->finish($msg);
         return 1;
     }

--- a/lib/OpenQA/Task/Utils.pm
+++ b/lib/OpenQA/Task/Utils.pm
@@ -11,7 +11,8 @@ use Scalar::Util qw(looks_like_number);
 use Time::Seconds;
 use Feature::Compat::Try;
 
-our @EXPORT_OK = (qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage));
+our @EXPORT_OK
+  = (qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage is_disk_usage_below_percentage));
 
 # acquire lock to prevent multiple limit_* tasks to run in parallel unless
 # concurrency is configured to be allowed
@@ -24,7 +25,7 @@ sub acquire_limit_lock_or_retry ($job) {
     return 0;
 }
 
-sub finish_job_if_disk_usage_below_percentage (%args) {
+sub is_disk_usage_below_percentage (%args) {
     my $job = $args{job};
     my $percentage = $job->app->config->{misc_limits}->{$args{setting}};
 
@@ -44,9 +45,16 @@ sub finish_job_if_disk_usage_below_percentage (%args) {
 
     my $free_percentage = $available_bytes / $total_bytes * 100;
     return undef if $free_percentage <= $percentage;
-    $job->finish("Skipping, free disk space on '$dir' exceeds configured percentage $percentage %"
-          . " (free percentage: $free_percentage %)");
-    return 1;
+    return
+"Skipping, free disk space on '$dir' exceeds configured percentage $percentage % (free percentage: $free_percentage %)";
+}
+
+sub finish_job_if_disk_usage_below_percentage (%args) {
+    if (my $msg = is_disk_usage_below_percentage(%args)) {
+        $args{job}->finish($msg);
+        return 1;
+    }
+    return undef;
 }
 
 1;

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -62,14 +62,19 @@ $mock_df->();
 subtest 'abort early if there is enough free disk space' => sub {
 
     $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 10;
-    my $job = run_gru_job($app, limit_results_and_logs => []);
+    my $job;
+    combined_like { $job = run_gru_job($app, limit_results_and_logs => []) }
+    qr/Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 11 %\)/,
+      'result cleanup early abort logged';
     is $job->{state}, 'finished', 'result cleanup still considered successful';
     like $job->{result},
       qr|Skipping.*/openqa/testresults.*exceeds configured percentage 10 % \(free percentage: 11 %\)|,
       'result cleanup aborted early';
 
     $app->config->{misc_limits}->{asset_cleanup_max_free_percentage} = 9;
-    $job = run_gru_job($app, limit_assets => []);
+    combined_like { $job = run_gru_job($app, limit_assets => []) }
+    qr/Skipping, free disk space on '.*' exceeds configured percentage 9 % \(free percentage: 11 %\)/,
+      'asset cleanup early abort logged';
     is $job->{state}, 'finished', 'asset cleanup still considered successful';
     like $job->{result},
       qr|Skipping.*/openqa/share/factory.*exceeds configured percentage 9 % \(free percentage: 11 %\)|,
@@ -101,7 +106,10 @@ subtest 'abort early during the loop' => sub {
     # There is already a `JobGroup` created below, but maybe we can just run the minion job and check the note.
     # To check the note, we must retrieve the minion job from the db.
     my $group_bar = $app->schema->resultset('JobGroups')->create({name => 'bar'});
-    my $loop_job = run_gru_job($app, limit_results_and_logs => []);
+    my $loop_job;
+    combined_like { $loop_job = run_gru_job($app, limit_results_and_logs => []) }
+qr/Early abort during job groups loop: Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 20 %\)/,
+      'early abort during loop logged';
     is $loop_job->{state}, 'finished', 'result cleanup still considered successful';
     like $loop_job->{notes}->{early_abort_results},
       qr|Skipping.*/openqa/testresults.*exceeds configured percentage 10 % \(free percentage: 20 %\)|,

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -90,6 +90,27 @@ subtest 'abort early if there is enough free disk space' => sub {
     is $job->{state}, undef, 'job not finished when proceeding with cleanup';
 };
 
+subtest 'abort early during the loop' => sub {
+    # We will simulate `df` returning low space on the first call, and high space on the second call.
+    my $df_call_count = 0;
+    my @bavail = (5);
+    $df_mock->redefine(df => sub ($dir, @) { {bavail => $bavail[$df_call_count++] // 20, blocks => 100} });
+    $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 10;
+
+    # We need to make sure there are JobGroups to iterate over
+    # There is already a `JobGroup` created below, but maybe we can just run the minion job and check the note.
+    # To check the note, we must retrieve the minion job from the db.
+    my $group_bar = $app->schema->resultset('JobGroups')->create({name => 'bar'});
+    my $loop_job = run_gru_job($app, limit_results_and_logs => []);
+    is $loop_job->{state}, 'finished', 'result cleanup still considered successful';
+    like $loop_job->{notes}->{early_abort_results},
+      qr|Skipping.*/openqa/testresults.*exceeds configured percentage 10 % \(free percentage: 20 %\)|,
+      'result cleanup aborted early inside the loop';
+    $group_bar->delete;
+
+    $mock_df->();    # restore
+};
+
 $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 100;
 $app->config->{misc_limits}->{asset_cleanup_max_free_percentage} = 100;
 $app->config->{misc_limits}->{dry_min_free_disk_space_cleanup} = 1;

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -370,4 +370,38 @@ subtest 'deleted screenshots always accounted to main storage' => sub {
       'not finished as job that gained disk space only did so by deleting screenshots on main storage';
 };
 
+subtest 'job groups are prioritized by job count' => sub {
+    $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 100;
+
+    # Create groups and their respective count of jobs
+    my %group_job_counts = (g_one => 1, g_two => 2, g_three => 3);
+    my @created_groups = map {
+        my $name = $_;
+        my $g = $app->schema->resultset('JobGroups')->create({name => $name});
+        $app->schema->resultset('Jobs')->create({TEST => "job-$name-$_", group_id => $g->id})
+          for 1 .. $group_job_counts{$name};
+        $g;
+    } keys %group_job_counts;
+
+    # Mock limit_results_and_logs to trace the invocation order
+    my $job_group_mock = Test::MockModule->new('OpenQA::Schema::Result::JobGroups');
+    my @processed;
+    $job_group_mock->redefine(
+        limit_results_and_logs => sub ($self, @args) {
+            push @processed, $self->name if $self->name;
+        });
+
+    run_gru_job($app, limit_results_and_logs => []);
+
+    my %our_groups = (g_one => 1, g_two => 1, g_three => 1);
+    my @processed_filtered = grep { $our_groups{$_} } @processed;
+
+    is_deeply \@processed_filtered, ['g_three', 'g_two', 'g_one'],
+      'job groups processed in descending order of job count';
+
+    # Clean up
+    $app->schema->resultset('Jobs')->search({group_id => [map { $_->id } @created_groups]})->delete;
+    $_->delete for @created_groups;
+};
+
 done_testing();


### PR DESCRIPTION
Motivation:
Iterating over job groups in default DB order creates an unfair bias, always
cleaning up the same groups first while newer groups escape early aborts.

Design Choices:
Query and sort JobGroups by 'COUNT(jobs.id) DESC' to dynamically process the
most active groups first, which likely consume the most disk space.

Benefits:
Ensures a fair distribution of cleanup operations and maximizes disk space
reclaimed early to prevent load surges during high-concurrency periods.

Related issue: https://progress.opensuse.org/issues/197483

After:
* #7574