### PR TITLE
feat: Use stateful round-robin for group cleanup

### DIFF
--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -5,15 +5,18 @@ package OpenQA::Task::Job::Limit;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use OpenQA::Jobs::Constants;
-use OpenQA::Log qw(log_debug log_info);
+use OpenQA::Log qw(log_debug log_info log_warning);
 use OpenQA::ScreenshotDeletion;
-use OpenQA::Utils qw(:DEFAULT resultdir archivedir check_df);
+use OpenQA::Utils qw(:DEFAULT prjdir resultdir archivedir check_df);
 use OpenQA::Task::Utils
   qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage is_disk_usage_below_percentage);
 use OpenQA::Task::SignalGuard;
 use Scalar::Util 'looks_like_number';
 use List::Util 'min';
 use Time::Seconds;
+use Mojo::JSON qw(decode_json encode_json);
+use Mojo::File;
+use Feature::Compat::Try;
 
 # define default parameters for batch processing
 use constant DEFAULT_SCREENSHOTS_PER_BATCH => 200000;
@@ -52,10 +55,36 @@ sub _limit ($job, $args = undef) {
     my $schema = $app->schema;
     $schema->resultset('JobGroups')->new({})->limit_results_and_logs;
 
-    my $groups = $schema->resultset('JobGroups');
+    my $cache_file_path = prjdir() . '/webui/cache/cleanup-status.json';
+    my $last_id;
+    if (-f $cache_file_path) {
+        try {
+            my $content = Mojo::File->new($cache_file_path)->slurp;
+            my $data = decode_json($content);
+            $last_id = $data->{last_processed_job_group_id};
+            log_debug "Resuming job group cleanup after group ID $last_id" if $last_id;
+        }
+        catch ($e) {
+            log_warning("Unable to read cleanup status from $cache_file_path: $e");
+        }
+    }
+
+    my $groups_rs = $schema->resultset('JobGroups')->search(undef, {order_by => 'id ASC'});
+    my @all_groups = $groups_rs->all;
+
+    if (defined $last_id) {
+        my @greater_than = grep { $_->id > $last_id } @all_groups;
+        my @less_or_equal = grep { $_->id <= $last_id } @all_groups;
+        @all_groups = (@greater_than, @less_or_equal);
+    }
+
+    my $groups_count = scalar @all_groups;
+    log_info "Starting cleanup for $groups_count job groups";
+
     my $gru = $app->gru;
     my %options = (priority => -20, ttl => 2 * ONE_DAY);
-    while (my $group = $groups->next) {
+    my $last_processed_id;
+    for my $group (@all_groups) {
         if (
             my $msg = is_disk_usage_below_percentage(
                 job => $job,
@@ -63,7 +92,7 @@ sub _limit ($job, $args = undef) {
                 dir => resultdir
             ))
         {
-            log_info "Early abort during job groups loop: $msg";
+            log_info "Early abort during job groups loop (halted before processing group '@{[$group->name]}'): $msg";
             $job->note(early_abort_results => $msg);
             last;
         }
@@ -72,6 +101,21 @@ sub _limit ($job, $args = undef) {
 
         # archive openQA jobs that were preserved because they are important
         $gru->enqueue(archive_job_results => [$_->id], \%options) for @preserved_important_jobs;
+
+        $last_processed_id = $group->id;
+    }
+
+    if (defined $last_processed_id) {
+        try {
+            my $cache_file = Mojo::File->new("$cache_file_path.new");
+            $cache_file->dirname->make_path();
+            $cache_file->spew(encode_json({last_processed_job_group_id => $last_processed_id}))
+              ->move_to($cache_file_path);
+            log_debug "Saved cleanup status: last processed group ID is $last_processed_id";
+        }
+        catch ($e) {
+            log_warning("Unable to write cleanup status to $cache_file_path: $e");
+        }
     }
 
     $ensure_task_retry_on_termination_signal_guard->retry(0);

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -8,7 +8,8 @@ use OpenQA::Jobs::Constants;
 use OpenQA::Log 'log_debug';
 use OpenQA::ScreenshotDeletion;
 use OpenQA::Utils qw(:DEFAULT resultdir archivedir check_df);
-use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage);
+use OpenQA::Task::Utils
+  qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage is_disk_usage_below_percentage);
 use OpenQA::Task::SignalGuard;
 use Scalar::Util 'looks_like_number';
 use List::Util 'min';
@@ -55,6 +56,16 @@ sub _limit ($job, $args = undef) {
     my $gru = $app->gru;
     my %options = (priority => -20, ttl => 2 * ONE_DAY);
     while (my $group = $groups->next) {
+        if (
+            my $msg = is_disk_usage_below_percentage(
+                job => $job,
+                setting => 'result_cleanup_max_free_percentage',
+                dir => resultdir
+            ))
+        {
+            $job->note(early_abort_results => $msg);
+            last;
+        }
         my @preserved_important_jobs;
         $group->limit_results_and_logs(\@preserved_important_jobs);
 

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -52,7 +52,13 @@ sub _limit ($job, $args = undef) {
     my $schema = $app->schema;
     $schema->resultset('JobGroups')->new({})->limit_results_and_logs;
 
-    my $groups = $schema->resultset('JobGroups');
+    my $groups = $schema->resultset('JobGroups')->search(
+        undef,
+        {
+            join => 'jobs',
+            group_by => ['me.id', 'me.name'],
+            order_by => 'COUNT(jobs.id) DESC'
+        });
     my $gru = $app->gru;
     my %options = (priority => -20, ttl => 2 * ONE_DAY);
     while (my $group = $groups->next) {

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -5,7 +5,7 @@ package OpenQA::Task::Job::Limit;
 use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use OpenQA::Jobs::Constants;
-use OpenQA::Log 'log_debug';
+use OpenQA::Log qw(log_debug log_info);
 use OpenQA::ScreenshotDeletion;
 use OpenQA::Utils qw(:DEFAULT resultdir archivedir check_df);
 use OpenQA::Task::Utils
@@ -63,6 +63,7 @@ sub _limit ($job, $args = undef) {
                 dir => resultdir
             ))
         {
+            log_info "Early abort during job groups loop: $msg";
             $job->note(early_abort_results => $msg);
             last;
         }

--- a/lib/OpenQA/Task/Utils.pm
+++ b/lib/OpenQA/Task/Utils.pm
@@ -5,7 +5,7 @@ package OpenQA::Task::Utils;
 use Mojo::Base -signatures;
 
 use Exporter qw(import);
-use OpenQA::Log qw(log_warning);
+use OpenQA::Log qw(log_warning log_info);
 use OpenQA::Utils qw(check_df);
 use Scalar::Util qw(looks_like_number);
 use Time::Seconds;
@@ -51,6 +51,7 @@ sub is_disk_usage_below_percentage (%args) {
 
 sub finish_job_if_disk_usage_below_percentage (%args) {
     if (my $msg = is_disk_usage_below_percentage(%args)) {
+        log_info $msg;
         $args{job}->finish($msg);
         return 1;
     }

--- a/lib/OpenQA/Task/Utils.pm
+++ b/lib/OpenQA/Task/Utils.pm
@@ -11,7 +11,8 @@ use Scalar::Util qw(looks_like_number);
 use Time::Seconds;
 use Feature::Compat::Try;
 
-our @EXPORT_OK = (qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage));
+our @EXPORT_OK
+  = (qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage is_disk_usage_below_percentage));
 
 # acquire lock to prevent multiple limit_* tasks to run in parallel unless
 # concurrency is configured to be allowed
@@ -24,7 +25,7 @@ sub acquire_limit_lock_or_retry ($job) {
     return 0;
 }
 
-sub finish_job_if_disk_usage_below_percentage (%args) {
+sub is_disk_usage_below_percentage (%args) {
     my $job = $args{job};
     my $percentage = $job->app->config->{misc_limits}->{$args{setting}};
 
@@ -44,9 +45,16 @@ sub finish_job_if_disk_usage_below_percentage (%args) {
 
     my $free_percentage = $available_bytes / $total_bytes * 100;
     return undef if $free_percentage <= $percentage;
-    $job->finish("Skipping, free disk space on '$dir' exceeds configured percentage $percentage %"
-          . " (free percentage: $free_percentage %)");
-    return 1;
+    return
+"Skipping, free disk space on '$dir' exceeds configured percentage $percentage % (free percentage: $free_percentage %)";
+}
+
+sub finish_job_if_disk_usage_below_percentage (%args) {
+    if (my $msg = is_disk_usage_below_percentage(%args)) {
+        $args{job}->finish($msg);
+        return 1;
+    }
+    return undef;
 }
 
 1;

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -62,14 +62,19 @@ $mock_df->();
 subtest 'abort early if there is enough free disk space' => sub {
 
     $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 10;
-    my $job = run_gru_job($app, limit_results_and_logs => []);
+    my $job;
+    combined_like { $job = run_gru_job($app, limit_results_and_logs => []) }
+    qr/Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 11 %\)/,
+      'result cleanup early abort logged';
     is $job->{state}, 'finished', 'result cleanup still considered successful';
     like $job->{result},
       qr|Skipping.*/openqa/testresults.*exceeds configured percentage 10 % \(free percentage: 11 %\)|,
       'result cleanup aborted early';
 
     $app->config->{misc_limits}->{asset_cleanup_max_free_percentage} = 9;
-    $job = run_gru_job($app, limit_assets => []);
+    combined_like { $job = run_gru_job($app, limit_assets => []) }
+    qr/Skipping, free disk space on '.*' exceeds configured percentage 9 % \(free percentage: 11 %\)/,
+      'asset cleanup early abort logged';
     is $job->{state}, 'finished', 'asset cleanup still considered successful';
     like $job->{result},
       qr|Skipping.*/openqa/share/factory.*exceeds configured percentage 9 % \(free percentage: 11 %\)|,
@@ -101,7 +106,10 @@ subtest 'abort early during the loop' => sub {
     # There is already a `JobGroup` created below, but maybe we can just run the minion job and check the note.
     # To check the note, we must retrieve the minion job from the db.
     my $group_bar = $app->schema->resultset('JobGroups')->create({name => 'bar'});
-    my $loop_job = run_gru_job($app, limit_results_and_logs => []);
+    my $loop_job;
+    combined_like { $loop_job = run_gru_job($app, limit_results_and_logs => []) }
+qr/Early abort during job groups loop: Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 20 %\)/,
+      'early abort during loop logged';
     is $loop_job->{state}, 'finished', 'result cleanup still considered successful';
     like $loop_job->{notes}->{early_abort_results},
       qr|Skipping.*/openqa/testresults.*exceeds configured percentage 10 % \(free percentage: 20 %\)|,

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -90,6 +90,27 @@ subtest 'abort early if there is enough free disk space' => sub {
     is $job->{state}, undef, 'job not finished when proceeding with cleanup';
 };
 
+subtest 'abort early during the loop' => sub {
+    # We will simulate `df` returning low space on the first call, and high space on the second call.
+    my $df_call_count = 0;
+    my @bavail = (5);
+    $df_mock->redefine(df => sub ($dir, @) { {bavail => $bavail[$df_call_count++] // 20, blocks => 100} });
+    $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 10;
+
+    # We need to make sure there are JobGroups to iterate over
+    # There is already a `JobGroup` created below, but maybe we can just run the minion job and check the note.
+    # To check the note, we must retrieve the minion job from the db.
+    my $group_bar = $app->schema->resultset('JobGroups')->create({name => 'bar'});
+    my $loop_job = run_gru_job($app, limit_results_and_logs => []);
+    is $loop_job->{state}, 'finished', 'result cleanup still considered successful';
+    like $loop_job->{notes}->{early_abort_results},
+      qr|Skipping.*/openqa/testresults.*exceeds configured percentage 10 % \(free percentage: 20 %\)|,
+      'result cleanup aborted early inside the loop';
+    $group_bar->delete;
+
+    $mock_df->();    # restore
+};
+
 $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 100;
 $app->config->{misc_limits}->{asset_cleanup_max_free_percentage} = 100;
 $app->config->{misc_limits}->{dry_min_free_disk_space_cleanup} = 1;

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -13,7 +13,8 @@ require OpenQA::Test::Database;
 use OpenQA::Task::Job::Limit;
 use OpenQA::Task::Utils qw(finish_job_if_disk_usage_below_percentage);
 use OpenQA::Test::Utils qw(perform_minion_jobs run_gru_job);
-use OpenQA::Utils qw(assetdir resultdir archivedir);
+use OpenQA::Utils qw(prjdir assetdir resultdir archivedir);
+use Mojo::JSON qw(decode_json encode_json);
 use Mojo::File qw(path tempdir);
 use Mojo::Log;
 use Test::Output qw(combined_like combined_from);
@@ -105,7 +106,7 @@ subtest 'abort early during the loop' => sub {
     my $group_bar = $app->schema->resultset('JobGroups')->create({name => 'bar'});
     my $loop_job;
     combined_like { $loop_job = run_gru_job($app, limit_results_and_logs => []) }
-qr/Early abort during job groups loop: Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 20 %\)/,
+qr/Early abort during job groups loop \(halted before processing group 'bar'\): Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 20 %\)/,
       'early abort during loop logged';
     is $loop_job->{state}, 'finished', 'result cleanup still considered successful';
     like $loop_job->{notes}->{early_abort_results},
@@ -365,6 +366,77 @@ subtest 'deleted screenshots always accounted to main storage' => sub {
     is $job->{state}, 'failed', 'job considered failed';
     is $job->{result}, join("\n", @expected_messages),
       'not finished as job that gained disk space only did so by deleting screenshots on main storage';
+};
+
+subtest 'job groups are processed in stateful round-robin order' => sub {
+    $schema->txn_begin;
+
+    $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 100;
+
+    my $cache_file_path = prjdir() . '/webui/cache/cleanup-status.json';
+    unlink $cache_file_path;
+
+    my $g1 = $job_groups->create({name => 'g_one'});
+    my $g2 = $job_groups->create({name => 'g_two'});
+    my $g3 = $job_groups->create({name => 'g_three'});
+
+    my $job_group_mock = Test::MockModule->new('OpenQA::Schema::Result::JobGroups');
+    my @processed;
+    $job_group_mock->redefine(
+        limit_results_and_logs => sub ($self, @args) {
+            push @processed, $self->name if $self->name;
+        });
+
+    subtest 'processing default ascending ID order when no state cache exists' => sub {
+        combined_like { run_gru_job($app, limit_results_and_logs => []) }
+        qr/Saved cleanup status: last processed group ID is \d+/, 'saved cleanup status logged';
+
+        my %our_groups = (g_one => 1, g_two => 1, g_three => 1);
+        my @processed_filtered = grep { $our_groups{$_} } @processed;
+
+        is_deeply \@processed_filtered, ['g_one', 'g_two', 'g_three'],
+          'job groups are processed in default order g_one -> g_two -> g_three';
+
+        ok -f $cache_file_path, 'state cache file is automatically created upon processing groups';
+        my $content = Mojo::File->new($cache_file_path)->slurp;
+        my $data = decode_json($content);
+        is $data->{last_processed_job_group_id}, $g3->id, 'state cache records g_three ID as the last processed group';
+    };
+
+    subtest 'resuming iteration from the group following last_processed_job_group_id with wrap-around' => sub {
+        Mojo::File->new($cache_file_path)->spew(encode_json({last_processed_job_group_id => $g1->id}));
+
+        @processed = ();
+        combined_like { run_gru_job($app, limit_results_and_logs => []) }
+qr/Resuming job group cleanup after group ID @{[$g1->id]}.*Saved cleanup status: last processed group ID is @{[$g1->id]}/s,
+          'resuming job group cleanup and saving status logged';
+        my %our_groups = (g_one => 1, g_two => 1, g_three => 1);
+        my @processed_filtered = grep { $our_groups{$_} } @processed;
+
+        is_deeply \@processed_filtered, ['g_two', 'g_three', 'g_one'],
+          'groups are processed starting with g_two and wrapping back to g_one';
+    };
+
+    subtest 'invalid JSON in state cache triggers read warning' => sub {
+        Mojo::File->new($cache_file_path)->spew('{"invalid JSON');
+
+        combined_like { run_gru_job($app, limit_results_and_logs => []) }
+        qr/Unable to read cleanup status from \Q$cache_file_path\E:/, 'warning logged on read failure';
+    };
+
+    subtest 'unable to write state cache triggers write warning' => sub {
+        unlink $cache_file_path;
+        my $new_cache_file = "$cache_file_path.new";
+        mkdir $new_cache_file;
+
+        combined_like { run_gru_job($app, limit_results_and_logs => []) }
+        qr/Unable to write cleanup status to \Q$cache_file_path\E:/, 'warning logged on write failure';
+
+        rmdir $new_cache_file;
+    };
+
+    unlink $cache_file_path;
+    $schema->txn_rollback;
 };
 
 done_testing();

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -370,4 +370,38 @@ subtest 'deleted screenshots always accounted to main storage' => sub {
       'not finished as job that gained disk space only did so by deleting screenshots on main storage';
 };
 
+subtest 'job groups are prioritized by job count' => sub {
+    $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 100;
+
+    # Create groups and their respective count of jobs
+    my %group_job_counts = (g_one => 1, g_two => 2, g_three => 3);
+    my @created_groups = map {
+        my $name = $_;
+        my $g = $app->schema->resultset('JobGroups')->create({name => $name});
+        $app->schema->resultset('Jobs')->create({TEST => "job-$name-$_", group_id => $g->id})
+          for 1 .. $group_job_counts{$name};
+        $g;
+    } keys %group_job_counts;
+
+    # Mock limit_results_and_logs to trace the invocation order
+    my $job_group_mock = Test::MockModule->new('OpenQA::Schema::Result::JobGroups');
+    my @processed;
+    $job_group_mock->redefine(
+        limit_results_and_logs => sub ($self, @args) {
+            push @processed, $self->name if $self->name;
+        });
+
+    run_gru_job($app, limit_results_and_logs => []);
+
+    my %our_groups = (g_one => 1, g_two => 1, g_three => 1);
+    my @processed_filtered = grep { $our_groups{$_} } @processed;
+
+    is_deeply \@processed_filtered, ['g_three', 'g_two', 'g_one'],
+      'job groups processed in descending order of job count';
+
+    # Clean up
+    $app->schema->resultset('Jobs')->search({group_id => [map { $_->id } @created_groups]})->delete;
+    $_->delete for @created_groups;
+};
+
 done_testing();

--- a/t/42-screenshots.t
+++ b/t/42-screenshots.t
@@ -15,7 +15,7 @@ use OpenQA::Test::Utils qw(run_gru_job);
 use OpenQA::ScreenshotDeletion;
 use Mojo::File qw(path tempdir);
 use Mojo::Log;
-use Test::Output qw(combined_like combined_unlike);
+use Test::Output qw(combined_like combined_unlike combined_from);
 use Test::Mojo;
 use Test::Warnings ':report_warnings';
 use DateTime;
@@ -110,7 +110,9 @@ subtest 'limiting screenshots split into multiple Minion jobs' => sub {
     };
 
     # run a limit_results_and_logs job with customized batch parameters
-    run_gru_job($app, limit_results_and_logs => [{screenshots_per_batch => 20, batches_per_minion_job => 5}]);
+    combined_from {
+        run_gru_job($app, limit_results_and_logs => [{screenshots_per_batch => 20, batches_per_minion_job => 5}])
+    };
 
     # check whether "limit_results_and_logs" enqueues further "limit_screenshots" and "ensure_results_below_threshold"
     # jobs
@@ -156,7 +158,7 @@ subtest 'limiting screenshots split into multiple Minion jobs' => sub {
       or always_explain \@remaining_screenshots;
 
     subtest 'run a limit_results_and_logs job with batch parameters from config' => sub {
-        run_gru_job($app, limit_results_and_logs => [{}]);
+        combined_from { run_gru_job($app, limit_results_and_logs => [{}]) };
         my $enqueued_minion_jobs
           = get_enqueued_minion_jobs($minion, {states => ['inactive'], tasks => ['limit_screenshots']});
         my $enququed_minion_job_args = $enqueued_minion_jobs->{enqueued_job_args};
@@ -166,7 +168,8 @@ subtest 'limiting screenshots split into multiple Minion jobs' => sub {
           'limit_screenshots task with default batch size from config enqueued'
           or always_explain $enququed_minion_job_args;
 
-        my $job_info = run_gru_job($app, limit_results_and_logs => [{}]);
+        my $job_info;
+        combined_from { $job_info = run_gru_job($app, limit_results_and_logs => [{}]) };
         like $job_info->{notes}->{screenshot_cleanup}, qr/skipping.*still 1.*job/i,
           'screenshot limit tasks not enqueued again'
           or always_explain $job_info;


### PR DESCRIPTION
Motivation:
Static iteration order biases cleanup, skipping the same groups on early
abort. Shuffling obscures debuggability.

Design Choices:
Track last processed group ID in "cleanup-status.json" and start subsequent
runs after that ID (wrapping around).

Benefits:
Ensures group cleanup fairness over time without database schema changes or
randomness.

Related issue: https://progress.opensuse.org/issues/197483