### PR TITLE
ci: Reduce memory usage of `t/05-scheduler.t`

### DIFF
--- a/t/05-scheduler-full.t
+++ b/t/05-scheduler-full.t
@@ -26,6 +26,7 @@ use IPC::Run qw(start);
 use Mojo::IOLoop::Server;
 use Mojo::File qw(path tempfile);
 use Time::HiRes 'sleep';
+use List::Util qw(min);
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use OpenQA::Constants qw(DEFAULT_WORKER_TIMEOUT DB_TIMESTAMP_ACCURACY);
@@ -254,10 +255,10 @@ subtest 'Simulation of heavy unstable load' => sub {
     stop_workers;
     dead_workers($schema);
 
-    my $unstable_workers = $ENV{OPENQA_SCHEDULER_TEST_UNSTABLE_COUNT} // 30;
+    my $unstable_workers = $ENV{OPENQA_SCHEDULER_TEST_UNSTABLE_COUNT} // ($ENV{CI} ? 10 : 30);
     @workers = map { unstable_worker(@$worker_settings, $_, 3) } (1 .. $unstable_workers);
     $i = 5;
-    wait_for_worker($schema, ++$i) for 0 .. 12;
+    wait_for_worker($schema, ++$i) for 1 .. min($unstable_workers - $i, 13);
 
     $allocated = $job_model->schedule;    # Will try to allocate to previous worker and fail!
     is @$allocated, 0, 'All failed allocation on second step - workers were killed';


### PR DESCRIPTION
Creating 30 workers seems to max out the availabe RAM on CircleCI as the graph under "Resources" on a stuck/auto-canceled test run shows a usage of 97 % (of 4 GiB) after 2 m 30 s (5 s before the test was auto-canceled with no further logs and artifacts). This change reduces the number of workers to 10 in an CI environment in consistency with the preceding part of the sub test.

Note that I haven't changed the logic for non-CI runs - even though we might want to consider that as we strangely spawn much more workers then we actually wait for afterwards. I am also not sure about the `$i = 5` assignment which goes back to commit
1069622bf8881a409056351e114c7f9243b7e967 which does not really explain it.

Related ticket: https://progress.opensuse.org/issues/202803