### PR TITLE
fix: XUnit: render skipped testcases as missing instead of ok

### DIFF
--- a/lib/OpenQA/Parser/Format/XUnit.pm
+++ b/lib/OpenQA/Parser/Format/XUnit.pm
@@ -11,7 +11,7 @@ sub _add_single_result ($self, @args) { $self->results->add(OpenQA::Parser::Resu
 
 sub addproperty ($self, $prop) { $self->{properties}->add(OpenQA::Parser::Result::XUnit::Property->new($prop)) }
 
-my %TC_RESULT_BY_TAG = (softfailure => 'softfail', failure => 'fail', error => 'fail');
+my %TC_RESULT_BY_TAG = (softfailure => 'softfail', failure => 'fail', error => 'fail', skipped => 'missing');
 
 sub parse ($self, $xml) {
     confess 'No XML given/loaded' unless $xml;

--- a/t/30-test_parser.t
+++ b/t/30-test_parser.t
@@ -454,6 +454,8 @@ sub test_xunit_file {
       'Overall 11 testsuites, 2 tests does not have title containing bacon';
     is $parser->results->search_in_details('text', qr/bacon/)->size, 16,
       'Overall 11 testsuites, 15 tests are for bacon';
+    is $parser->results->search_in_details('result', qr/^missing$/)->size, 3,
+      'skipped testcases are mapped to missing, not ok';
     is $parser->generated_tests_output->size, 24, '24 Outputs';
 
     my $resultsdir = tempdir;


### PR DESCRIPTION
background:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26004

I was adding the kernel-qe scripts `known_issues` to the infiniband tests. In the first round the inifiband tests got updated with `--skip-test` flag. Then the the openQA runner for infiniband tests got the support for the skip.

All works well however the openQA renders the view this way (green indicating pass instead of typical gray as openQA does for the skipped tests):
<img width="347" height="67" alt="Screenshot from 2026-07-06 15-43-38" src="https://github.com/user-attachments/assets/7e2673b3-608c-4eb8-805a-b686acf9d53a" />

underlying xml:
```
<testcase name="04-h1_reset_all_ports" time="0" classname="phase.0.state.cleanup">
<skipped message="test skipped by CLI option"/>

I assume this is the deficiency of the xunit.pm thus this initial PR.