### PR TITLE
feat: support global instance-wide test settings

### DIFF
--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -263,15 +263,10 @@ a test suite and a product that appear in the same job template. The precedence
 order for variables is as follows (from lowest to highest):
 
 - Instance-wide test settings (defined in the `[test_settings]` section of `openqa.ini`)
-
 - Product
-
 - Machine
-
 - Test suite
-
 - Job template
-
 - API POST query parameters
 
 That is, variable values set as part of the API request that triggers the jobs will

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -262,6 +262,8 @@ used for a single job - for instance, you may have a variable defined in both
 a test suite and a product that appear in the same job template. The precedence
 order for variables is as follows (from lowest to highest):
 
+- Instance-wide test settings (defined in the `[test_settings]` section of `openqa.ini`)
+
 - Product
 
 - Machine

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -550,3 +550,11 @@ concurrent = 0
 ## The pattern is a regex.
 ## This can be specified multiple times.
 #add_worker_class_if_missing = size-.* -> size-large
+
+## Global instance-wide test settings. These are applied to all test jobs
+## with the lowest precedence, unless overridden by more specific settings
+## (like product, machine, test suite settings or API parameters).
+## Overriding with a '+' prefix (e.g. '+TEST_SETTING1') also works here.
+[test_settings]
+#TEST_SETTING1 = value
+#TEST_SETTING2 = value

--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -8,6 +8,7 @@ use Mojo::Base -strict, -signatures;
 use File::Basename;
 use Mojo::URL;
 use Mojo::Util 'url_unescape';
+use OpenQA::App;
 use OpenQA::Log 'log_debug';
 use OpenQA::Utils qw(asset_type_from_setting get_url_short);
 use Feature::Compat::Try;
@@ -17,6 +18,21 @@ my $PLACEHOLDER_RE = qr/(%+)(\w+)(%+)/;
 sub generate_settings ($params) {
     my $settings = $params->{settings};
     my @worker_class;
+
+    if (my $app = OpenQA::App->singleton) {
+        if (my $global_test_settings = $app->config->{test_settings}) {
+            for my $k (keys %$global_test_settings) {
+                my $uc_k = uc $k;
+                if ($uc_k eq 'WORKER_CLASS') {
+                    push @worker_class, $global_test_settings->{$k};
+                }
+                else {
+                    $settings->{$uc_k} = $global_test_settings->{$k};
+                }
+            }
+        }
+    }
+
     for my $entity (qw (product machine test_suite job_template)) {
         next unless $params->{$entity};
         my @entity_settings = $params->{$entity}->settings;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -341,6 +341,7 @@ sub default_config () {
             ignored_failed_minion_jobs => '',
         },
         carry_over => {%CARRY_OVER_DEFAULTS},
+        test_settings => {},
         'test_preset example' => {
             title => 'Create example test',
             info => 'Parameters to create an example test have been pre-filled in the following form. '

--- a/t/40-job_settings.t
+++ b/t/40-job_settings.t
@@ -4,9 +4,12 @@
 
 use Test::Most;
 use Test::Warnings ':report_warnings';
+use Mojo::Base -signatures;
+use Test::MockObject;
 
 use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use OpenQA::App;
 use OpenQA::JobSettings;
 use OpenQA::Test::TimeLimit '3';
 
@@ -143,6 +146,49 @@ subtest 'unexpanded variables' => sub {
     my ($error, $unexpanded) = OpenQA::JobSettings::expand_placeholders(\%settings);
     is $error, undef, 'no error';
     is_deeply $unexpanded, ['MIRROR'], 'MIRROR detected as unexpanded';
+};
+
+sub mock_setting ($key, $val) { Test::MockObject->new->set_always(key => $key)->set_always(value => $val) }
+
+subtest 'generate_settings with global test settings' => sub {
+    my $mock_app = Test::MockObject->new->set_always(
+        config => {
+            test_settings => {
+                pretty_serial_marker => '1',
+                worker_class => 'global_worker',
+                test_setting_var => 'global_val',
+                '+overridden_var' => 'global_plus',
+                overridden_by_plus => 'global_normal',
+            }});
+    my $orig_app = OpenQA::App->singleton;
+    OpenQA::App->set_singleton($mock_app);
+    my $mock_product = Test::MockObject->new->set_list(
+        settings => (
+            mock_setting('PRODUCT_VAR', 'prod_val'),
+            mock_setting('OVERRIDDEN_VAR', 'prod_overwrites_global'),
+            mock_setting('WORKER_CLASS', 'product_worker'),
+            mock_setting('+OVERRIDDEN_BY_PLUS', 'prod_plus_overwrites_global_normal'),
+        ));
+    my $params = {
+        settings => {},
+        product => $mock_product,
+        input_args => {
+            input_var => 'input_val',
+        }};
+    my $error = OpenQA::JobSettings::generate_settings($params);
+    is $error, undef, 'no error during generate_settings';
+    my $expected_settings = {
+        PRETTY_SERIAL_MARKER => '1',
+        WORKER_CLASS => 'global_worker,product_worker',
+        TEST_SETTING_VAR => 'global_val',
+        OVERRIDDEN_VAR => 'global_plus',
+        OVERRIDDEN_BY_PLUS => 'prod_plus_overwrites_global_normal',
+        PRODUCT_VAR => 'prod_val',
+        INPUT_VAR => 'input_val',
+    };
+    is_deeply $params->{settings}, $expected_settings,
+'generate_settings correctly applies lowest-precedence global test settings, respects +, and combines WORKER_CLASS';
+    OpenQA::App->set_singleton($orig_app);
 };
 
 done_testing;


### PR DESCRIPTION
Motivation:
Allow defining default, instance-wide test settings in openqa.ini to easily
manage global defaults across all jobs.

Design Choices:
Added a test_settings section in Setup.pm and extracted those keys with
lowest precedence when generating job settings.

Benefits:
Provides a clean, centralized way to set baseline test parameters that can
be overridden by products, machines, test suites, or API POST requests.

Related issue: https://progress.opensuse.org/issues/203688