### PR TITLE
fix: OpenSuseKernelBug: Never route kernel bug reports to PUBLIC product

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseBugzillaUtils.pm
+++ b/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseBugzillaUtils.pm
@@ -60,8 +60,8 @@ sub get_bugzilla_distri_name ($raw_distri) {
 
 # taken from the external_reporting.html.ep
 # likely this could be improved
-sub get_bugzilla_product_name ($job, $raw_distri, $distri_ref) {
-    return _sle_product($job, $distri_ref) if $raw_distri eq 'sle';
+sub get_bugzilla_product_name ($job, $raw_distri, $distri_ref, $allow_public = 1) {
+    return _sle_product($job, $distri_ref, $allow_public) if $raw_distri eq 'sle';
     return _sle_micro_product($job) if $raw_distri eq 'sle-micro';
     return _opensuse_product($job) if $raw_distri eq 'opensuse' || $raw_distri eq 'microos';
     return _caasp_product($job) if $raw_distri eq 'caasp';
@@ -69,7 +69,9 @@ sub get_bugzilla_product_name ($job, $raw_distri, $distri_ref) {
     return '';
 }
 
-sub _sle_product ($job, $distri_ref) {
+# $allow_public can be disabled by callers (e.g. kernel bug reports) for which routing to the
+# customer-visible PUBLIC product would be inappropriate, e.g. regressions in unreleased kernels
+sub _sle_product ($job, $distri_ref, $allow_public = 1) {
     my $subproduct = $job->FLAVOR // '';
     $subproduct =~ s/(\w*)(-\w*)?/$1/;
 
@@ -82,7 +84,7 @@ sub _sle_product ($job, $distri_ref) {
 
     my $sle_product = FLAVOR_TO_PROD_SLE->{$subproduct} // 'Server';
 
-    if (my $public = PUBLIC_SLE_PRODUCTS->{$sle_product}) {
+    if ($allow_public && (my $public = PUBLIC_SLE_PRODUCTS->{$sle_product})) {
         if ($version =~ /(\d+)\s+SP(\d+)/ && $1 == 15 && $2 >= 3) {
             $$distri_ref = "PUBLIC $$distri_ref";
             $sle_product = $public;

--- a/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseKernelBug.pm
+++ b/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseKernelBug.pm
@@ -16,7 +16,9 @@ sub actions ($c) {
     my $job = $ctx->{job};
     my $raw_distri = $job->DISTRI // '';
     my $bugzilla_distri = get_bugzilla_distri_name($raw_distri);
-    my $bugzilla_product = get_bugzilla_product_name($job, $raw_distri, \$bugzilla_distri);
+    # kernel regressions are frequently against unreleased kernels, so never route them to the
+    # customer-visible PUBLIC
+    my $bugzilla_product = get_bugzilla_product_name($job, $raw_distri, \$bugzilla_distri, 0);
     my $bugzilla_url = get_bugzilla_url($raw_distri);
     my ($first_known_bad, $last_good) = get_regression_links($c, $job);
     my $latest = $c->url_for('latest')->query($job->scenario_hash)->to_abs;

--- a/t/ui/30-issue-reporter-plugin.t
+++ b/t/ui/30-issue-reporter-plugin.t
@@ -68,6 +68,11 @@ subtest 'get_bugzilla_product_name' => sub {
     is get_bugzilla_product_name(Test::FakeJob->new(VERSION => '4.5'), 'caasp', undef), '4', 'caasp';
     is get_bugzilla_product_name(Test::FakeJob->new(), 'openqa', undef), 'openQA', 'openqa';
     is get_bugzilla_product_name(Test::FakeJob->new(), 'test-unknown', undef), '', 'unknown';
+
+    $distri = 'SUSE Linux Enterprise';
+    is get_bugzilla_product_name(Test::FakeJob->new(FLAVOR => 'Server', VERSION => '15 SP3'), 'sle', \$distri, 0),
+      'Server 15 SP3', 'allow_public=0 keeps product name for 15 SP3+';
+    is $distri, 'SUSE Linux Enterprise', 'allow_public=0 suppresses PUBLIC rewrite for 15 SP3+';
 };
 
 done_testing;


### PR DESCRIPTION
Kernel regressions found by openQA are frequently against unreleased kernels, so filing them straight into the customer-visible PUBLIC SLE Bugzilla product (as done for generic bug reports on SLE 15 SP3+) can disclose pre-release kernel issues. Add an allow_public flag to get_bugzilla_product_name/_sle_product and have the kernel bug reporter opt out, keeping generic bug reports unaffected.

new behaviour can be checked here: 
https://rmarliere-openqa.qe.prg2.suse.org/tests/1686#step/selftests:cgroup:test_cpu/4
<img width="244" height="56" alt="Screenshot from 2026-07-07 17-42-32" src="https://github.com/user-attachments/assets/45378607-78b1-4089-b236-6bfde0773867" />

vs:
https://openqa.suse.de/tests/23212669#step/test_cpu/8
<img width="343" height="55" alt="Screenshot from 2026-07-07 17-41-58" src="https://github.com/user-attachments/assets/4a4a71b1-2a05-4bc6-b60a-318003d32ceb" />
