### PR TITLE
feat(worker): Allow configuring lock to throttle job execution

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -85,6 +85,27 @@
 # Set to 0 to disable.
 #CRITICAL_LOAD_AVG_THRESHOLD = 40
 
+# Let the worker acquire a lock with the specified name before accepting a job.
+# The lock will be released after the job is done or after the specified
+# expiration. The expiration is effective when isotovideo has been started. The
+# worker will reject the job if it cannot acquire the lock. The number of local
+# worker instances that can acquire the lock can be limited.
+# By default no lock is acquired. The purpose of configuring a lock is
+# throttling the startup of jobs on a particular worker host so the setting
+# CRITICAL_LOAD_AVG_THRESHOLD is more effective. (Otherwise many worker
+# instances might still all start newly scheduled jobs at the same time. With
+# the example config below, only 5 worker instances would be able to start newly
+# scheduled jobs at the same time. More worker instances would only start
+# further jobs after 30 seconds - unless the load exceeds the configured
+# threshold then.)
+# Workers that could not acquire a lock will temporarily show as unavailable
+# with an according note. This prevents the scheduler from immediately assigning
+# a job on these slots again (increasing the chances it will spread future
+# job assignments across different/other worker hosts).
+#LOCK_NAME = qemu-job
+#LOCK_EXPIRATION = 30
+#LOCK_LIMIT = 5
+
 # If IPMI_HOSTNAME, IPMI_USER and IPMI_PASSWORD is set the worker will periodically
 # ensure that the IPMI controlled SUT is powered off when no job is running.
 # The default period is 300 seconds.

--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -6,7 +6,7 @@ use Mojo::Base 'Mojolicious', -signatures;
 
 use Time::Seconds;
 use OpenQA::Worker::Settings;
-use OpenQA::CacheService::Db;
+use OpenQA::CacheService::DB;
 use OpenQA::CacheService::Model::Cache;
 use OpenQA::CacheService::Model::Downloads;
 
@@ -40,7 +40,7 @@ sub startup ($self) {
 
     # Worker settings
     my $global_settings = OpenQA::Worker::Settings->new->global_settings;
-    my $location = OpenQA::CacheService::Db::location($global_settings);
+    my $location = OpenQA::CacheService::DB::location($global_settings);
     die "Cache directory unspecified. Set environment variable 'OPENQA_CACHE_DIR' or config variable 'CACHEDIRECTORY'\n"
       unless defined $location;
     my $limit = $global_settings->{CACHELIMIT};
@@ -58,7 +58,7 @@ sub startup ($self) {
     $log->unsubscribe('message') if $ENV{OPENQA_CACHE_SERVICE_QUIET};
 
     # Increase busy timeout to 5 minutes
-    my $sqlite = OpenQA::CacheService::Db::open_default_sqlite_database($self->log, $location);
+    my $sqlite = OpenQA::CacheService::DB::open_default_sqlite_database($self->log, $location);
     $sqlite->migrations->name('cache_service')->from_data;
 
     my @cache_params = (sqlite => $sqlite, log => $self->log, location => $location);

--- a/lib/OpenQA/CacheService.pm
+++ b/lib/OpenQA/CacheService.pm
@@ -4,43 +4,15 @@
 package OpenQA::CacheService;
 use Mojo::Base 'Mojolicious', -signatures;
 
-use Mojo::SQLite;
-use Mojo::File 'path';
 use Time::Seconds;
 use OpenQA::Worker::Settings;
+use OpenQA::CacheService::Db;
 use OpenQA::CacheService::Model::Cache;
 use OpenQA::CacheService::Model::Downloads;
 
 use constant DEFAULT_MINION_WORKERS => 5;
 
-# Default to 10 minutes
-use constant SQLITE_BUSY_TIMEOUT => $ENV{OPENQA_SQLITE_BUSY_TIMEOUT} // 600000;
-
-# Defaults to 1 minute
-use constant SQLITE_SLOW_QUERY => $ENV{OPENQA_SQLITE_SLOW_QUERY} // 60000;
-
 has exit_code => undef;
-
-sub _configure_sqlite_database ($self, $sqlite, $dbh) {
-    # default to using DELETE journaling mode to avoid database corruption seen in production (see poo#67000)
-    # check out https://www.sqlite.org/pragma.html#pragma_journal_mode for possible values
-    my $sqlite_mode = uc($ENV{OPENQA_CACHE_SERVICE_SQLITE_JOURNAL_MODE} || 'DELETE');
-    $dbh->sqlite_busy_timeout(SQLITE_BUSY_TIMEOUT);
-    $dbh->do("pragma journal_mode=$sqlite_mode");
-    $dbh->do('pragma synchronous=NORMAL') if $sqlite_mode eq 'WAL';
-
-    # Log slow queries
-    $dbh->sqlite_profile(
-        sub ($statement, $elapsed, @) {
-            $self->log->info(qq{Slow SQLite query: "$statement" -> ${elapsed}ms}) if $elapsed > SQLITE_SLOW_QUERY;
-        });
-}
-
-sub _open_sqlite_database ($self, $db_file) {
-    my $sqlite = Mojo::SQLite->new->from_string("file://$db_file?no_wal=1");
-    $sqlite->on(connection => sub ($sqlite, $dbh) { $self->_configure_sqlite_database($sqlite, $dbh) });
-    return $sqlite;
-}
 
 sub startup ($self) {
     $self->moniker('openqa_cache_service');
@@ -68,7 +40,7 @@ sub startup ($self) {
 
     # Worker settings
     my $global_settings = OpenQA::Worker::Settings->new->global_settings;
-    my $location = $ENV{OPENQA_CACHE_DIR} || $global_settings->{CACHEDIRECTORY};
+    my $location = OpenQA::CacheService::Db::location($global_settings);
     die "Cache directory unspecified. Set environment variable 'OPENQA_CACHE_DIR' or config variable 'CACHEDIRECTORY'\n"
       unless defined $location;
     my $limit = $global_settings->{CACHELIMIT};
@@ -86,7 +58,7 @@ sub startup ($self) {
     $log->unsubscribe('message') if $ENV{OPENQA_CACHE_SERVICE_QUIET};
 
     # Increase busy timeout to 5 minutes
-    my $sqlite = $self->_open_sqlite_database(path($location, 'cache.sqlite'));
+    my $sqlite = OpenQA::CacheService::Db::open_default_sqlite_database($self->log, $location);
     $sqlite->migrations->name('cache_service')->from_data;
 
     my @cache_params = (sqlite => $sqlite, log => $self->log, location => $location);

--- a/lib/OpenQA/CacheService/DB.pm
+++ b/lib/OpenQA/CacheService/DB.pm
@@ -1,7 +1,7 @@
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-package OpenQA::CacheService::Db;
+package OpenQA::CacheService::DB;
 use Mojo::Base -strict, -signatures;
 
 use Mojo::SQLite;

--- a/lib/OpenQA/CacheService/Db.pm
+++ b/lib/OpenQA/CacheService/Db.pm
@@ -1,0 +1,43 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::CacheService::Db;
+use Mojo::Base -strict, -signatures;
+
+use Mojo::SQLite;
+use Mojo::File 'path';
+
+# Default to 10 minutes
+use constant SQLITE_BUSY_TIMEOUT => $ENV{OPENQA_SQLITE_BUSY_TIMEOUT} // 600000;
+
+# Defaults to 1 minute
+use constant SQLITE_SLOW_QUERY => $ENV{OPENQA_SQLITE_SLOW_QUERY} // 60000;
+
+sub _configure_sqlite_database ($log, $sqlite, $dbh) {
+    # default to using DELETE journaling mode to avoid database corruption seen in production (see poo#67000)
+    # check out https://www.sqlite.org/pragma.html#pragma_journal_mode for possible values
+    my $sqlite_mode = uc($ENV{OPENQA_CACHE_SERVICE_SQLITE_JOURNAL_MODE} || 'DELETE');
+    $dbh->sqlite_busy_timeout(SQLITE_BUSY_TIMEOUT);
+    $dbh->do("pragma journal_mode=$sqlite_mode");
+    $dbh->do('pragma synchronous=NORMAL') if $sqlite_mode eq 'WAL';
+
+    # Log slow queries
+    $dbh->sqlite_profile(
+        sub ($statement, $elapsed, @) {
+            $log->info(qq{Slow SQLite query: "$statement" -> ${elapsed}ms}) if $elapsed > SQLITE_SLOW_QUERY;
+        });
+}
+
+sub location ($global_settings) { $ENV{OPENQA_CACHE_DIR} || $global_settings->{CACHEDIRECTORY} }
+
+sub db_file ($location, $file_name = 'cache.sqlite') { path($location, $file_name) }
+
+sub open_sqlite_database ($log, $db_file) {
+    my $sqlite = Mojo::SQLite->new->from_string("file://$db_file?no_wal=1");
+    $sqlite->on(connection => sub ($sqlite, $dbh) { _configure_sqlite_database($log, $sqlite, $dbh) });
+    return $sqlite;
+}
+
+sub open_default_sqlite_database ($log, $location) { open_sqlite_database($location, db_file($location)) }
+
+1;

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -47,7 +47,7 @@ use OpenQA::Constants
   qw(WEBSOCKET_API_VERSION WORKER_COMMAND_QUIT WORKER_SR_BROKEN WORKER_SR_DONE WORKER_SR_DIED WORKER_SR_FINISH_OFF);
 use OpenQA::Client;
 use OpenQA::CacheService::Client;
-use OpenQA::CacheService::Db;
+use OpenQA::CacheService::DB;
 use OpenQA::Log qw(log_error log_warning log_info log_debug add_log_channel remove_log_channel);
 use OpenQA::Utils qw(prjdir load_avg);
 use OpenQA::Worker::WebUIConnection;
@@ -89,9 +89,9 @@ sub new ($class, $cli_options) {
     $settings->apply_to_app($app);
 
     # init Minion for locking
-    my $location = OpenQA::CacheService::Db::location($settings->global_settings) // (prjdir . '/cache');
-    my $db_file = OpenQA::CacheService::Db::db_file($location, 'worker-locks.sqlite');
-    my $sqlite = OpenQA::CacheService::Db::open_sqlite_database($app->log, $db_file);
+    my $location = OpenQA::CacheService::DB::location($settings->global_settings) // (prjdir . '/cache');
+    my $db_file = OpenQA::CacheService::DB::db_file($location, 'worker-locks.sqlite');
+    my $sqlite = OpenQA::CacheService::DB::open_sqlite_database($app->log, $db_file);
     $app->plugin(Minion => {SQLite => $sqlite});
 
     # setup the isotovideo engine

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -67,6 +67,7 @@ has 'current_webui_host';
 has 'current_job';
 has 'current_error';
 has 'current_error_is_fatal';
+has 'current_error_is_ephemeral';
 has 'worker_hostname';
 has 'isotovideo_interface_version';
 
@@ -707,6 +708,8 @@ sub is_ovs_dbus_service_running ($self) {
 # returns whether the worker is available and a reason
 # note: This is used to check certain error conditions *before* starting a job to prevent incompletes and
 #       being able to propagate the brokenness to the web UIs.
+# note: This function returns a value >0 if there is no fatal problem and >1 if the problem is even expected
+#       to be resolved soon.
 # note: High load will yield a corresponding error message as reason so the worker becomes broken and
 #       thus will not pick up any new jobs. However, a worker under high load is still considered being
 #       able to work on jobs that are already enqueued. Hence this function returns a "1" for the
@@ -743,7 +746,7 @@ sub check_availability ($self) {
     # check whether we failed to get the job lock (and would still not be able to get it)
     if (defined(my $guard_or_error = $self->{_guard_or_error})) {
         my $is_error = !ref $guard_or_error;
-        return (1, $guard_or_error) if $is_error && !$self->can_acquire_job_guard;
+        return (2, $guard_or_error) if $is_error && !$self->can_acquire_job_guard;
         undef $self->{_guard_or_error} if $is_error;
     }
 
@@ -751,9 +754,10 @@ sub check_availability ($self) {
 }
 
 sub set_current_error_based_on_availability ($self) {
-    my ($is_available, $reason) = $self->check_availability;
+    my ($availability, $reason) = $self->check_availability;
     $self->current_error($reason);
-    $self->current_error_is_fatal(!$is_available);
+    $self->current_error_is_fatal($availability < 1);
+    $self->current_error_is_ephemeral($availability > 1);
     return $reason;
 }
 

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -45,6 +45,8 @@ use Scalar::Util 'looks_like_number';
 use OpenQA::Constants
   qw(WEBSOCKET_API_VERSION WORKER_COMMAND_QUIT WORKER_SR_BROKEN WORKER_SR_DONE WORKER_SR_DIED WORKER_SR_FINISH_OFF);
 use OpenQA::Client;
+use OpenQA::CacheService::Client;
+use OpenQA::CacheService::Db;
 use OpenQA::Log qw(log_error log_warning log_info log_debug add_log_channel remove_log_channel);
 use OpenQA::Utils qw(prjdir load_avg);
 use OpenQA::Worker::WebUIConnection;
@@ -84,6 +86,12 @@ sub new ($class, $cli_options) {
     $settings->auto_detect_worker_address($short_hostname);
     $settings->apply_to_app($app);
 
+    # init Minion for locking
+    my $location = OpenQA::CacheService::Db::location($settings->global_settings) // (prjdir . '/cache');
+    my $db_file = OpenQA::CacheService::Db::db_file($location, 'worker-locks.sqlite');
+    my $sqlite = OpenQA::CacheService::Db::open_sqlite_database($app->log, $db_file);
+    $app->plugin(Minion => {SQLite => $sqlite});
+
     # setup the isotovideo engine
     my $isotovideo_interface_version = OpenQA::Worker::Engines::isotovideo::set_engine_exec($cli_options->{isotovideo});
 
@@ -106,6 +114,8 @@ sub new ($class, $cli_options) {
 
     return $self;
 }
+
+sub guard ($self, @args) { $self->app->minion->guard(@args) }
 
 # logs the basic configuration of the worker instance
 sub log_setup_info ($self) {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -42,6 +42,7 @@ use Mojo::IOLoop;
 use Mojo::File 'path';
 use POSIX ();
 use Scalar::Util 'looks_like_number';
+use Time::Seconds qw(ONE_HOUR);
 use OpenQA::Constants
   qw(WEBSOCKET_API_VERSION WORKER_COMMAND_QUIT WORKER_SR_BROKEN WORKER_SR_DONE WORKER_SR_DIED WORKER_SR_FINISH_OFF);
 use OpenQA::Client;
@@ -111,11 +112,39 @@ sub new ($class, $cli_options) {
     $self->{_finishing_off} = undef;
     $self->{_ovs_dbus_service_name} = $ENV{OVS_DBUS_SERVICE_NAME} // 'org.opensuse.os_autoinst.switch';
     $self->{_initial_working_dir} = getcwd() // '.';
-
+    $self->{_minion_sqlite} = $sqlite;
     return $self;
 }
 
 sub guard ($self, @args) { $self->app->minion->guard(@args) }
+
+sub _job_guard ($self) {
+    my $settings = $self->settings->global_settings;
+    return undef unless defined(my $lock_name = $settings->{LOCK_NAME});
+    return $self->guard($lock_name, ONE_HOUR, {limit => $settings->{LOCK_LIMIT} // 1})
+      // "Limited by configured lock '$lock_name'";
+}
+
+sub can_acquire_job_guard ($self) { !!(ref $self->_job_guard) }
+
+sub acquire_job_guard ($self) {
+    $self->{_guard_or_error} = undef if ref $self->{_guard_or_error};
+    $self->{_guard_or_error} = $self->_job_guard;
+}
+
+# reduces the expiration of the lock with the longest expiration from the initial ONE_HOUR to the configured LOCK_EXPIRATION
+# note: This function is called by the engine when the setup is over and the actual execution starts and thus an increased load
+#       is expected.
+sub update_job_guard_expiration ($self) {
+    return 0 unless ref $self->{_guard_or_error};    # skip if we don't hold a lock
+    my $settings = $self->settings->global_settings;
+    return undef unless defined(my $lock_name = $settings->{LOCK_NAME});
+    my $expiration = int($settings->{LOCK_EXPIRATION} // 30);
+    my $query = q(update minion_locks set expires = datetime('now', ?) where name = ? order by expires desc limit 1);
+    $self->{_minion_sqlite}->db->query($query, "+$expiration seconds", $lock_name);
+}
+
+sub release_job_guard ($self) { undef $self->{_guard_or_error} }
 
 # logs the basic configuration of the worker instance
 sub log_setup_info ($self) {
@@ -551,9 +580,19 @@ sub _accept_or_skip_next_job_in_queue ($self) {
     return $next_job->accept;
 }
 
+sub _ensure_job_guard ($self, $client, $job_ids) {
+    my $guard_or_error = $self->acquire_job_guard;
+    return 1 if !defined $guard_or_error || ref $guard_or_error;
+    $client->send_status(on_error => 1);
+    $client->reject_jobs($job_ids, $guard_or_error);
+    log_info "Rejecting job: $guard_or_error";
+    return 0;
+}
+
 # accepts a single job from the job info received via the 'grab_job' command
 sub accept_job ($self, $client, $job_info) {
     $self->_assert_whether_job_acceptance_possible;
+    $self->_ensure_job_guard($client, [$job_info->{id}]) or return 0;
     $self->{_queue} = undef;
     $self->_prepare_job_execution(OpenQA::Worker::Job->new($self, $client, $job_info));
     $self->current_job->accept;
@@ -579,6 +618,7 @@ sub enqueue_jobs_and_accept_first ($self, $client, $job_info) {
     #       if one job fails.
 
     $self->_assert_whether_job_acceptance_possible;
+    $self->_ensure_job_guard($client, [keys %{$job_info->{data}}]) or return 0;
     $self->_enqueue_job_sub_sequence($client, $self->_init_queue, $job_info->{sequence}, $job_info->{data});
     $self->_accept_or_skip_next_job_in_queue;
 }
@@ -696,7 +736,18 @@ sub check_availability ($self) {
       if $settings->has_class('tap') && !$self->is_ovs_dbus_service_running;
 
     # continue with enqueued jobs in any case but avoid picking up new jobs if system utilization is critical
-    return (1, $self->_check_system_utilization);
+    if (my $system_utilization_error = $self->_check_system_utilization) {
+        return (1, $system_utilization_error);
+    }
+
+    # check whether we failed to get the job lock (and would still not be able to get it)
+    if (defined(my $guard_or_error = $self->{_guard_or_error})) {
+        my $is_error = !ref $guard_or_error;
+        return (1, $guard_or_error) if $is_error && !$self->can_acquire_job_guard;
+        undef $self->{_guard_or_error} if $is_error;
+    }
+
+    return (1, undef);
 }
 
 sub set_current_error_based_on_availability ($self) {
@@ -787,6 +838,7 @@ sub _handle_job_status_changed ($self, $job, $event_data) {
         if (my $error_message = $event_data->{error_message}) { log_error($error_message) }
         $self->current_job(undef);
         $self->current_webui_host(undef);
+        $self->release_job_guard;
         if (my $queue = $self->{_queue}) {
             $queue->{failed_jobs}->{$job_id} = $reason if $reason ne WORKER_SR_DONE || !$event_data->{ok};
         }

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -497,6 +497,7 @@ sub _engine_workit_step_2 ($job, $job_settings, $vars, $shared_cache, $callback)
     $container->on(container_error => sub ($cont, $e) { log_error("Container error: @{$e}", channels => 'worker') });
 
     log_info('Starting isotovideo container');
+    $worker->update_job_guard_expiration;
     $container->start();
     $workerpid = $child->pid();
     return $callback->({child => $child});

--- a/lib/OpenQA/Worker/WebUIConnection.pm
+++ b/lib/OpenQA/Worker/WebUIConnection.pm
@@ -17,6 +17,7 @@ use constant _HTTP_TOO_EARLY => 425;
 
 use constant DEFAULT_OPENQA_WORKER_CONNECT_RETRIES => 60;
 use constant MAX_WEBSOCKET_SIZE => 1024 * 1024 * 10;
+use constant EPHEMERAL_RECHECK_INTERVAL => $ENV{OPENQA_WORKER_EPHEMERAL_RECHECK_INTERVAL} // 10;
 
 has 'webui_host';    # hostname:port of the web UI to connect to
 has 'url';    # URL of the web UI to connect to - initially deduced from webui_host (Mojo::URL instance)
@@ -380,12 +381,23 @@ sub send_status ($self, %args) {
     # send the worker status (unless the websocket connection has been lost)
     my $websocket_connection = $self->websocket_connection;
     return undef unless $websocket_connection;
-    my $status = $self->{_last_worker_status} = $self->worker->status;
+    my $status = $self->{_last_worker_status} = $args{status} // $self->worker->status;
     $websocket_connection->send({json => $status}) if !$args{on_error} || defined $status->{reason};
 }
 
 sub send_status_delayed ($self) {
     return undef if $self->{_send_status_timer} || !$self->websocket_connection;
+
+    # re-evaluate the error status after just a few seconds if the current error is ephemeral
+    return $self->{_send_status_timer} = Mojo::IOLoop->timer(
+        EPHEMERAL_RECHECK_INTERVAL,
+        sub {
+            my $worker = $self->worker;
+            my $status = $self->{_last_worker_status} = $self->worker->status;
+            return $self->send_status(status => $status) unless $worker->current_error;
+            delete $self->{_send_status_timer};
+            $self->send_status_delayed;
+        }) if $self->worker->current_error_is_ephemeral;
 
     my $status_update_interval = $self->calculate_status_update_interval;
     my $webui_host = $self->webui_host;

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -31,6 +31,7 @@ use Mojo::Util 'scope_guard';
 use File::Copy::Recursive qw(dircopy);
 
 my $workdir = tempdir("$FindBin::Script-XXXX", TMPDIR => 1);
+$ENV{OPENQA_CACHE_DIR} = $workdir;
 chdir $workdir;
 my $guard = scope_guard sub { chdir $FindBin::Bin };
 dircopy "$FindBin::Bin/$_", "$workdir/t/$_" or BAIL_OUT($!) for qw(data);
@@ -367,6 +368,8 @@ subtest 'syncing tests' => sub {
     OpenQA::Worker::Engines::isotovideo::sync_tests(OpenQA::CacheService::Client->new, @args);
     Mojo::IOLoop->start;
     is $result, 'cache-dir/webuihost/tests', 'returns synced test directory on success' or always_explain $result;
+
+    is $worker->job_guard_expiration_updated, 0, 'job guard not updated while just syncing tests';
 };
 
 subtest 'symlink testrepo, logging behavior, variable expansion' => sub {
@@ -401,12 +404,13 @@ subtest 'symlink testrepo, logging behavior, variable expansion' => sub {
         like $result->{error}, qr/The source directory $casedir\/needles does not exist/,
           'symlink needles directory failed because source directory does not exist';
     };
-
     subtest 'good case: direct invocation of helper function for symlinking' => sub {
         my $casedir = testcasedir('opensuse', undef, undef);
         my $result = OpenQA::Worker::Engines::isotovideo::_link_repo($casedir, $pool_directory, 'opensuse');
         is $result, undef, 'create symlink successfully';
     };
+
+    is $worker->job_guard_expiration_updated, 0, 'job guard not updated';
 
     my @custom_casedir_settings = (
         CASEDIR_DOMAIN => 'github.com',
@@ -432,6 +436,7 @@ subtest 'symlink testrepo, logging behavior, variable expansion' => sub {
           'PRODUCTDIR still defaults to a relative path when CASEDIR is a URL to main.pm from custom test repo is used';
         is $vars_data->{NEEDLES_DIR}, 'needles', 'relative NEEDLES_DIR is set to its basename';
         is $result->{error}, undef, 'no error occurred (1)';
+        is $worker->job_guard_expiration_updated, 1, 'job guard updated as the engine was started';
     };
 
     subtest 'good case: custom CASEDIR and custom NEEDLES_DIR specified and both are Git repos' => sub {

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -11,9 +11,11 @@ use Mojo::Base -signatures;
 use OpenQA::Test::TimeLimit '10';
 use OpenQA::Test::Utils qw(simulate_load);
 use Data::Dumper;
+use DateTime::Format::Pg;
 use Mojo::File qw(tempdir tempfile path);
 use Mojo::Util 'scope_guard';
 use Mojolicious;
+use Time::Seconds qw(ONE_MINUTE);
 use Test::Output qw(combined_like combined_from);
 use Test::MockModule;
 use Test::MockObject;
@@ -33,6 +35,7 @@ $ENV{OPENQA_CONFIG} = "$FindBin::Bin/data/24-worker-overall";
 $ENV{OPENQA_LOGFILE} = undef;
 
 my $workdir = tempdir("$FindBin::Script-XXXX", TMPDIR => 1);
+$ENV{OPENQA_CACHE_DIR} = $workdir;
 chdir $workdir;
 my $guard = scope_guard sub { chdir $FindBin::Bin };
 
@@ -126,6 +129,57 @@ push @{$worker->settings->parse_errors}, 'foo', 'bar';
 combined_like { $worker->log_setup_info }
 qr/.*http:\/\/localhost:9527,https:\/\/remotehost.*qemu_i386,qemu_x86_64.*Errors occurred.*foo.*bar.*/s,
   'setup info with parse errors';
+
+sub get_locks () {
+    $worker->{_minion_sqlite}->db->query(q(select expires from minion_locks order by expires;))->arrays;
+}
+
+subtest 'job lock for throttling' => sub {
+    is $worker->acquire_job_guard, undef, 'no attempt to acquire job lock if not configured';
+
+    my $settings = $worker->settings->global_settings;
+    local $settings->{LOCK_NAME} = 'foo';
+    local $settings->{LOCK_LIMIT} = 2;
+
+    ok ref(my $guard_1 = $worker->acquire_job_guard), 'was able to acquire lock';
+    is $worker->{_guard_or_error}, $guard_1, 'worker keeps a hold on the lock';
+    ok $worker->app->minion->is_locked('foo'), 'expected lock acquired';
+    ok $worker->can_acquire_job_guard, 'there is room for one more lock';
+    ok ref(my $guard_2 = $worker->acquire_job_guard), 'was able to acquire second lock (still within limit)';
+    ok !$worker->can_acquire_job_guard, 'limit has been reached';
+    my ($available, $error) = $worker->check_availability;
+    is $error, undef, 'no availability error as we have not tried to go beyond limit';
+
+    subtest 'updating expiration' => sub {
+        is $worker->update_job_guard_expiration->rows, 1, 'one lock updated';
+        my $locks = get_locks;
+        is @$locks, 2, 'the two locks are present' or return;
+        # DateTime::Format::Pg works for these SQLite datetimes as well
+        my $expiration_1 = DateTime::Format::Pg->parse_datetime($locks->[0]->[0])->epoch;
+        my $expiration_2 = DateTime::Format::Pg->parse_datetime($locks->[1]->[0])->epoch;
+        my $diff = abs $expiration_1 - $expiration_2;
+        cmp_ok $diff, '>', ONE_MINUTE, 'expirations differ in the order of minutes after update_job_guard_expiration';
+    };
+
+    subtest 'unable to acquire lock' => sub {
+        is $worker->acquire_job_guard, "Limited by configured lock 'foo'",
+          'was unable to acquire third lock (exceeds limit)';
+        is $worker->{_guard_or_error}, "Limited by configured lock 'foo'", 'error recorded';
+        ($available, $error) = $worker->check_availability;
+        is $error, "Limited by configured lock 'foo'", 'availability error returned as we tried to go beyond limit';
+    };
+
+    subtest 'releasing locks' => sub {
+        undef $guard_1;
+        undef $guard_2;
+        is @{get_locks()}, 0, 'locks are released by setting guards to undef';
+        ($available, $error) = $worker->check_availability;
+        is $error, undef, 'availability error cleared';
+        is $worker->{_guard_or_error}, undef, 'guard/error cleared';
+    };
+
+    undef $worker->{_guard_or_error};
+};
 
 subtest 'worker load' => sub {
     my $load = OpenQA::Utils::load_avg();

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -53,9 +53,9 @@ package Test::FakeClient {    # uncoverable statement count:2
     has service_port_delta => 2;
     has api_calls => sub { [] };
 
-    sub send ($self, $method, $path, %args) {
-        push @{$self->api_calls}, $method, $path, $args{params};
-    }
+    sub send ($self, $method, $path, %args) { push @{$self->api_calls}, $method, $path, $args{params} }
+    sub send_status ($self, @args) { push @{$self->api_calls}, 'send_status', @args }
+    sub reject_jobs ($self, @args) { push @{$self->api_calls}, 'reject_jobs', @args }
 }    # uncoverable statement
 
 package Test::FakeJob {    # uncoverable statement count:2
@@ -167,6 +167,12 @@ subtest 'job lock for throttling' => sub {
         is $worker->{_guard_or_error}, "Limited by configured lock 'foo'", 'error recorded';
         ($available, $error) = $worker->check_availability;
         is $error, "Limited by configured lock 'foo'", 'availability error returned as we tried to go beyond limit';
+
+        my $client = Test::FakeClient->new;
+        $worker->_ensure_job_guard($client, [42]);
+        my @expected = (send_status => (on_error => 1), reject_jobs => ([42], "Limited by configured lock 'foo'"));
+        is_deeply $client->api_calls, \@expected, 'status sent to web UI and assignment rejected'
+          or always_explain $client->api_calls;
     };
 
     subtest 'releasing locks' => sub {

--- a/t/24-worker-webui-connection.t
+++ b/t/24-worker-webui-connection.t
@@ -10,6 +10,8 @@ use FindBin;
 use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
 use Mojo::Base -signatures;
 
+BEGIN { $ENV{OPENQA_WORKER_EPHEMERAL_RECHECK_INTERVAL} = 0 }
+
 use Mojo::IOLoop;
 use Mojolicious;
 use Test::Output 'combined_like';
@@ -368,7 +370,14 @@ subtest 'send status' => sub {
     $client->send_status();
     is_deeply $ws->sent_messages, [{json => {fake_status => 1, reason => 'some error'}}], 'status sent'
       or always_explain $ws->sent_messages;
-    combined_like { $client->send_status_delayed } qr/some error.*checking again/, 'error logged in callback';
+
+    # consider the error ephemeral; it is expected to be re-checked and replaced by the FakeWorker with "another error"
+    $client->worker->current_error_is_ephemeral(1);
+    combined_like {
+        $client->send_status_delayed;
+        Mojo::IOLoop->start;
+    }
+    qr/another error.*checking again/, 'error logged in callback';
 };
 
 subtest 'quit' => sub {

--- a/t/lib/OpenQA/Test/FakeWorker.pm
+++ b/t/lib/OpenQA/Test/FakeWorker.pm
@@ -1,6 +1,8 @@
 package OpenQA::Test::FakeWorker;
 use Mojo::Base -base, -signatures;
 
+use Mojo::IOLoop;
+
 package Test::FakeSettings {
     use Mojo::Base -base;
     has global_settings => sub { {RETRIES => 3, RETRY_DELAY => 10, RETRY_DELAY_IF_WEBUI_BUSY => 90} };
@@ -17,6 +19,7 @@ has is_stopping => 0;
 has skipped_jobs => sub { [] };
 has current_error => undef;
 has current_job => undef;
+has current_error_is_ephemeral => 0;
 has pending_job => undef;
 has has_pending_jobs => 0;
 has pending_job_ids => sub { [] };
@@ -30,7 +33,14 @@ has job_guard_expiration_updated => 0;
 sub update_job_guard_expiration ($self) { $self->job_guard_expiration_updated(1) }
 sub stop_current_job ($self, $reason) { $self->stop_current_job_called($reason) }
 sub stop ($self) { $self->is_stopping(1) }
-sub status ($self) { {fake_status => 1, reason => $self->current_error} }
+
+sub status ($self) {
+    if ($self->current_error_is_ephemeral) {
+        $self->current_error('another error')->current_error_is_ephemeral(0);
+        Mojo::IOLoop->stop;
+    }
+    return {fake_status => 1, reason => $self->current_error};
+}
 
 sub accept_job ($self, $client, $job_info) {
     $self->current_job(OpenQA::Worker::Job->new($self, $client, $job_info));

--- a/t/lib/OpenQA/Test/FakeWorker.pm
+++ b/t/lib/OpenQA/Test/FakeWorker.pm
@@ -25,7 +25,9 @@ has is_busy => 0;
 has settings => sub { Test::FakeSettings->new };
 has enqueued_job_info => undef;
 has is_executing_single_job => 1;
+has job_guard_expiration_updated => 0;
 
+sub update_job_guard_expiration ($self) { $self->job_guard_expiration_updated(1) }
 sub stop_current_job ($self, $reason) { $self->stop_current_job_called($reason) }
 sub stop ($self) { $self->is_stopping(1) }
 sub status ($self) { {fake_status => 1, reason => $self->current_error} }


### PR DESCRIPTION
This is still a draft to show how a worker-side approach could look like. The comment in `workers.ini` contains more details. The locking via Minion worked in a few manual tests I did and is probably simpler on our side compared to adding a lock file. There's only one FIXME to resolve and of course I need to do more manual testing and add unit tests.

The main concern I have is the `LOCK_EXPIRATION` setting. I put 60 seconds there but considering asset downloads (that happen before QEMU even starts and the load increases) might take significantly longer we might need to put a higher value there. That has the disadvantage that other worker slots will be blocked for longer with re-evaluating the load threshold (so we possibly limit ourselves to just a few workers needlessly long).

It would be good if the worker could change the expiration of the lock it holds after the setup (without temporarily releasing it). This way we could initially set a high expiration (definitely covering any asset downloads that might take long) and lower it when we started isotovideo. Unfortunately, I haven't found a way to do this with Minion locks.

We could also only acquire the lock once the setup is done. Unfortunately, if we then cannot acquire the job we needed to set the job to `incomplete` or `setup_failure`. (We could set it back to `scheduled` and pretend nothing happened but that's nothing we currently already do at this point and I'm not sure whether we should open this can of worms.)

Note that a centralized scheduler-based approach has even less chances of taking the setup time into account. There would probably also be some cool-down setting (similar to `LOCK_EXPIRATION` here, but as part of the web UI settings) and we would have the same problem there as well.

The advantage a scheduler-based approach has is being able to distribute jobs across as many worker hosts as possible. That's of course only useful if we have sufficiently many worker hosts (e.g. of a certain architecture). So maybe we could combine this worker-side locking/throttling with a change in the scheduler to max out distribution of jobs across worker hosts (but not having any limit/throttling in the scheduler).

Related ticket: https://progress.opensuse.org/issues/203478