### PR TITLE
fix(client): Encode text_data as UTF-8 in archive command

### DIFF
--- a/lib/OpenQA/Client/Archive.pm
+++ b/lib/OpenQA/Client/Archive.pm
@@ -63,7 +63,7 @@ sub _download_test_result_details ($self, $url, $path, $module, $options) {
     }
     elsif ($module->{text}) {
         my $file = $path->child('testresults', $module->{text});
-        $file->spew($module->{text_data} // "No data\n");
+        $file->spew($module->{text_data} // "No data\n", 'UTF-8');
     }
     return undef;
 }


### PR DESCRIPTION
'openqa-cli archive' writes each test step's captured text output via Mojo::File::spew() without specifying an encoding. text_data comes from decoded JSON, so it can be a character string containing non-ASCII text (e.g. command output captured by a test). Writing it out raw dies with 'Wide character in syswrite' as soon as such text is encountered.

This aborts the whole archive run partway through processing test results, before it ever reaches the logs/ulogs download step, so jobs with any non-ASCII step output silently end up missing all logs and ulogs (e.g. serial_terminal.txt, autoinst-log.txt, and any uploaded logs) with no clear error.

Fix by telling spew() to encode the content as UTF-8, which is a no-op for the common plain-ASCII case and correctly encodes non-ASCII text instead of crashing.