### PR TITLE
feat: allow UEFI_PFLASH_CODE as asset

### DIFF
--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -1468,6 +1468,7 @@ The following job settings are specifying that an asset is required by a job:
 - `ISO` (type `iso`)
 - `ISO_n` (type `iso`)
 - `HDD_n` (type `hdd`)
+- `UEFI_PFLASH_CODE` (type `hdd`) (in some cases, see below)
 - `UEFI_PFLASH_VARS` (type `hdd`) (in some cases, see below)
 - `REPO_n` (type `repo`)
 - `ASSET_n` (type `other`)
@@ -1485,7 +1486,8 @@ assets): this exempts them from the automatic cleanup described in the section a
 [asset cleanup](UsersGuide.md#asset_cleanup).
 Non-fixed assets are always subject to the cleanup.
 
-`UEFI_PFLASH_VARS` is a special case: whether it is treated as an asset depends on the value. If the value looks like an absolute path (starts with `/`), it will not be treated as an asset (and
+`UEFI_PFLASH_CODE` and `_VARS` are a special case: whether it is treated as an asset depends on the value.
+If the value looks like an absolute path (starts with `/`), it will not be treated as an asset (and
 so the value should be an absolute path for a file which exists on the relevant worker system(s)).
 Otherwise, it is treated as an `hdd`-type asset. This allows tests to use a stock base image
 (like the ones provided by edk2) for a simple case, but also allows a job to upload its image on

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -379,12 +379,12 @@ sub run_cmd_with_log_return_error ($cmd, %args) {
 }
 
 # passing $value is optional but makes the result more accurate
-# (it affects only UEFI_PFLASH_VARS currently).
+# (it affects only UEFI_PFLASH_(CODE|VARS) currently).
 sub asset_type_from_setting ($setting, $value = undef) {
     return 'iso' if $setting eq 'ISO' || $setting =~ /^ISO_\d+$/;
     return 'hdd' if $setting =~ /^HDD_\d+$/;
-    # non-absolute-path value of UEFI_PFLASH_VARS treated as HDD asset
-    return 'hdd' if $setting eq 'UEFI_PFLASH_VARS' && ($value // '') !~ m,^/,;
+    # non-absolute-path value of UEFI_PFLASH_(CODE|VARS) treated as HDD asset
+    return 'hdd' if $setting =~ /^UEFI_PFLASH_(?:CODE|VARS)$/ && ($value // '') !~ m{^/};
     return 'repo' if $setting =~ /^REPO_\d+$/;
     return 'other' if $setting =~ /^ASSET_\d+$/ || $setting eq 'KERNEL' || $setting eq 'INITRD';
     # empty string if this doesn't look like an asset type

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -327,6 +327,9 @@ subtest 'Plugins handling' => sub {
 subtest asset_type_from_setting => sub {
     use OpenQA::Utils 'asset_type_from_setting';
     is asset_type_from_setting('ISO'), 'iso', 'simple from ISO';
+    is asset_type_from_setting('UEFI_PFLASH_CODE'), 'hdd', 'simple from UEFI_PFLASH_CODE';
+    is asset_type_from_setting('UEFI_PFLASH_CODE', 'relative'), 'hdd', 'relative from UEFI_PFLASH_CODE';
+    is asset_type_from_setting('UEFI_PFLASH_CODE', '/absolute'), '', 'absolute from UEFI_PFLASH_CODE';
     is asset_type_from_setting('UEFI_PFLASH_VARS'), 'hdd', 'simple from UEFI_PFLASH_VARS';
     is asset_type_from_setting('UEFI_PFLASH_VARS', 'relative'), 'hdd', 'relative from UEFI_PFLASH_VARS';
     is asset_type_from_setting('UEFI_PFLASH_VARS', '/absolute'), '', 'absolute from UEFI_PFLASH_VARS';
@@ -371,8 +374,10 @@ subtest parse_assets_from_settings => sub {
     };
     is_deeply $assets, $refassets, 'correct with absolute UEFI_PFLASH_VARS';
     # now make this relative: it should now be seen as an asset type
+    $settings->{UEFI_PFLASH_CODE} = 'uefi_pflash_code.qcow2';
     $settings->{UEFI_PFLASH_VARS} = 'uefi_pflash_vars.qcow2';
     $assets = parse_assets_from_settings($settings);
+    $refassets->{UEFI_PFLASH_CODE} = {type => 'hdd', name => 'uefi_pflash_code.qcow2'};
     $refassets->{UEFI_PFLASH_VARS} = {type => 'hdd', name => 'uefi_pflash_vars.qcow2'};
     is_deeply $assets, $refassets, 'correct with relative UEFI_PFLASH_VARS';
     # KERNEL/INITRD are treated similar to UEFI_PFLASH_VARS
@@ -380,7 +385,6 @@ subtest parse_assets_from_settings => sub {
     $assets = parse_assets_from_settings($settings);
     $refassets->{KERNEL} = {type => 'other', name => '/path/vmlinuz'};
     is_deeply $assets, $refassets, 'correct with absolute KERNEL';
-
 };
 
 subtest 'base_host' => sub {


### PR DESCRIPTION
Just like UEFI_PFLASH_VARS, allow to download it as an asset.

This allows to supply a consistent firmware image independent of the worker the test runs on.

Related ticket: https://progress.opensuse.org/issues/203625

Depends on: https://github.com/os-autoinst/os-autoinst/pull/3011

Verification run: https://openqa.opensuse.org/tests/6081282 (monkeypatched on experimental ow28 worker. It attempts to download it at least)