### PR TITLE
ci: Add cli tool to report uncovered lines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,7 @@ jobs:
       - codecov/upload:
           files: cover_db/codecov.json
           verbose: true
+      - run: ./tools/check-line-coverage cover_db/codecov.json
 
   build-docs: &docs-template
     docker:

--- a/tools/check-line-coverage
+++ b/tools/check-line-coverage
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+input_file=$1
+limit=${2:-500}
+
+declare -i counter=0
+
+echo "Checking for uncovered lines" >&2
+
+while read -r file line; do
+    [[ $line -eq 0 ]] && continue
+    if [[ -f "$file" ]]; then
+        content=$(sed -n "${line}p" "$file")
+        printf "%-60s %s\n" "$file:$line" "| $content"
+        counter+=1
+        if [[ $counter -ge $limit ]]; then
+            echo "Reached limit of $limit printed lines. Stopping." >&2
+            break
+        fi
+    else
+        echo "Warning: File '$file' not found." >&2
+    fi
+done < <(jq -r '.coverage | to_entries[] | .key as $file | .value | to_entries[] | select(.value == 0) | "\($file) \(.key)"' "$input_file")
+
+if [[ $counter -gt 0 ]]; then
+    echo "$counter uncovered lines" >&2
+    exit 1
+fi
+
+echo "All lines covered \\o/" >&2


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/203757

This is executed after the codecov upload and will fail the codecov step if there are any uncovered lines.

Example output:
```
Checking for uncovered lines 
t/01-test-utilities.t:64     | pass "something 2";
t/01-test-utilities.t:65     | pass "something 3";
t/01-test-utilities.t:66     | pass "something 4";
t/01-test-utilities.t:67     | pass "something 5";
t/01-test-utilities.t:68     | pass "something 6";
t/01-test-utilities.t:69     | pass "something 7";
t/01-test-utilities.t:70     | pass "something 8";
t/01-test-utilities.t:71     | pass "something 9";
t/01-test-utilities.t:72     | pass "something 10";
t/01-test-utilities.t:73     | pass "something 11";
Reached limit of 10 printed lines. Stopping.
10 uncovered lines

Exited with code exit status 1
```
Demo: https://app.circleci.com/pipelines/github/perlpunk/openQA/518/workflows/a11e59ee-9392-43e9-b75f-434abaa2ce98/jobs/4524?invite=true&expanded=true#step-114-0_49