### PR TITLE
feat(worker): Implement load-proportionate delay

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -1065,23 +1065,14 @@ to access files of the host) use the following setting:
 HOST = http://openqa.example.com
 ```
 
-The load of the system can affect test execution and cause failures due to delays of command execution and [thrashing](https://en.wikipedia.org/wiki/Thrashing_(computer_science)). If the average over a period of 15 minutes exceeds the specified value the worker will not accept new jobs.
-
-
-
-
-
-workers.ini
-
-
-
-``` ini
-[global]
-# Set to 0 to disable.
-#CRITICAL_LOAD_AVG_THRESHOLD = 40
-```
-
-
+The load of the system can affect test execution and cause failures due to delays
+of command execution and [thrashing](<https://en.wikipedia.org/wiki/Thrashing_(computer_science)>).
+To prevent "load storms" (synchronized boot avalanches), workers check the
+system load average before picking up jobs. If the load is very high, they
+temporarily reject jobs. If the load is moderately high, they introduce a
+load-proportionate sleep delay to stagger job acceptance. The specific load
+thresholds, factor, and jitter are configurable in `workers.ini` (e.g.,
+`CRITICAL_LOAD_AVG_THRESHOLD`, `WORKER_LOAD_LOW_LIMIT`).
 
 Once you got workers running they should show up in the admin section of openQA in
 the workers section as 'idle'. When you get so far, you have your own instance

--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -106,6 +106,17 @@
 #LOCK_EXPIRATION = 30
 #LOCK_LIMIT = 5
 
+# When checking the 1-minute load average, if it is below WORKER_LOAD_LOW_LIMIT,
+# jobs are picked up immediately. If the load is between WORKER_LOAD_LOW_LIMIT
+# and CRITICAL_LOAD_AVG_THRESHOLD, the worker sleeps to stagger job acceptance
+# and prevent "boot avalanches" on high-density hosts.
+# Delay formula: WORKER_LOAD_FACTOR * load + rand(WORKER_LOAD_JITTER)
+# The feature is disabled by default. If enabling, a WORKER_LOAD_FACTOR of 10 to 15
+# is recommended to allow the OS load average sufficient time to reflect the actual load.
+#WORKER_LOAD_LOW_LIMIT = 4
+#WORKER_LOAD_FACTOR = 0
+#WORKER_LOAD_JITTER = 0
+
 # If IPMI_HOSTNAME, IPMI_USER and IPMI_PASSWORD is set the worker will periodically
 # ensure that the IPMI controlled SUT is powered off when no job is running.
 # The default period is 300 seconds.

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -885,6 +885,28 @@ sub _check_system_utilization (
     return undef;
 }
 
+sub _calculate_load_delay (
+    $self,
+    $threshold = $self->settings->global_settings->{CRITICAL_LOAD_AVG_THRESHOLD},
+    $load = load_avg())
+{
+    return 0 if !$threshold || @$load < 3;
+    my $global_settings = $self->settings->global_settings;
+    my $low_limit = $global_settings->{WORKER_LOAD_LOW_LIMIT};
+    if ($load->[0] >= $low_limit && $load->[0] < $threshold) {
+        my $factor = $global_settings->{WORKER_LOAD_FACTOR};
+        my $jitter = $global_settings->{WORKER_LOAD_JITTER};
+        my $delay = $factor * $load->[0] + ($jitter > 0 ? rand $jitter : 0);
+        if ($delay > 0) {
+            my $format
+              = 'Load is %.2f (between %d and %d). Delaying job acceptance for %.2f seconds to prevent load storms.';
+            log_debug sprintf $format, $load->[0], $low_limit, $threshold, $delay;
+            return $delay;
+        }
+    }
+    return 0;
+}
+
 sub _setup_pool_directory ($self) {
     # skip if we have already locked the pool directory
     return undef if defined $self->{_pool_directory_lock_fd};

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -139,6 +139,19 @@ sub accept ($self) {
     my $info = $self->info;
     die 'attempt to accept job without ID and job info' unless $id && defined $info && ref $info eq 'HASH';
     die 'attempt to accept job which is not newly initialized' unless $self->is_supposed_to_start;
+
+    my $worker = $self->worker;
+    my $delay = $worker->_calculate_load_delay;
+    if ($delay > 0 && !$self->{_delay_applied}) {
+        $self->{_delay_applied} = 1;
+        $self->_set_status(accepting => {}) if $self->status ne 'accepting';
+        Mojo::IOLoop->timer(
+            $delay => sub {
+                $self->accept if $self->is_supposed_to_start;
+            });
+        return 1;
+    }
+
     $self->_set_status(accepting => {}) if $self->status ne 'accepting';
 
     # clear last API error (which happened before this job) and is therefore unrelated

--- a/lib/OpenQA/Worker/Settings.pm
+++ b/lib/OpenQA/Worker/Settings.pm
@@ -21,6 +21,9 @@ has 'webui_host_specific_settings';
 
 use constant QEMU_PORT_OFFSET => 20_002;
 use constant DEFAULT_CRITICAL_LOAD_AVG_THRESHOLD => 40;
+use constant DEFAULT_WORKER_LOAD_LOW_LIMIT => 4;
+use constant DEFAULT_WORKER_LOAD_FACTOR => 0;
+use constant DEFAULT_WORKER_LOAD_JITTER => 0;
 
 sub new ($class, $instance_number = undef, $cli_options = {}) {
     my $config_paths = lookup_config_files(undef, 'workers.ini', 1);
@@ -35,7 +38,7 @@ sub new ($class, $instance_number = undef, $cli_options = {}) {
     _read_section($cfg, "class:$_", \%global_settings, 1) for split /,/, $global_settings{WORKER_CLASS} // '';
 
     # read global settings from environment variables
-    for my $var (qw(LOG_DIR TERMINATE_AFTER_JOBS_DONE)) {
+    for my $var (qw(LOG_DIR TERMINATE_AFTER_JOBS_DONE WORKER_LOAD_LOW_LIMIT WORKER_LOAD_FACTOR WORKER_LOAD_JITTER)) {
         $global_settings{$var} = $ENV{"OPENQA_WORKER_$var"} if ($ENV{"OPENQA_WORKER_$var"} // '') ne '';
     }
 
@@ -51,6 +54,9 @@ sub new ($class, $instance_number = undef, $cli_options = {}) {
     # Select sensible system CPU load15 threshold to prevent system overload
     # based on experiences with system stability so far
     $global_settings{CRITICAL_LOAD_AVG_THRESHOLD} //= DEFAULT_CRITICAL_LOAD_AVG_THRESHOLD;
+    $global_settings{WORKER_LOAD_LOW_LIMIT} //= DEFAULT_WORKER_LOAD_LOW_LIMIT;
+    $global_settings{WORKER_LOAD_FACTOR} //= DEFAULT_WORKER_LOAD_FACTOR;
+    $global_settings{WORKER_LOAD_JITTER} //= DEFAULT_WORKER_LOAD_JITTER;
 
     # set some environment variables
     # TODO: This should be sent to the scheduler to be included in the worker's table.

--- a/t/24-worker-overall.t
+++ b/t/24-worker-overall.t
@@ -193,13 +193,29 @@ subtest 'worker load' => sub {
     is $load->[0], 10.93, 'expected load';
     is_deeply $load, [10.93, 10.91, 10.25], 'expected computed system load, rising flank';
     is_deeply OpenQA::Utils::load_avg(path($ENV{OPENQA_CONFIG}, 'invalid_loadavg')), [], 'error on invalid load';
+    $worker->settings->global_settings->{WORKER_LOAD_FACTOR} = 0;
+    $worker->settings->global_settings->{WORKER_LOAD_JITTER} = 0;
     ok !$worker->_check_system_utilization, 'default threshold not exceeded';
+    $worker->settings->global_settings->{WORKER_LOAD_LOW_LIMIT} = 4;
     ok $worker->_check_system_utilization(10), 'stricter threshold exceeded by load';
     ok !$worker->_check_system_utilization(10, [3, 9, 11]), 'load ok on falling flank';
     ok $worker->_check_system_utilization(10, [12, 9, 3]), 'load exceeded on rising flank';
     ok $worker->_check_system_utilization(10, [12, 3, 9]), 'load exceeded on rising flank and old load';
     ok $worker->_check_system_utilization(10, [11, 13, 12]), 'load still exceeded on short load dip';
     ok $worker->_check_system_utilization(10, [11, 12, 13]), 'load still exceeded on falling flank but high';
+
+    subtest 'sleep duration is calculated proportionally to current system load and executed when above low limit' =>
+      sub {
+        $worker->settings->global_settings->{WORKER_LOAD_LOW_LIMIT} = 5;
+        $worker->settings->global_settings->{WORKER_LOAD_FACTOR} = 2;
+        $worker->settings->global_settings->{WORKER_LOAD_JITTER} = 0;
+        my $delay = $worker->_calculate_load_delay;
+        cmp_ok $delay, '>', 15, 'sleep duration is greater than the expected lower bound of 15 seconds';
+        cmp_ok $delay, '<', 25, 'sleep duration is less than the expected upper bound of 25 seconds';
+        $worker->settings->global_settings->{WORKER_LOAD_LOW_LIMIT} = 4;
+        $worker->settings->global_settings->{WORKER_LOAD_FACTOR} = 0;
+        $worker->settings->global_settings->{WORKER_LOAD_JITTER} = 0;
+      };
 };
 
 subtest 'passing return code' => sub {
@@ -961,6 +977,9 @@ subtest 'handle job status changes' => sub {
             $reset_job_and_queue->();
             $worker_mock->unmock('is_qemu_running');
             $worker->settings->global_settings->{CRITICAL_LOAD_AVG_THRESHOLD} = '10';
+            $worker->settings->global_settings->{WORKER_LOAD_FACTOR} = 0;
+            $worker->settings->global_settings->{WORKER_LOAD_JITTER} = 0;
+
             combined_like { $worker->_handle_job_status_changed($fake_job, {status => 'stopped', reason => 'done'}) }
             qr/Job 42 from some-host finished - reason: done.*Continuing.*769.*despite.*load.*exceeding/s,
               'continuation despite error logged';

--- a/t/24-worker-settings.t
+++ b/t/24-worker-settings.t
@@ -31,6 +31,9 @@ my @common_settings = (
     LOG_DIR => 'log/dir',
     RETRY_DELAY => 5,
     RETRY_DELAY_IF_WEBUI_BUSY => 60,
+    WORKER_LOAD_LOW_LIMIT => 4,
+    WORKER_LOAD_FACTOR => 0,
+    WORKER_LOAD_JITTER => 0,
 );
 
 is_deeply $settings->global_settings, {@common_settings, TERMINATE_AFTER_JOBS_DONE => 1},

--- a/t/data/24-worker-overall/workers.ini
+++ b/t/data/24-worker-overall/workers.ini
@@ -4,6 +4,9 @@
 HOST = http://localhost:9527 https://remotehost
 WORKER_HOSTNAME = 127.0.0.1
 LOG_LEVEL = debug
+WORKER_LOAD_LOW_LIMIT = 4
+WORKER_LOAD_FACTOR = 0
+WORKER_LOAD_JITTER = 0
 
 [1]
 WORKER_CLASS = qemu_i386,qemu_x86_64


### PR DESCRIPTION
Motivation:
During wave concurrent test triggers, multiple idle workers read the same low
load due to OS load average sampling lag, launching heavy QEMU instances at the
exact same millisecond and causing severe boot avalanches.

Design Choices:
Instead of a hard critical limit, we introduce parameters to calculate a
load-proportionate sleep delay before accepting a job. Sleeping staggers job
acceptance, letting the OS sampling lag catch up so subsequent workers can
correctly reject jobs when overloaded. Low loads bypass sleep to preserve
fast performance on local single-instance development hosts.

Benefits:
This safely prevents thundering herd load storms on high-density hosts while
maintaining immediate responsiveness for local test developers.

Related issue: https://progress.opensuse.org/issues/203478

This is related to #7604 which inspired me to a complementary idea.