### PR TITLE
feat(build): add check-line-coverage target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ JavaScript (Bootstrap).
 - `make test-unit-and-integration TESTS=t/your_test.t`: Run specific tests.
 - `COVERAGE=1 make test-unit-and-integration TESTS=t/your_test.t`: Run
   specific tests with statement coverage enabled.
+- `make check-line-coverage`: Check for uncovered lines in current cover_db.
 - `cover -report text -select_re 'path/to/modified_file'`: Generate and view a
   fast text-based coverage report restricted to the specific file you changed
   (run this after generating the coverage database).
@@ -34,9 +35,9 @@ JavaScript (Bootstrap).
   creating git commits.
 - **Strict Statement Coverage:** Full statement coverage is a hard
   requirement. You MUST run tests with `COVERAGE=1` for your specific test
-  adaptations and verify that all new/modified lines are covered using `cover
-  -report text` before creating git commits. Do not wait for CI/Codecov in PRs
-  to catch missing coverage.
+  adaptations, and then run `make check-line-coverage` to verify that all
+  new/modified lines are covered. Do not wait for CI/Codecov in PRs to catch
+  missing coverage.
 
 ## Constraints
 

--- a/Makefile
+++ b/Makefile
@@ -386,6 +386,10 @@ coverage-report-codecov: ## Generate codecov report
 	export DEVEL_COVER_DB_FORMAT=JSON;\
 	cover $(COVER_REPORT_OPTS) -report codecovbash
 
+.PHONY: check-line-coverage
+check-line-coverage: coverage-report-codecov ## Check for uncovered lines in current cover_db
+	./tools/check-line-coverage cover_db/codecov.json
+
 .PHONY: coverage-codecov
 coverage-codecov: coverage ## Run coverage and generate codecov report
 	$(MAKE) coverage-report-codecov


### PR DESCRIPTION
Motivation:
We need a simple way to run the local line coverage checks using our
newly introduced CLI check-line-coverage tool.

Design Choices:
Added a `check-line-coverage` target to the Makefile that depends on
`coverage-report-codecov` and executes the check script.

Benefits:
Provides an automated and idiomatic command to check statement coverage
locally without manual report generation steps.