### PR TITLE
test: reuse reserved socket in create_webapi

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -840,6 +840,17 @@ sub reserve_ports ($services = [keys %SERVICE_OFFSETS], %options) {
     return @$services == 1 ? $RESERVED_SOCKETS{$services->[0]} : \%RESERVED_SOCKETS;
 }
 
+# Map a plain reserved port back to its "port&fd=…" form so a child daemon reuses
+# the parent's already-bound socket instead of binding a fresh one (which only
+# succeeds on IPv6 loopback and deadlocks IPv4 clients). Returns the port
+# unchanged if it was not reserved.
+sub raw_port_for_reserved ($plain) {
+    for my $socket (values %RESERVED_SOCKETS) {
+        return "$plain&fd=" . $socket->fileno if $socket->sockport == $plain;
+    }
+    return $plain;
+}
+
 sub random_string ($length = RANDOM_STRING_DEFAULT_LENGTH, $chars = ['a' .. 'z', 'A' .. 'Z', '0' .. '9', '_']) {
     return join '', map { $chars->[rand @$chars] } 1 .. $length;
 }

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -813,7 +813,12 @@ sub set_listen_address ($service) { $ENV{MOJO_LISTEN} //= make_listen_url(raw_se
 my %SERVICE_OFFSETS = (webui => 0, websocket => 1, livehandler => 2, scheduler => 3, cache_service => 4);
 my %RESERVED_SOCKETS;
 
-sub raw_service_port ($service) {
+sub raw_service_port ($service, $port = undef) {
+    if (defined $port) {
+        $port = raw_port_for_reserved($port) if $port =~ /^\d+$/;
+        return $port;
+    }
+
     my $base = $ENV{OPENQA_BASE_PORT} ||= DEFAULT_OPENQA_BASE_PORT;
     if (my $env_port = $ENV{"OPENQA_PORT_\U$service"}) {    # \U uppercases the interpolated variable
         return $env_port;

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -556,4 +556,12 @@ subtest 'create downloads list' => sub {
       'valid download for asset URL';
 };
 
+subtest 'reserved ports' => sub {
+    is raw_service_port('webui', 1234), 1234, 'unreserved port unchanged';
+    my $socket = OpenQA::Utils::reserve_ports(['webui'], force => 1);
+    my $port = $socket->sockport;
+    my $fileno = $socket->fileno;
+    is raw_service_port('webui', $port), "$port&fd=$fileno", 'reserved port mapped to fd form';
+};
+
 done_testing;

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -269,10 +269,7 @@ sub stop_service {
 }
 
 sub create_webapi ($port = undef, $no_cover = undef) {
-    # Callers commonly pass the plain reserved port via `reserve_ports(...)->sockport`;
-    # restore its socket fd so the daemon reuses the parent's bound socket.
-    $port = OpenQA::Utils::raw_port_for_reserved($port) if defined $port && $port =~ /^\d+$/;
-    $port //= raw_service_port 'webui';
+    $port = raw_service_port('webui', $port);
     note("Starting WebUI service. Port: $port");
 
     my $h = _setup_sigchld_handler 'openqa-webapi', start sub {
@@ -299,7 +296,7 @@ sub create_webapi ($port = undef, $no_cover = undef) {
 }
 
 sub create_websocket_server ($port, $bogus, $with_embedded_scheduler = undef, $no_cover = undef) {
-    OpenQA::WebSockets::Client->singleton->port(to_plain_service_port($port //= raw_service_port('websocket')));
+    OpenQA::WebSockets::Client->singleton->port(to_plain_service_port($port = raw_service_port('websocket', $port)));
     note "Starting WebSocket service (port: $port, bogus: $bogus)";
     my $h = _setup_sigchld_handler 'openqa-websocket', start sub {
         _setup_sub_process 'openqa-websocket';
@@ -342,7 +339,8 @@ sub create_websocket_server ($port, $bogus, $with_embedded_scheduler = undef, $n
     return $h;
 }
 
-sub create_scheduler ($port = raw_service_port('scheduler')) {
+sub create_scheduler ($port = undef) {
+    $port = raw_service_port('scheduler', $port);
     note("Starting Scheduler service. Port: $port");
     OpenQA::Scheduler::Client->singleton->port(to_plain_service_port($port));
     _setup_sigchld_handler 'openqa-scheduler', start sub {
@@ -355,7 +353,8 @@ sub create_scheduler ($port = raw_service_port('scheduler')) {
     };
 }
 
-sub create_live_view_handler ($port = raw_service_port 'livehandler') {
+sub create_live_view_handler ($port = undef) {
+    $port = raw_service_port('livehandler', $port);
     _setup_sigchld_handler 'openqa-livehandler', start sub {
         _setup_sub_process 'openqa-livehandler';
         my $daemon

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -269,6 +269,9 @@ sub stop_service {
 }
 
 sub create_webapi ($port = undef, $no_cover = undef) {
+    # Callers commonly pass the plain reserved port via `reserve_ports(...)->sockport`;
+    # restore its socket fd so the daemon reuses the parent's bound socket.
+    $port = OpenQA::Utils::raw_port_for_reserved($port) if defined $port && $port =~ /^\d+$/;
     $port //= raw_service_port 'webui';
     note("Starting WebUI service. Port: $port");
 


### PR DESCRIPTION
Motivation:
When tests passed the plain reserved port to create_webapi, Mojo bound a fresh
listener that only succeeded on IPv6 loopback and deadlocked IPv4 clients,
hanging the test. This surfaced locally as a lengthy timeout in t/14-grutasks.t
under HEAVY=1 with a real PostgreSQL, while CI's networking happened to
mask it.