### PR TITLE
docs: Remove example from `LOCK_NAME` worker setting

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -121,7 +121,7 @@ on 'develop' => sub {
     requires 'Code::TidyAll';
     requires 'Perl::Critic', '>= 1.156.0';
     requires 'Perl::Critic::Community';
-    requires 'Perl::Tidy', '== 20260204.0.0';
+    requires 'Perl::Tidy', '== 20260705';
     requires 'Pod::Markdown';
     requires 'TAP::Harness::JUnit';
     requires 'Test::CheckGitStatus';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -88,7 +88,7 @@ devel_no_selenium_requires:
   xorg-x11-fonts:
   pandoc:  # for generating HTML documentation
   python3-weasyprint:  # for generating PDF documentation
-  perl(Perl::Tidy): '== 20260204.0.0'
+  perl(Perl::Tidy): '== 20260705'
   perl(Test::CheckGitStatus):
   perl(TAP::Harness::JUnit):  # for JUnit-compatible test results
 

--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -102,7 +102,7 @@
 # with an according note. This prevents the scheduler from immediately assigning
 # a job on these slots again (increasing the chances it will spread future
 # job assignments across different/other worker hosts).
-#LOCK_NAME = qemu-job
+#LOCK_NAME =
 #LOCK_EXPIRATION = 30
 #LOCK_LIMIT = 5
 

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -122,7 +122,7 @@ sub guard ($self, @args) { $self->app->minion->guard(@args) }
 sub _job_guard ($self) {
     my $settings = $self->settings->global_settings;
     return undef unless defined(my $lock_name = $settings->{LOCK_NAME});
-    return $self->guard($lock_name, ONE_HOUR, {limit => $settings->{LOCK_LIMIT} // 1})
+    return $self->guard($lock_name, ONE_HOUR, {limit => $settings->{LOCK_LIMIT} // 5})
       // "Limited by configured lock '$lock_name'";
 }
 

--- a/t/05-scheduler-serialize-directly-chained-dependencies.t
+++ b/t/05-scheduler-serialize-directly-chained-dependencies.t
@@ -142,7 +142,7 @@ $cluster_info{$_}->{state} = SCHEDULED for (1, 9);
 # provide a sort function to control the order between multiple children of the same parent
 my %sort_criteria = (12 => 'anfang', 7 => 'danach', 6 => 'mitte', 8 => 'nach mitte', 1 => 'zuletzt');
 my $sort_function = sub ($items) {
-    return [sort { ($sort_criteria{$a} // $a) cmp($sort_criteria{$b} // $b) } @$items];
+    return [sort { ($sort_criteria{$a} // $a) cmp ($sort_criteria{$b} // $b) } @$items];
 };
 @expected_sequence = (0, 12, 7, 6, [8, [10, 11], 9], [1, [2, 3], [4, 5]]);
 ($computed_sequence, $visited)


### PR DESCRIPTION
Locking is disabled by default and the example lock name was maybe a bit too specific.

Related ticket: https://progress.opensuse.org/issues/203478

---

Note that we already allow workers to write to the cache directory and it seems to work on openqaworker23. So I haven't included any AppArmor changes here.