### PR TITLE
feat: Improve scalability of dependency tree computation

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2046,8 +2046,20 @@ sub incomplete_ancestors ($self, $limit = -1) {
 }
 
 sub latest_job ($self) {
-    return $self unless my $clone = $self->clone;
-    return $clone->latest_job;
+    my $latest = $self->{_latest};
+    return $latest if defined $latest;
+    my $self_id = $self->id;
+    my $schema = $self->result_source->schema;
+    my $sth = $schema->storage->dbh->prepare('
+        with recursive clone_id as (
+            select ? as clone_id
+            union all
+            select jobs.clone_id as clone_id from jobs join clone_id on clone_id.clone_id = jobs.id where jobs.clone_id is not null)
+        select clone_id from clone_id order by clone_id desc limit 1;');
+    $sth->bind_param(1, $self_id, SQL_BIGINT);
+    $sth->execute;
+    my $latest_id = $sth->fetchrow_array;
+    $self->{_latest} = $latest_id == $self_id ? $self : $schema->resultset('Jobs')->find($latest_id);
 }
 
 sub handle_retry ($self) {

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -1173,9 +1173,9 @@ sub _add_job ($dependency_data, $job, $as_child_of, $preferred_depth) {
 
     # show only the latest child jobs but still require the cloned job to be an actual child
     if ($as_child_of) {
-        my $clone = $job->clone;
-        if ($clone && $clone->is_child_of($as_child_of)) {
-            return _add_job($dependency_data, $clone, $as_child_of, $preferred_depth);
+        my $latest_job = $job->latest_job;
+        if ($latest_job != $job && $latest_job->is_child_of($as_child_of)) {
+            return _add_job($dependency_data, $latest_job, $as_child_of, $preferred_depth);
         }
     }
 

--- a/t/ui/16-tests_dependencies.t
+++ b/t/ui/16-tests_dependencies.t
@@ -109,7 +109,11 @@ subtest 'dependency json' => sub {
     always_explain $t->tx->res->json unless $t->success;
 
     %cluster = (cluster_99963 => [99963, 99961]);
-    @edges = ({from => 99937, to => 99938}, {from => 99961, to => 99927}, {from => 99938, to => 99963});
+    @edges = (
+        {from => 99937, to => 99945},
+        {from => 99937, to => 99938},
+        {from => 99961, to => 99927},
+        {from => 99938, to => 99963});
     @nodes = (
         {
             @basic_node,
@@ -127,6 +131,16 @@ subtest 'dependency json' => sub {
             result => PASSED,
             state => DONE,
             name => node_name('13.1-DVD-i586-Build0091-kde@32bit', 0, 0, 0, 2),
+        },
+        {
+            @basic_node,
+            id => 99945,
+            label => 'textmode@32bit',
+            result => PASSED,
+            state => DONE,
+            name => node_name('13.1-DVD-i586-Build0091-textmode@32bit', 1, 1, 99937, 2),
+            chained => ['kde'],
+            parallel => [],
         },
         {
             @basic_node,
@@ -227,8 +241,8 @@ subtest 'graph rendering' => sub {
         is scalar @child_elements, $expected_count, $test_name;
     };
     $check_element_quandity->('.cluster', 1, 'one cluster present');
-    $check_element_quandity->('.edgePath', 3, 'three edges present');
-    $check_element_quandity->('.node', 5, 'five nodes present');
+    $check_element_quandity->('.edgePath', 4, 'three edges present');
+    $check_element_quandity->('.node', 6, 'five nodes present');
 
     like
       get_tooltip(99938),


### PR DESCRIPTION
* Optimize finding the latest job using raw SQL query
    * Reduce lookup time from almost 7 minutes to 3 seconds on my system with a clone chain of 742 jobs with parallel dependencies
* Avoid warning `Deep recursion on subroutine "OpenQA::WebAPI::Controller::Test::_add_job"` if there are long clone chains
* Evaluate `is_child_of` only for the latest job (and not each and every job in the chain); that changes the behavior a little bit requiring the tests change
    * The number of displayed jobs did not notably increase in the big dependency trees I checked.

Related ticket: https://progress.opensuse.org/issues/204120