### PR TITLE
feat(cli): improve connection error reporting

### DIFF
--- a/lib/OpenQA/Command.pm
+++ b/lib/OpenQA/Command.pm
@@ -132,11 +132,12 @@ sub retry_tx ($self, $client, $tx, $retries = undef, $delay = undef) {
         my $waited = time - $start;
         my $error = $new_tx->error;
         my $error_msg = $error ? " ($error->{message})" : '';
+        my $error_info = $res_code == 0 ? "connection error$error_msg" : "error $res_code$error_msg";
         my $url = $new_tx->req->url;
         my $port = $url->port // ($url->scheme && $url->scheme eq 'https' ? 443 : 80);
         my $target = ($url->host || 'localhost') . ":$port";
         print STDERR encode('UTF-8',
-"Request to $target failed, hit error $res_code$error_msg, retrying up to $retries more times after waiting … (delay: $delay; waited ${waited}s)\n"
+"Request to $target failed, hit $error_info, retrying up to $retries more times after waiting … (delay: $delay; waited ${waited}s)\n"
         );
         sleep $delay;
         $delay *= $factor;

--- a/t/43-cli-api.t
+++ b/t/43-cli-api.t
@@ -13,6 +13,7 @@ use Mojo::Server::Daemon;
 use Mojo::JSON qw(decode_json);
 use Mojo::File qw(tempfile);
 use Mojo::Util qw(encode);
+use Test::MockModule;
 use OpenQA::CLI;
 use OpenQA::CLI::api;
 use OpenQA::Test::Case;
@@ -468,6 +469,13 @@ EOF
     ($stdout, $stderr, @result) = capture sub { $api->run(@params) };
     like $stderr, qr/Connection refused/, 'aborts on connection refused';
     like $stderr, qr/failed.*retrying/, 'requests are retried on error if requested';
+
+    {
+        my $mock_tx = Test::MockModule->new('Mojo::Transaction::HTTP');
+        $mock_tx->redefine(error => sub { return undef });
+        ($stdout, $stderr, @result) = capture sub { $api->run(@params) };
+        like $stderr, qr/hit connection error, retrying/, 'shows connection error without details when error is undef';
+    }
 };
 
 subtest 'Pretty print JSON' => sub {


### PR DESCRIPTION
Motivation:
When network connection failures occur, the response code defaults to 0.
This prints as "hit error 0", which is confusing and lacks clarity.

Design Choices:
Map code 0 to "connection error" while retaining other HTTP status codes.
Mock Mojo transaction errors to verify the fallback formatting in tests.

Benefits:
Provides much clearer error messages when network connectivity issues occur.