### PR TITLE
fix: Call open_sqlite_database with correct arguments

### DIFF
--- a/lib/OpenQA/CacheService/DB.pm
+++ b/lib/OpenQA/CacheService/DB.pm
@@ -38,6 +38,6 @@ sub open_sqlite_database ($log, $db_file) {
     return $sqlite;
 }
 
-sub open_default_sqlite_database ($log, $location) { open_sqlite_database($location, db_file($location)) }
+sub open_default_sqlite_database ($log, $location) { open_sqlite_database($log, db_file($location)) }
 
 1;


### PR DESCRIPTION
    Can't locate object method "info" via package "/var/lib/openqa/cache"
    (perhaps you forgot to load "/var/lib/openqa/cache"?) at
    /usr/share/openqa/script/../lib/OpenQA/CacheService/DB.pm line 27.

Without having a deeper look I think this commit should fix it.

Issue: https://progress.opensuse.org/issues/204252