### PR TITLE
Separate openQA job history for independent submissions via custom keys

### DIFF
--- a/assets/javascripts/job_next_previous.js
+++ b/assets/javascripts/job_next_previous.js
@@ -18,6 +18,7 @@ function setupJobNextPrevious() {
   };
 
   const tableElement = document.getElementById('job_next_previous_table');
+  const strictToggle = document.getElementById('next_previous_strict');
   const table = $(tableElement).DataTable({
     ajax: {
       url: tableElement.dataset.ajaxUrl,
@@ -27,6 +28,9 @@ function setupJobNextPrevious() {
         }
         if (typeof params.next_limit != 'undefined') {
           d.next_limit = params.next_limit.toString();
+        }
+        if (strictToggle && strictToggle.checked) {
+          d.strict = '1';
         }
       }
     },
@@ -71,6 +75,11 @@ function setupJobNextPrevious() {
     setupLazyLoadingFailedSteps();
     document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(e => new bootstrap.Tooltip(e));
   });
+  if (strictToggle) {
+    strictToggle.addEventListener('change', function () {
+      table.ajax.reload();
+    });
+  }
 }
 
 function renderMarks(data, type, row) {

--- a/assets/javascripts/job_next_previous.js
+++ b/assets/javascripts/job_next_previous.js
@@ -19,6 +19,9 @@ function setupJobNextPrevious() {
 
   const tableElement = document.getElementById('job_next_previous_table');
   const strictToggle = document.getElementById('next_previous_strict');
+  if (strictToggle && params.strict && params.strict[0] === '1') {
+    strictToggle.checked = true; // restore the shared/bookmarked strict view
+  }
   const table = $(tableElement).DataTable({
     ajax: {
       url: tableElement.dataset.ajaxUrl,
@@ -77,6 +80,13 @@ function setupJobNextPrevious() {
   });
   if (strictToggle) {
     strictToggle.addEventListener('change', function () {
+      const p = parseQueryParams();
+      if (strictToggle.checked) {
+        p.strict = ['1'];
+      } else {
+        delete p.strict;
+      }
+      updateQueryParams(p); // keep the view bookmarkable/shareable
       table.ajax.reload();
     });
   }

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -139,6 +139,38 @@ lookup using globbing. This is particularly helpful for the following scenarios:
   version. For example by specifying `16.1:PR-*` in the medium type, openQA will
   automatically match and use this type for any scheduled product where the
   `VERSION` begins with `16.1:PR-`.
+  Note that overloading `VERSION` this way pollutes the version string that test
+  code may rely on being a "proper" value (e.g. `16.1`); to keep `VERSION`
+  pristine, prefer the dedicated
+  [history isolation keys](#history-isolation-keys) mechanism instead.
+
+<a id="history-isolation-keys"></a>
+#### Separating the history of independent submissions
+
+Features that operate on the history of a scenario (bug reference
+[carry-over](#carry-over), the investigation "last good" build and the "Next &
+Previous" list) match jobs by the scenario keys `DISTRI`, `VERSION`, `FLAVOR`,
+`ARCH`, `TEST` and `MACHINE`. Independent submissions (e.g. different
+pull-requests) that share all these keys are therefore treated as one
+consecutive history, causing unintended carry-overs and misleading "last good"
+builds.
+
+Set the job setting `_HISTORY_ISOLATION_KEYS` to a comma-separated list of other
+job settings whose values must additionally match for two jobs to share a
+history. For example, tagging each submission with a `PR_ID` and setting
+`_HISTORY_ISOLATION_KEYS=PR_ID` keeps `VERSION` pristine while separating the
+history per pull-request:
+
+```
+VERSION=16.1
+PR_ID=1234
+_HISTORY_ISOLATION_KEYS=PR_ID
+```
+
+Carry-over and investigation isolate on all declared keys
+automatically. The "Next & Previous" tab keeps showing the generalized history
+by default and offers a switch to the isolated ("strict") view when a job
+declares isolation keys.
 
 ### Test Suites
 
@@ -734,6 +766,11 @@ Jenkins.
 > For an approach to add bug references based on a search expression found
 > in the job reason for incomplete jobs or job logs consider to
 > [Enable custom hook scripts on "job done" based on result](Installing.md#enable_custom_hook_scripts_on_job_done_based_on_result).
+
+> **NOTE:**
+> To keep the carry-over of independent submissions (e.g. pull-requests) apart
+> despite otherwise equal scenario keys, use
+> [history isolation keys](#history-isolation-keys).
 
 ### Pinning comments as group description
 

--- a/lib/OpenQA/Schema/Result/JobNextPrevious.pm
+++ b/lib/OpenQA/Schema/Result/JobNextPrevious.pm
@@ -17,23 +17,40 @@ __PACKAGE__->add_columns(source => {data_type => 'text'});
 # do not attempt to deploy() this view
 __PACKAGE__->result_source_instance->is_virtual(1);
 
-__PACKAGE__->result_source_instance->view_definition(
-    <<~'END_SQL'
-    WITH allofjobs AS(
-        SELECT me.* FROM jobs me
-            WHERE me.state=?
-                AND me.result NOT IN (?, ?, ?, ?, ?, ?)
-                AND me.DISTRI=? AND me.VERSION=? AND me.FLAVOR=? AND me.ARCH=?
-                AND me.TEST=? AND me.MACHINE=?
-    )
-    ((SELECT *, 'l' AS source FROM jobs
-        WHERE DISTRI=? AND VERSION=? AND FLAVOR=? AND ARCH=? AND TEST=? AND MACHINE=?
-        ORDER BY ID DESC LIMIT 1)
-    UNION (SELECT *, 'n' AS source FROM allofjobs WHERE id > ? ORDER BY ID ASC LIMIT ? + 1)
-    UNION (SELECT *, 'p' AS source FROM allofjobs WHERE id < ? ORDER BY ID DESC LIMIT ? + 1)
-    UNION (SELECT *, 'c' AS source FROM jobs WHERE id = ?)
-    ORDER BY ID DESC)
-    END_SQL
-);
+# Build the "Next & Previous" query SQL. When $isolation_key_count > 0, an
+# `EXISTS` clause per history isolation key is folded into the `allofjobs` CTE so
+# the whole result (including the "latest" row) is restricted to the isolated
+# history. Benchmarks on production (see tasks/096) showed this EXISTS-in-CTE
+# form is stable (~2x baseline worst case, no cold-cache cliff) whereas wrapping
+# the view with an outer `id IN (subquery)` spiked to several seconds cold.
+sub query_sql ($isolation_key_count = 0) {
+    my $exists = join '',
+      map { "\n            AND EXISTS (SELECT 1 FROM job_settings s WHERE s.job_id=me.id AND s.key=? AND s.value=?)" }
+      1 .. $isolation_key_count;
+    # with isolation the "latest" row must also respect the isolated history, so
+    # it is taken from `allofjobs` (which carries the EXISTS) instead of `jobs`
+    my $latest_from = $isolation_key_count ? 'allofjobs' : 'jobs';
+    my $latest_where
+      = $isolation_key_count
+      ? ''
+      : 'WHERE DISTRI=? AND VERSION=? AND FLAVOR=? AND ARCH=? AND TEST=? AND MACHINE=? ';
+    return <<~"END_SQL";
+        WITH allofjobs AS(
+            SELECT me.* FROM jobs me
+                WHERE me.state=?
+                    AND me.result NOT IN (?, ?, ?, ?, ?, ?)
+                    AND me.DISTRI=? AND me.VERSION=? AND me.FLAVOR=? AND me.ARCH=?
+                    AND me.TEST=? AND me.MACHINE=?$exists
+        )
+        ((SELECT *, 'l' AS source FROM $latest_from
+            ${latest_where}ORDER BY ID DESC LIMIT 1)
+        UNION (SELECT *, 'n' AS source FROM allofjobs WHERE id > ? ORDER BY ID ASC LIMIT ? + 1)
+        UNION (SELECT *, 'p' AS source FROM allofjobs WHERE id < ? ORDER BY ID DESC LIMIT ? + 1)
+        UNION (SELECT *, 'c' AS source FROM jobs WHERE id = ?)
+        ORDER BY ID DESC)
+        END_SQL
+}
+
+__PACKAGE__->result_source_instance->view_definition(query_sql());
 
 1;

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1972,7 +1972,9 @@ good" job in the same scenario.
 =cut
 
 sub investigate ($self, %args) {
-    my @previous = $self->_previous_scenario_jobs;
+    # isolate on all declared history isolation keys so "last good" refers to
+    # this job's own isolated history (e.g. the same PR), not an unrelated one
+    my @previous = $self->_previous_scenario_jobs(undef, {}, undef);
     return {error => 'No previous job in this scenario, cannot provide hints'} unless @previous;
     my %inv;
     return {error => 'No result directory available for current job'} unless $self->result_dir();

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1776,8 +1776,9 @@ sub _carry_over_candidate ($self) {
     # we only do carryover for jobs with some kind of (soft) failure
     return undef if $current_failure_reason eq 'GOOD';
 
-    # search for previous jobs
-    for my $job ($self->_previous_scenario_jobs($lookup_depth)) {
+    # search for previous jobs, isolating on all declared history isolation keys
+    # so bugrefs are not carried over between independent submissions
+    for my $job ($self->_previous_scenario_jobs($lookup_depth, {}, undef)) {
         my $job_fr = $job->_failure_reason;
         log_debug(sprintf "$label: checking take over from %d: _failure_reason=%s", $job->id, $job_fr);
         if ($job_fr eq $current_failure_reason) {

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1669,8 +1669,35 @@ sub needle_dir ($self) {
     return $self->{_needle_dir};
 }
 
-# return the last X complete jobs of the same scenario
-sub _previous_scenario_jobs ($self, $rows = undef, $search_attrs = {}) {
+# names of job settings that additionally separate the scenario history, e.g.
+# to keep the history of independent submissions (PRs) apart despite otherwise
+# equal scenario keys. The referenced settings themselves are ordinary,
+# test-visible settings; only this meta-setting carries the underscore prefix.
+use constant HISTORY_ISOLATION_SETTING => '_HISTORY_ISOLATION_KEYS';
+
+# The isolation keys declared by this job via HISTORY_ISOLATION_SETTING as a
+# sorted array-ref. Returns an empty array-ref when the meta-setting is unset.
+sub history_isolation_keys ($self) {
+    my $declared = $self->settings_hash->{HISTORY_ISOLATION_SETTING()};
+    return [] unless defined $declared && length $declared;
+    return [sort grep { length } split /\s*,\s*/, $declared];
+}
+
+# The key/value pairs to additionally match on to isolate the history, limited
+# to the requested subset of $self's declared isolation keys. An undefined
+# $keys means "all declared keys"; an empty array-ref means "none".
+sub history_isolation_values ($self, $keys = undef) {
+    $keys //= $self->history_isolation_keys;
+    return {} unless @$keys;
+    my $settings = $self->settings_hash;
+    return {map { $_ => $settings->{$_} } @$keys};
+}
+
+# return the last X complete jobs of the same scenario. When $isolation_keys is
+# passed (an array-ref subset of the declared isolation keys, or undef for all
+# declared keys), jobs are additionally required to match $self's values for
+# those job settings so that independent histories stay separate.
+sub _previous_scenario_jobs ($self, $rows = undef, $search_attrs = {}, $isolation_keys = []) {
     my $schema = $self->result_source->schema;
     my $conds = [{'me.state' => 'done'}, {'me.result' => [COMPLETE_RESULTS]}, {'me.id' => {'<', $self->id}}];
     for my $key (SCENARIO_WITH_MACHINE_KEYS) {
@@ -1681,6 +1708,19 @@ sub _previous_scenario_jobs ($self, $rows = undef, $search_attrs = {}) {
         rows => $rows,
         %$search_attrs,
     );
+    my $isolation = $self->history_isolation_values($isolation_keys);
+    if (my @keys = sort keys %$isolation) {
+        # match each isolation key/value via a correlated job_settings subquery
+        my $settings_rs = $schema->resultset('JobSettings');
+        for my $key (@keys) {
+            push @$conds,
+              {
+                'me.id' => {
+                    -in =>
+                      $settings_rs->search({key => $key, value => $isolation->{$key}})->get_column('job_id')->as_query
+                }};
+        }
+    }
     return $schema->resultset('Jobs')->search({-and => $conds}, \%attrs)->all;
 }
 

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -584,11 +584,23 @@ sub next_previous_jobs_query ($self, $job, $jobid, %args) {
     }
     push @params, $jobid, $n_limit, $jobid, $p_limit, $jobid;
 
-    my $jobs_rs = $self->result_source->schema->resultset('JobNextPrevious')->search(
-        {},
-        {
-            bind => \@params
-        });
+    my $schema = $self->result_source->schema;
+    my $jobs_rs = $schema->resultset('JobNextPrevious')->search({}, {bind => \@params});
+
+    # optionally isolate the history to the requested subset of the job's
+    # declared isolation keys; keep the raw-SQL view for the base scenario and
+    # filter its (already limited) result set via correlated job_settings
+    # subqueries to preserve performance
+    my $isolation = $job->history_isolation_values($args{isolation_keys});
+    if (my @keys = sort keys %$isolation) {
+        my $settings_rs = $schema->resultset('JobSettings');
+        my @conds = map {
+            {'me.id' =>
+                  {-in => $settings_rs->search({key => $_, value => $isolation->{$_}})->get_column('job_id')->as_query}}
+        } @keys;
+        # never filter out the current job so the table can still anchor on it
+        $jobs_rs = $jobs_rs->search({-or => [{'me.id' => $jobid}, {-and => \@conds}]});
+    }
     return $jobs_rs;
 }
 

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -573,35 +573,32 @@ sub cancel_by_settings (
 sub next_previous_jobs_query ($self, $job, $jobid, %args) {
     my $p_limit = $args{previous_limit};
     my $n_limit = $args{next_limit};
-    my @params = (
-        'done',    # only consider jobs with state 'done'
-        OpenQA::Jobs::Constants::ABORTED_RESULTS,    # ignore aborted results
-    );
-    for (1 .. 2) {
-        for my $key (OpenQA::Schema::Result::Jobs::SCENARIO_WITH_MACHINE_KEYS) {
-            push @params, $job->get_column($key);
-        }
-    }
-    push @params, $jobid, $n_limit, $jobid, $p_limit, $jobid;
-
     my $schema = $self->result_source->schema;
-    my $jobs_rs = $schema->resultset('JobNextPrevious')->search({}, {bind => \@params});
 
     # optionally isolate the history to the requested subset of the job's
-    # declared isolation keys; keep the raw-SQL view for the base scenario and
-    # filter its (already limited) result set via correlated job_settings
-    # subqueries to preserve performance
+    # declared isolation keys by folding an EXISTS clause per key into the CTE
+    # (see OpenQA::Schema::Result::JobNextPrevious::query_sql and tasks/096 for
+    # the benchmark that motivated this form over an outer id-IN filter)
     my $isolation = $job->history_isolation_values($args{isolation_keys});
-    if (my @keys = sort keys %$isolation) {
-        my $settings_rs = $schema->resultset('JobSettings');
-        my @conds = map {
-            {'me.id' =>
-                  {-in => $settings_rs->search({key => $_, value => $isolation->{$_}})->get_column('job_id')->as_query}}
-        } @keys;
-        # never filter out the current job so the table can still anchor on it
-        $jobs_rs = $jobs_rs->search({-or => [{'me.id' => $jobid}, {-and => \@conds}]});
-    }
-    return $jobs_rs;
+    my @iso_keys = sort keys %$isolation;
+
+    # binds for the `allofjobs` CTE: state, aborted results, scenario keys, then
+    # the (key, value) pairs for each isolation EXISTS clause
+    my @cte = ('done', OpenQA::Jobs::Constants::ABORTED_RESULTS);
+    push @cte, $job->get_column($_) for OpenQA::Schema::Result::Jobs::SCENARIO_WITH_MACHINE_KEYS;
+    push @cte, $_, $isolation->{$_} for @iso_keys;
+
+    # binds for the `l` (latest) subquery: only the isolation-free view still
+    # filters by scenario keys there; the isolated variant reuses the CTE
+    my @latest = @iso_keys ? () : map { $job->get_column($_) } OpenQA::Schema::Result::Jobs::SCENARIO_WITH_MACHINE_KEYS;
+
+    my @params = (@cte, @latest, $jobid, $n_limit, $jobid, $p_limit, $jobid);
+    my $rs = $schema->resultset('JobNextPrevious');
+    # generalized: reuse the static view. isolated: override the view SQL with
+    # the EXISTS-augmented variant, binding its parameters via the `from` clause
+    return $rs->search({}, {bind => \@params}) unless @iso_keys;
+    my $sql = OpenQA::Schema::Result::JobNextPrevious::query_sql(scalar @iso_keys);
+    return $rs->search({}, {from => \["($sql) me", @params]});
 }
 
 

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -734,10 +734,16 @@ sub job_next_previous_ajax ($self) {
 
     my $schema = $self->schema;
     my $jobs_rs = $schema->resultset('Jobs');
+    # history isolation: `strict=1` isolates on all declared keys, an explicit
+    # `isolation_keys` comma-list selects a subset; default is the generalized
+    # history matching legacy behavior
+    my $isolation_keys
+      = $self->param('strict') ? undef : [grep { length } split /\s*,\s*/, $self->param('isolation_keys') // ''];
     my @jobs = $jobs_rs->next_previous_jobs_query(
         $main_job, $main_jobid,
         previous_limit => $p_limit,
         next_limit => $n_limit,
+        isolation_keys => $isolation_keys,
     )->all;
 
     my $job_ids = [map { $_->id } @jobs];

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -1252,6 +1252,23 @@ subtest 'history isolation keys separate the scenario history' => sub {
           'undef isolation with no declared keys behaves generalized';
     };
 
+    subtest 'next_previous_jobs_query honors isolation keys' => sub {
+        # the raw view returns rows under multiple sources (l/n/p/c); assert on
+        # the unique id set which is the meaningful isolation contract
+        my $uniq_ids = sub ($j, %a) {
+            my %seen;
+            $seen{$_->id} = 1
+              for $jobs->next_previous_jobs_query($j, $j->id, previous_limit => 10, next_limit => 10, %a)->all;
+            return [sort { $a <=> $b } keys %seen];
+        };
+        my @all = sort { $a <=> $b } ($pr1a->id, $pr1b->id, $pr2->id, $cur->id);
+        my @same = sort { $a <=> $b } ($pr1a->id, $pr1b->id, $cur->id);
+        # empty key-set = generalized (matches the controller default), undef/full = strict
+        is_deeply $uniq_ids->($cur, isolation_keys => []), \@all, 'generalized query returns all PRs plus current';
+        is_deeply $uniq_ids->($cur, isolation_keys => undef), \@same, 'strict query keeps same-PR jobs and current';
+        is_deeply $uniq_ids->($cur, isolation_keys => ['PR_ID']), \@same, 'isolating on PR_ID keeps same-PR jobs';
+    };
+
     subtest 'investigation picks last good from the isolated history' => sub {
         my %inv_s = (%settings, TEST => 'inviso', DISTRI => 'inv-distri', _HISTORY_ISOLATION_KEYS => 'PR_ID');
         my $good_same = $mk->(%inv_s, PR_ID => 1);    # isolated last good

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -1251,6 +1251,18 @@ subtest 'history isolation keys separate the scenario history' => sub {
         is_deeply [map { $_->id } $now->_previous_scenario_jobs(undef, {}, undef)], [$prev->id],
           'undef isolation with no declared keys behaves generalized';
     };
+
+    subtest 'investigation picks last good from the isolated history' => sub {
+        my %inv_s = (%settings, TEST => 'inviso', DISTRI => 'inv-distri', _HISTORY_ISOLATION_KEYS => 'PR_ID');
+        my $good_same = $mk->(%inv_s, PR_ID => 1);    # isolated last good
+        my $good_other = $mk->(%inv_s, PR_ID => 2);    # unrelated PR, must be ignored
+        my $cur = _job_create({%inv_s, PR_ID => 1});
+        $cur->update({state => DONE, result => FAILED});
+        $cur->discard_changes;
+        $cur->create_result_dir;
+        my $inv = $cur->investigate;
+        is $inv->{last_good}{link}, '/tests/' . $good_same->id, 'last good is the same-PR job, not the newer other PR';
+    };
 };
 
 done_testing();

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -1210,4 +1210,47 @@ subtest 'adding logs to result file list, including virtio console logs' => sub 
     is_deeply $files, \@expected, 'list of existing result files returned' or always_explain $files;
 };
 
+subtest 'history isolation keys separate the scenario history' => sub {
+    my %s = (%settings, TEST => 'isolation', DISTRI => 'iso-distri');
+    my $mk = sub (%extra) {
+        my $job = _job_create({%s, %extra});
+        $job->update({state => DONE, result => PASSED});
+        $job->discard_changes;
+        return $job;
+    };
+    # independent PRs sharing every scenario key but differing in PR_ID
+    my %iso = (PACKAGE_TESTED => 'vim', _HISTORY_ISOLATION_KEYS => 'PR_ID,PACKAGE_TESTED');
+    my $pr1a = $mk->(%iso, PR_ID => 1);
+    my $pr1b = $mk->(%iso, PR_ID => 1);
+    my $pr2 = $mk->(%iso, PR_ID => 2);
+    my $cur = $mk->(%iso, PR_ID => 1);
+
+    is_deeply $cur->history_isolation_keys, [qw(PACKAGE_TESTED PR_ID)], 'declared keys parsed and sorted';
+    is_deeply $cur->history_isolation_values, {PR_ID => 1, PACKAGE_TESTED => 'vim'}, 'all declared values';
+    is_deeply $cur->history_isolation_values(['PR_ID']), {PR_ID => 1}, 'subset of values';
+    is_deeply $cur->history_isolation_values([]), {}, 'empty subset yields no values';
+
+    my $ids = sub ($j, @args) {
+        [sort { $a <=> $b } map { $_->id } $j->_previous_scenario_jobs(@args)]
+    };
+    my @same_pr = sort { $a <=> $b } ($pr1a->id, $pr1b->id);
+    my @all = sort { $a <=> $b } ($pr1a->id, $pr1b->id, $pr2->id);
+    is_deeply $ids->($cur), \@all, 'without isolation all previous jobs match';
+    is_deeply $ids->($cur, undef, {}, undef), \@same_pr, 'full isolation keeps only same PR and package';
+    is_deeply $ids->($cur, undef, {}, ['PR_ID']), \@same_pr, 'isolating on PR_ID only keeps same-PR jobs';
+    is_deeply $ids->($cur, undef, {}, ['PACKAGE_TESTED']), \@all,
+      'isolating on same package keeps all PRs testing that package';
+    is_deeply $ids->($cur, undef, {}, []), \@all, 'empty isolation key-set matches generalized history';
+
+    subtest 'job without isolation meta-setting is unaffected' => sub {
+        my %p = (%settings, TEST => 'plain', DISTRI => 'plain-distri');
+        my $prev = _job_create(\%p);
+        $prev->update({state => DONE, result => PASSED});
+        my $now = _job_create(\%p);
+        is_deeply $now->history_isolation_keys, [], 'no declared keys';
+        is_deeply [map { $_->id } $now->_previous_scenario_jobs(undef, {}, undef)], [$prev->id],
+          'undef isolation with no declared keys behaves generalized';
+    };
+};
+
 done_testing();

--- a/t/17-labels_carry_over.t
+++ b/t/17-labels_carry_over.t
@@ -193,6 +193,37 @@ subtest 'failure reason still computed without results, modules without results 
     like $curr_job->_failure_reason, qr/amarok:none,aplay:failed,.*yast2_lan:failed,.*zypper_up:none/, 'failure reason';
 };
 
+subtest 'history isolation keys prevent carry-over between independent PRs' => sub {
+    my %base = (
+        DISTRI => 'iso',
+        VERSION => '1',
+        FLAVOR => 'f',
+        ARCH => 'x86_64',
+        TEST => 'carryiso',
+        MACHINE => 'm',
+        BUILD => 'b',
+        _HISTORY_ISOLATION_KEYS => 'PR_ID',
+    );
+    my $mk = sub ($pr) {
+        my $j = $jobs->create_from_settings({%base, PR_ID => $pr});
+        $j->insert_module({name => 'a', category => 'a', script => 'a', flags => {}});
+        $j->update_module('a', {result => 'fail', details => []});
+        $j->update({state => DONE, result => FAILED});
+        $j->discard_changes;
+        return $j;
+    };
+    my $prev = $mk->(1);
+    $prev->comments->create({text => 'bsc#4321', user_id => $schema->resultset('Users')->first->id});
+
+    my $other_pr = $mk->(2);
+    $other_pr->carry_over_bugrefs;
+    is $other_pr->comments->count, 0, 'no carry-over to a different PR despite matching scenario+failure';
+
+    my $same_pr = $mk->(1);
+    $same_pr->carry_over_bugrefs;
+    like $same_pr->comments->first->text, qr/bsc#4321/, 'carry-over still happens within the same PR';
+};
+
 subtest 'too many state changes' => sub {
     $t->app->config->{carry_over}->{state_changes_limit} = 1;
     my $mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
@@ -201,7 +232,7 @@ subtest 'too many state changes' => sub {
             {99961 => 'a:failed', 99962 => 'b:failed', 99963 => 'c:failed'}->{$self->id};
         });
     $mock->redefine(
-        _previous_scenario_jobs => sub ($self, $depth) {
+        _previous_scenario_jobs => sub ($self, $depth = undef, $search_attrs = {}, $isolation_keys = []) {
             map { $jobs->find($_) } qw(99962 99961);
         });
     my $job = $jobs->find(99963);

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -349,6 +349,16 @@ subtest 'history isolation toggle for "Next & Previous"' => sub {
     ok !$strict{$base_id + 4}, 'strict view excludes jobs from the other PR';
     ok $strict{$base_id + 1}, 'strict view keeps same-PR jobs';
     ok $strict{$current}, 'strict view keeps the current job';
+
+    subtest 'toggle renders and syncs the URL' => sub {
+        $driver->get("/tests/$current#next_previous");
+        my $toggle = wait_for_element selector => '#next_previous_strict', desc => 'strict toggle present';
+        like $driver->find_element('label[for=next_previous_strict]')->get_text, qr/isolate history by PR_ID/,
+          'toggle labelled with the isolation key';
+        $toggle->click;
+        wait_for_ajax msg => 'table reloaded after enabling strict';
+        like $driver->get_current_url, qr/strict=1/, 'URL reflects the strict view for sharing';
+    };
 };
 
 kill_driver();

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -312,5 +312,44 @@ subtest 'server-side limit has precedence over user-specified limit' => sub {
     like $info->get_text, qr/previous.*6.*exceeded/is, 'info about previous jobs being limited shown';
 };
 
+subtest 'history isolation toggle for "Next & Previous"' => sub {
+    my $jobs_rs = $schema->resultset('Jobs');
+    my $base_id = 99500;
+    my %base = (
+        group_id => 1001,
+        priority => 35,
+        result => 'passed',
+        state => 'done',
+        TEST => 'isoscen',
+        FLAVOR => 'DVD',
+        DISTRI => 'opensuse',
+        BUILD => '0091',
+        VERSION => '13.1',
+        MACHINE => '32bit',
+        ARCH => 'i586',
+    );
+    # 3 jobs of PR 1 and 2 jobs of PR 2, all sharing the scenario
+    for my $spec ([1, 1], [2, 1], [3, 1], [4, 2], [5, 2]) {
+        my ($n, $pr) = @$spec;
+        $jobs_rs->create(
+            {
+                %base,
+                id => $base_id + $n,
+                settings => [{key => 'PR_ID', value => $pr}, {key => '_HISTORY_ISOLATION_KEYS', value => 'PR_ID'}],
+            });
+    }
+    my $current = $base_id + 3;    # a PR 1 job
+
+    $t->get_ok("/tests/$current/ajax", 'generalized next/previous')->status_is(200);
+    my %gen = map { $_->{id} => 1 } @{$t->tx->res->json->{data}};
+    ok $gen{$base_id + 4}, 'generalized view includes a job from the other PR';
+
+    $t->get_ok("/tests/$current/ajax?strict=1", 'strict next/previous')->status_is(200);
+    my %strict = map { $_->{id} => 1 } @{$t->tx->res->json->{data}};
+    ok !$strict{$base_id + 4}, 'strict view excludes jobs from the other PR';
+    ok $strict{$base_id + 1}, 'strict view keeps same-PR jobs';
+    ok $strict{$current}, 'strict view keeps the current job';
+};
+
 kill_driver();
 done_testing();

--- a/templates/webapi/test/job_next_previous.html.ep
+++ b/templates/webapi/test/job_next_previous.html.ep
@@ -34,6 +34,15 @@
         </div>
     </div>
 </div>
+% my $isolation_keys = $job->history_isolation_keys;
+% if ($isolation_keys && @$isolation_keys) {
+    <div class="form-check form-switch mb-2">
+        <input class="form-check-input" type="checkbox" role="switch" id="next_previous_strict">
+        <label class="form-check-label" for="next_previous_strict">
+            Strict scenario (isolate history by <%= join ', ', @$isolation_keys %>)
+        </label>
+    </div>
+% }
 <div>
     <table id="job_next_previous_table" class="overview table table-striped no-wrap" style="width: 100%"
       data-ajax-url="<%= url_for('job_next_previous_ajax', testid => $testid) %>">


### PR DESCRIPTION
## Motivation

Multiple openQA features build on the history of results within a scenario, matching jobs by the fixed scenario keys `DISTRI VERSION FLAVOR ARCH TEST MACHINE`. Independent submissions (e.g. different PRs) that share all these keys are treated as one consecutive history, causing:

- bug references carried over between unrelated submissions,
- the investigation tab picking "last good" from an unrelated submission,
- cluttered "Next & Previous" lists.

The existing workaround encodes an identifier into `VERSION` (e.g. `VERSION=16.1:PR-1234`), which pollutes the version string that test code expects to be "proper" (e.g. `16.1`).

Related issues: [poo#200952](https://progress.opensuse.org/issues/200952), [poo#200985](https://progress.opensuse.org/issues/200985)

## What this does

Introduces an opt-in `_HISTORY_ISOLATION_KEYS` job setting: a comma-separated list of other (ordinary, test-visible) job settings whose values must additionally match for two jobs to share a history. `VERSION` and the core scenario keys stay untouched.

- **Primitive:** `_previous_scenario_jobs` gains a key-set argument (`undef` = all declared keys, `[]` = none); `history_isolation_keys` / `history_isolation_values` read the meta-setting.
- **Carry-over** and **investigation** isolate on all declared keys automatically; jobs without the setting behave exactly as before.
- **"Next & Previous"** exposes a UI toggle (shown only when a job declares isolation keys) to switch between the generalized (default) and strict/isolated views; the choice is reflected in the URL for sharing.

* Custom isolation settings
<img width="505" height="209" alt="Screenshot_20260717_163032_oQA_isolation_settings" src="https://github.com/user-attachments/assets/baace324-38d7-419b-aed3-09a537a8dd07" />

* Default, old non-strict mode
<img width="498" height="427" alt="Screenshot_20260717_162952_oQA_non_strict" src="https://github.com/user-attachments/assets/3f7f7e86-bb6c-4154-802d-a7efcdd73719" />

* New, optional strict mode
<img width="498" height="427" alt="Screenshot_20260717_163014_oQA_strict_scenario" src="https://github.com/user-attachments/assets/07e69ae1-474b-492b-986d-b79fdf36b93b" />

## Benchmark (production, osd)

Measured on the largest history in production (13,683 jobs), with a zero-selectivity isolation value (worst case):

| variant | execution (cold / warm) |
|---|---|
| generalized baseline (unchanged) | 76 / 73–84 ms |
| id-IN wrapper (initial approach, replaced) | **5548** / 176–302 ms |
| EXISTS-in-CTE (shipped) | 154 / 140–154 ms |

The generalized default path is byte-for-byte the unchanged view. The strict path is bounded at ~2× worst case with no cold cliff; with realistic selective keys (a handful of jobs per PR) it will be cheaper than baseline.

## Reviewer notes

**Please focus on:**

- **The isolated SQL.** `JobNextPrevious::query_sql($n)` builds the view SQL dynamically with an `EXISTS` clause per isolation key folded into the `allofjobs` CTE, and the isolated "latest" row is taken from the CTE. Check the bind-parameter ordering in `next_previous_jobs_query` matches the generated SQL (CTE binds → optional latest-scenario binds → n/p/c binds), and that the raw `from => \[$sql, @binds]` path is sound.
- **Isolation query correctness / injection surface.** Isolation values reach SQL as bind parameters (both the `EXISTS` path and the `_previous_scenario_jobs` subquery in `Jobs.pm`); confirm no value is interpolated into SQL text.
- **No-op guarantee for existing jobs.** Every isolation path is gated on a job actually declaring `_HISTORY_ISOLATION_KEYS`. The generalized "Next & Previous" query should be identical to today (see `query_sql(0)`).
- **Naming/namespacing of `_HISTORY_ISOLATION_KEYS`** — the underscore-prefixed, persisted, openQA-internal convention (like `_TRIGGER_JOB_DONE_HOOK`). Is this the desired setting name and semantics?
- **AC1/AC2 (poo#200952):** the default "Next & Previous" view stays generalized and the dashboard is untouched — this matches current behavior, but confirm this is the wanted default before broader rollout.

**Less relevant for review:**

- One earlier commit describes the "Next & Previous" isolation as "correlated job_settings subqueries" (the initial id-IN approach) — this is **intentionally superseded** by the later `perf` commit (EXISTS-in-CTE). Review the final state, not that commit's approach in isolation.
- Frontend JS/template (`job_next_previous.js`, `.html.ep`) and the docs change are low-risk; the toggle is covered end-to-end by the AJAX + Selenium tests in `t/ui/16-tests_job_next_previous.t`.

**Out of scope / follow-up (not in this PR):**

- Migrating production job templates (`os-autoinst-distri-opensuse`, `opensuse-jobgroups`, `qam-openqa-yml`) off the `VERSION` hack to `PR_ID` + `_HISTORY_ISOLATION_KEYS`.
- Per-key UI selection (multi-select instead of a boolean); the backend key-set model already supports it.
- The `openqa-investigate` retrigger bot lives in `os-autoinst/scripts` and is unaffected here.