### PR TITLE
feat: Add reserved SUBMISSION_ID default history isolation key

### DIFF
--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -155,22 +155,31 @@ pull-requests) that share all these keys are therefore treated as one
 consecutive history, causing unintended carry-overs and misleading "last good"
 builds.
 
-Set the job setting `_HISTORY_ISOLATION_KEYS` to a comma-separated list of other
-job settings whose values must additionally match for two jobs to share a
-history. For example, tagging each submission with a `PR_ID` and setting
-`_HISTORY_ISOLATION_KEYS=PR_ID` keeps `VERSION` pristine while separating the
-history per pull-request:
+The simplest way to enable this is the reserved, well-known job setting
+`SUBMISSION_ID`. Tagging each independent submission with a distinct
+`SUBMISSION_ID` value keeps `VERSION` pristine while separating the history per
+submission, without any further configuration:
 
 ```
 VERSION=16.1
-PR_ID=1234
-_HISTORY_ISOLATION_KEYS=PR_ID
+SUBMISSION_ID=1234
 ```
 
-Carry-over and investigation isolate on all declared keys
-automatically. The "Next & Previous" tab keeps showing the generalized history
-by default and offers a switch to the isolated ("strict") view when a job
-declares isolation keys.
+For finer control, set the meta-setting `_HISTORY_ISOLATION_KEYS` to a
+comma-separated list of the job settings whose values must additionally match
+for two jobs to share a history:
+
+- unset (default): isolate on `SUBMISSION_ID` if the job carries it, otherwise
+  no isolation (so existing jobs are unaffected);
+- empty (`_HISTORY_ISOLATION_KEYS=`): isolation disabled, even if
+  `SUBMISSION_ID` is present;
+- explicit keys (e.g. `_HISTORY_ISOLATION_KEYS=PR_ID,SUBMISSION_ID`): exactly
+  those keys, overriding or extending the default.
+
+Carry-over and investigation isolate on all declared keys automatically. The
+"Next & Previous" tab keeps showing the generalized history by default and
+offers a switch to the isolated ("strict") view when a job has isolation keys
+in effect.
 
 ### Test Suites
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1676,11 +1676,22 @@ sub needle_dir ($self) {
 # test-visible settings; only this meta-setting carries the underscore prefix.
 use constant HISTORY_ISOLATION_SETTING => '_HISTORY_ISOLATION_KEYS';
 
-# The isolation keys declared by this job via HISTORY_ISOLATION_SETTING as a
-# sorted array-ref. Returns an empty array-ref when the meta-setting is unset.
+# reserved, well-known isolation key used as the default so tests can enable the
+# feature by just setting SUBMISSION_ID without supplying HISTORY_ISOLATION_SETTING
+use constant HISTORY_ISOLATION_DEFAULT_KEY => 'SUBMISSION_ID';
+
+# The isolation keys effective for this job as a sorted array-ref. Semantics of the
+# HISTORY_ISOLATION_SETTING meta-setting:
+#   - unset: default to HISTORY_ISOLATION_DEFAULT_KEY, but only if the job
+#     actually carries that setting (so it stays a no-op for existing jobs);
+#   - empty string: isolation explicitly disabled;
+#   - comma-separated keys: exactly those keys (overrides/extends the default).
 sub history_isolation_keys ($self) {
-    my $declared = $self->settings_hash->{HISTORY_ISOLATION_SETTING()};
-    return [] unless defined $declared && length $declared;
+    my $settings = $self->settings_hash;
+    my $declared = $settings->{HISTORY_ISOLATION_SETTING()};
+    unless (defined $declared) {
+        return exists $settings->{HISTORY_ISOLATION_DEFAULT_KEY()} ? [HISTORY_ISOLATION_DEFAULT_KEY] : [];
+    }
     return [sort grep { length } split /\s*,\s*/, $declared];
 }
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -1256,6 +1256,36 @@ subtest 'history isolation keys separate the scenario history' => sub {
           'undef isolation with no declared keys behaves generalized';
     };
 
+    subtest 'reserved SUBMISSION_ID default key' => sub {
+        my %d = (%settings, TEST => 'submission', DISTRI => 'sub-distri');
+        my @cases = (
+            {
+                settings => {%d, SUBMISSION_ID => 5},
+                expected => ['SUBMISSION_ID'],
+                desc => 'SUBMISSION_ID present but no meta-setting auto-isolates on SUBMISSION_ID',
+            },
+            {
+                settings => {%d},
+                expected => [],
+                desc => 'no keys with missing SUBMISSION_ID and no meta-setting (no-op default)',
+            },
+            {
+                settings => {%d, SUBMISSION_ID => 5, _HISTORY_ISOLATION_KEYS => ''},
+                expected => [],
+                desc => 'empty meta-setting disables the SUBMISSION_ID default',
+            },
+            {
+                settings => {%d, SUBMISSION_ID => 5, _HISTORY_ISOLATION_KEYS => 'PR_ID,SUBMISSION_ID'},
+                expected => [qw(PR_ID SUBMISSION_ID)],
+                desc => 'explicit meta-setting overrides or extends the SUBMISSION_ID default',
+            },
+        );
+
+        for my $case (@cases) {
+            is_deeply _job_create($case->{settings})->history_isolation_keys, $case->{expected}, $case->{desc};
+        }
+    };
+
     subtest 'next_previous_jobs_query honors isolation keys' => sub {
         # the raw view returns rows under multiple sources (l/n/p/c); assert on
         # the unique id set which is the meaningful isolation contract

--- a/t/ui/16-tests_job_next_previous.t
+++ b/t/ui/16-tests_job_next_previous.t
@@ -359,6 +359,22 @@ subtest 'history isolation toggle for "Next & Previous"' => sub {
         wait_for_ajax msg => 'table reloaded after enabling strict';
         like $driver->get_current_url, qr/strict=1/, 'URL reflects the strict view for sharing';
     };
+
+    subtest 'reserved SUBMISSION_ID enables isolation without meta-setting' => sub {
+        my $sub_id = $base_id + 10;
+        for my $spec ([10, 'a'], [11, 'a'], [12, 'b']) {
+            my ($n, $sid) = @$spec;
+            $jobs_rs->create({%base, id => $base_id + $n, settings => [{key => 'SUBMISSION_ID', value => $sid}]});
+        }
+        my $cur = $base_id + 11;
+        $t->get_ok("/tests/$cur/ajax?strict=1", 'strict via default key')->status_is(200);
+        my %strict = map { $_->{id} => 1 } @{$t->tx->res->json->{data}};
+        ok $strict{$base_id + 10}, 'keeps same-submission job';
+        ok !$strict{$base_id + 12}, 'excludes a different submission';
+        $driver->get("/tests/$cur#next_previous");
+        like $driver->find_element('label[for=next_previous_strict]')->get_text, qr/isolate history by SUBMISSION_ID/,
+          'toggle labelled with the default SUBMISSION_ID key';
+    };
 };
 
 kill_driver();


### PR DESCRIPTION
Motivation: Enabling history isolation required declaring
_HISTORY_ISOLATION_KEYS with a custom key name in every test. A reserved,
well-known key lets tests enable the feature by just setting one value.

Design Choices: history_isolation_keys defaults to the reserved
SUBMISSION_ID key when _HISTORY_ISOLATION_KEYS is unset, but only if the
job carries SUBMISSION_ID so existing jobs stay unaffected. An empty
meta-setting disables isolation; explicit keys override or extend the
default.

Benefits: One-setting opt-in via SUBMISSION_ID while keeping full
customization and the no-op guarantee for jobs without either setting.

Related issue: https://progress.opensuse.org/issues/200952

After:
* #7636