### PR TITLE
refactor: Deduplicate post-processing of job settings

### DIFF
--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -15,16 +15,13 @@ use Feature::Compat::Try;
 
 my $PLACEHOLDER_RE = qr/(%+)(\w+)(%+)/;
 
-sub generate_settings ($params) {
-    my $settings = $params->{settings};
-    my @worker_class;
-
+sub apply_global_test_settings ($settings, $worker_classes) {
     if (my $app = OpenQA::App->singleton) {
         if (my $global_test_settings = $app->config->{test_settings}) {
             for my $k (keys %$global_test_settings) {
                 my $uc_k = uc $k;
                 if ($uc_k eq 'WORKER_CLASS') {
-                    push @worker_class, $global_test_settings->{$k};
+                    push @$worker_classes, $global_test_settings->{$k};
                 }
                 else {
                     $settings->{$uc_k} = $global_test_settings->{$k};
@@ -32,6 +29,13 @@ sub generate_settings ($params) {
             }
         }
     }
+}
+
+sub generate_settings ($params) {
+    my $settings = $params->{settings};
+    my @worker_class;
+
+    apply_global_test_settings($settings, \@worker_class);
 
     for my $entity (qw (product machine test_suite job_template)) {
         next unless $params->{$entity};

--- a/lib/OpenQA/JobSettings.pm
+++ b/lib/OpenQA/JobSettings.pm
@@ -31,6 +31,17 @@ sub apply_global_test_settings ($settings, $worker_classes) {
     }
 }
 
+sub finalize_job_settings ($settings, $worker_classes) {
+    $settings->{WORKER_CLASS} = join ',', sort @$worker_classes if @$worker_classes > 0;
+
+    # make sure that the DISTRI is lowercase
+    $settings->{DISTRI} = lc($settings->{DISTRI}) if $settings->{DISTRI};
+
+    parse_url_settings($settings);
+    handle_plus_in_settings($settings);
+    return expand_placeholders($settings);
+}
+
 sub generate_settings ($params) {
     my $settings = $params->{settings};
     my @worker_class;
@@ -48,7 +59,6 @@ sub generate_settings ($params) {
             $settings->{$setting->key} = $setting->value;
         }
     }
-    $settings->{WORKER_CLASS} = join ',', sort @worker_class if @worker_class > 0;
     if (my $input_args = $params->{input_args}) {
         $settings->{+uc} = $input_args->{$_} for keys %$input_args;
     }
@@ -59,9 +69,6 @@ sub generate_settings ($params) {
         $settings->{MACHINE} = $machine->name;
     }
 
-    # make sure that the DISTRI is lowercase
-    $settings->{DISTRI} = lc($settings->{DISTRI}) if $settings->{DISTRI};
-
     # add properties from dedicated database columns to settings
     if (my $job_template = $params->{job_template}) {
         $settings->{TEST} = $job_template->name || $job_template->test_suite->name;
@@ -69,9 +76,7 @@ sub generate_settings ($params) {
         $settings->{JOB_DESCRIPTION} = $job_template->description if length $job_template->description;
     }
 
-    parse_url_settings($settings);
-    handle_plus_in_settings($settings);
-    my ($error) = expand_placeholders($settings);
+    my ($error) = finalize_job_settings($settings, \@worker_class);
     return $error;
 }
 

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -814,12 +814,8 @@ sub _schedule_from_yaml ($self, $args, $skip_chained_deps, $include_children, @l
         }
 
         # handle further settings
-        $settings->{WORKER_CLASS} = join ',', sort @worker_class if @worker_class > 0;
         _merge_settings_uppercase($args, $settings, 'TEST');
-        $settings->{DISTRI} = _distri_key($settings) if $settings->{DISTRI};
-        OpenQA::JobSettings::parse_url_settings($settings);
-        OpenQA::JobSettings::handle_plus_in_settings($settings);
-        my ($error) = OpenQA::JobSettings::expand_placeholders($settings);
+        my ($error) = OpenQA::JobSettings::finalize_job_settings($settings, \@worker_class);
         $error_msg .= $error if defined $error;
         _populate_wanted_jobs_for_test_arg($args, $settings, \%wanted);
         push @job_templates, $settings;

--- a/lib/OpenQA/Schema/Result/ScheduledProducts.pm
+++ b/lib/OpenQA/Schema/Result/ScheduledProducts.pm
@@ -775,10 +775,13 @@ sub _schedule_from_yaml ($self, $args, $skip_chained_deps, $include_children, @l
     my ($error_msg, %wanted, @job_templates);
     for my $key (sort keys %$job_templates) {
         my $job_template = $job_templates->{$key};
-        my $settings = $job_template->{settings} // {};
-        $settings->{TEST} = $key;
+        my $settings = {};
         my @worker_class;
-        push @worker_class, $settings->{WORKER_CLASS} if $settings->{WORKER_CLASS};
+        OpenQA::JobSettings::apply_global_test_settings($settings, \@worker_class);
+        # overlay job template settings
+        my $jt_settings = $job_template->{settings} // {};
+        _merge_settings_and_worker_classes($jt_settings, $settings, \@worker_class);
+        $settings->{TEST} = $key;
 
         # add settings from product (or skip if there is no such product) if a product is specified
         if (my $product_name = $job_template->{product}) {

--- a/t/api/02-iso-yaml.t
+++ b/t/api/02-iso-yaml.t
@@ -144,4 +144,25 @@ subtest 'schedule from yaml file: wildcard version' => sub {
     is_deeply $job_settings, \%expected, 'job1 scheduled with expected settings' or always_explain $job_settings;
 };
 
+
+use Test::MockObject;
+subtest 'schedule from yaml applies global test settings' => sub {
+    # mock global test settings
+    my $orig_config = OpenQA::App->singleton->config;
+    OpenQA::App->singleton->config->{test_settings} = {PRETTY_SERIAL_MARKER => '1', GLOBAL_VAR => 'global_val'};
+
+    my $file = "$FindBin::Bin/../data/09-schedule_from_file.yaml";
+    my %args = (%iso, GROUP_ID => '0', SCENARIO_DEFINITIONS_YAML => path($file)->slurp, TEST => 'autoyast_btrfs');
+    my $res = schedule_iso($t, \%args);
+    my $json = $res->json;
+    ok $json->{ids}, 'jobs scheduled';
+
+    my $job = $jobs->find($json->{ids}->[0]);
+    my $settings = {map { $_->key => $_->value } $job->settings};
+    is $settings->{PRETTY_SERIAL_MARKER}, '1', 'global PRETTY_SERIAL_MARKER applied';
+    is $settings->{GLOBAL_VAR}, 'global_val', 'global test setting applied';
+
+    OpenQA::App->singleton->config->{test_settings} = $orig_config->{test_settings};
+};
+
 done_testing();


### PR DESCRIPTION
Motivation:
There are two completely independent paths for calculating job settings
in openQA: `generate_settings` in `JobSettings.pm` (used for standard
product/API job scheduling) and `_schedule_from_yaml` in
`ScheduledProducts.pm` (used for YAML-based definitions like the example
test). Both duplicated the exact same post-processing steps.

Design Choices:
Extracted `WORKER_CLASS` joining, `DISTRI` lowercasing, URL parsing,
`+` handling, and placeholder expansion into a common, shared function
`finalize_job_settings` in `OpenQA::JobSettings`. Replaced the
duplicated logic in both code paths with a single call to this function.

Benefits:
Reduces code duplication across the two main code paths that generate
job settings and ensures any future enhancements to settings
post-processing will consistently apply to both paths.

Related issue: https://progress.opensuse.org/issues/203688