### PR TITLE
Revert "fix: filter out md files when collecting python files"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(patsubst %/,%,$(dir $(mkfile_path)))
 unstables := $(shell cat tools/unstable_tests.txt | tr '\n' :)
 shellfiles := $$(file --mime-type script/* t/* container/worker/*.sh tools/* | sed -n 's/^\(.*\):.*text\/x-shellscript.*$$/\1/p')
-pyfiles ?= $(shell git ls-files | grep -v '\.md$$' | xargs file --mime-type 2>/dev/null | grep -E 'text/x-script\.python|text/x-python' | grep --invert-match -E '^(t/data|container/openqa_data/)' | cut -d: -f1)
+pyfiles ?= $(shell git ls-files | xargs file --mime-type 2>/dev/null | grep -E 'text/x-script\.python|text/x-python' | grep --invert-match -E '^(t/data|container/openqa_data/)' | cut -d: -f1)
 
 # tests need these environment variables to be unset
 OPENQA_BASEDIR =


### PR DESCRIPTION
This "fix" was wrong in my opinion. `file` detects these files *correctly* as Python scripts because they in fact contain Python code snippets and Ruff can help fix these.