### PR TITLE
feat: Turn job restart dropdown into a distinct button

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -214,31 +214,15 @@ function showJobRestartResults(responseJSON, newJobUrl, retryFunction, targetEle
     btnGroup.appendChild(button);
 
     if (parentId) {
-      const dropdownToggle = document.createElement('button');
-      dropdownToggle.type = 'button';
-      dropdownToggle.className = 'btn btn-danger dropdown-toggle dropdown-toggle-split';
-      dropdownToggle.setAttribute('data-bs-toggle', 'dropdown');
-      dropdownToggle.setAttribute('aria-expanded', 'false');
-
-      const srOnly = document.createElement('span');
-      srOnly.className = 'visually-hidden sr-only';
-      srOnly.appendChild(document.createTextNode('Toggle Dropdown'));
-      dropdownToggle.appendChild(srOnly);
-      btnGroup.appendChild(dropdownToggle);
-
-      const dropdownMenu = document.createElement('div');
-      dropdownMenu.className = 'dropdown-menu dropdown-menu-end';
-
-      const item = document.createElement('a');
-      item.className = 'dropdown-item restart-parent-skip-ok';
-      item.href = '#';
-      item.appendChild(document.createTextNode('Restart parent job skipping passed/softfailed children'));
-      item.onclick = function (e) {
+      const skipOkButton = document.createElement('button');
+      skipOkButton.type = 'button';
+      skipOkButton.className = 'btn btn-secondary restart-parent-skip-ok';
+      skipOkButton.appendChild(document.createTextNode('Restart parent job skipping passed/softfailed children'));
+      skipOkButton.onclick = function (e) {
         e.preventDefault();
         restartJob(urlWithBase(`/api/v1/jobs/${parentId}/restart?skip_ok_result_children=1`), parentId);
       };
-      dropdownMenu.appendChild(item);
-      btnGroup.appendChild(dropdownMenu);
+      btnGroup.appendChild(skipOkButton);
     }
 
     container.appendChild(btnGroup);

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -161,13 +161,10 @@ subtest 'restart job from info panel in test results' => sub {
         wait_until(sub { flash_messages =~ m/Direct parent 99937 needs to be cloned as well/s },
             'direct parent error shown', 20);
 
-        ok my $toggle = $driver->find_element('#flash-messages .dropdown-toggle'), 'dropdown toggle button is present'
-          or return;
-        $toggle->click();    # open dropdown and find our new option
-        my $option = $driver->find_element('.restart-parent-skip-ok');
-        is $option->get_text(), 'Restart parent job skipping passed/softfailed children',
-          'dropdown option text is correct';
-        $option->click();    # click the dropdown option to restart parent job skipping OK children
+        my $button = $driver->find_element('#flash-messages .restart-parent-skip-ok');
+        ok $button, 'restart parent skipping OK children button is present' or return;
+        is $button->get_text, 'Restart parent job skipping passed/softfailed children', 'button text';
+        $button->click;    # click the button to restart parent job skipping OK children
 
         # since it successfully restarts, it should redirect to the newly cloned parent job.
         wait_for_ajax(msg => 'parent job restarted skipping OK children');


### PR DESCRIPTION
Replace the dropdown menu with a direct button for restarting parent jobs and skipping OK children. This avoids an extra click. This way it is also clearer that doing this special restart is *not* a dangerous operation (as this distinct button just has the class "secondary" and not "danger").

This addresses
https://github.com/os-autoinst/openQA/pull/7625#discussion_r3593175564.

Related ticket: https://progress.opensuse.org/issues/203967