### PR TITLE
feat: Skip download of unnecessary assets in clone_job

### DIFF
--- a/lib/OpenQA/Script/CloneJob.pm
+++ b/lib/OpenQA/Script/CloneJob.pm
@@ -14,6 +14,7 @@ use Mojo::File 'path';
 use Mojo::URL;
 use Mojo::JSON;    # booleans
 use OpenQA::Script::CloneJobSUSE;
+use OpenQA::Utils 'asset_type_from_setting';
 use List::Util 'any';
 use HTTP::Status qw(:constants);
 
@@ -203,13 +204,19 @@ sub mirror ($url_handler, $from, $dst) {
     return _run_cmd CURL, @$curl_args, @{_auth_args($from, $secrets)}, qw(--continue-at - --output), $dst, $from;
 }
 
-sub clone_job_download_assets ($jobid, $job, $url_handler, $options) {
+sub clone_job_download_assets ($jobid, $job, $url_handler, $options, $settings = undef) {
+    $settings //= $job->{settings};
     my $parents = _get_chained_parents($job, $url_handler, $options);
     _check_for_missing_assets($job, $parents, $options);
     my $remote_url = $url_handler->{remote_url};
+    # consider only settings that actually reference an asset to avoid matching unrelated settings
+    my %new_assets = map { asset_type_from_setting($_, $settings->{$_}) ? ($settings->{$_} => 1) : () } keys %$settings;
     for my $type (keys %{$job->{assets}}) {
         next if $type eq 'repo';    # we can't download repos
         for my $file (@{$job->{assets}->{$type}}) {
+            # skip assets whose setting was overridden or cleared for the new job
+            next unless $new_assets{$file};
+
             my $dst = $file;
             # skip downloading published assets if we are also cloning the generation job or
             # if the only cloned job *is* the generation job
@@ -423,7 +430,7 @@ sub clone_job ($jobid, $url_handler, $options, $post_params = {}, $jobs = {}, $d
     clone_job_apply_settings($options->{args}, $relation eq 'children' ? 0 : $depth, $settings, $options);
     OpenQA::Script::CloneJobSUSE::detect_maintenance_update($jobid, $url_handler, $settings)
       if $options->{'check-repos'};
-    clone_job_download_assets($jobid, $job, $url_handler, $options) unless $options->{'skip-download'};
+    clone_job_download_assets($jobid, $job, $url_handler, $options, $settings) unless $options->{'skip-download'};
 }
 
 sub _assign_existing_dependencies ($name, $deps, $settings, $jobs) {

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -170,6 +170,13 @@ subtest 'asset download' => sub {
     my %job = (
         id => $job_id,
         parents => {Chained => [2]},
+        settings => {
+            ISO_1 => 'foo.iso',
+            ISO_2 => 'bar.iso',
+            HDD_1 => 'some.qcow2',
+            HDD_2 => 'uefi-vars.qcow2',
+            HDD_3 => 'another.qcow2',
+        },
         assets => {
             repo => 'supposed to be skipped',
             iso => [qw(foo.iso bar.iso)],
@@ -237,6 +244,14 @@ subtest 'asset download' => sub {
     ok -f "$temp_assetdir/iso/bar.iso", 'foo touched';
 
     %mirrored = ();
+    # assets are always referenced by asset-typed settings (see register_assets_from_settings)
+    $job{settings} = {
+        ISO_1 => 'foo.iso',
+        ISO_2 => 'bar.iso',
+        HDD_1 => 'another.qcow2',
+        HDD_2 => 'some.qcow2',
+        HDD_3 => 'uefi-vars.qcow2',
+    };
     $options{'skip-deps'} = 1;
     $expected_downloads{"http://foo/tests/$job_id/asset/hdd/some.qcow2"} = "$temp_assetdir/hdd/some.qcow2";
     $expected_downloads{"http://foo/tests/$job_id/asset/hdd/uefi-vars.qcow2"} = "$temp_assetdir/hdd/uefi-vars.qcow2";
@@ -253,6 +268,25 @@ subtest 'asset download' => sub {
       'downloading logged (2)';
     is_deeply \%mirrored, \%expected_downloads,
       'assets downloadeded except uefi-vars because no parent produces it anyways'
+      or always_explain \%mirrored;
+
+    %mirrored = ();
+    my %new_settings = %{$job{settings}};
+    delete $new_settings{ISO_1};    # assume overridden by command line `ISO_1=`
+    delete $expected_downloads{"http://foo/tests/$job_id/asset/iso/foo.iso"};
+    combined_like { clone_job_download_assets($job_id, \%job, \%url_handler, \%options, \%new_settings) }
+    qr/downloading/, 'downloading logged with overridden settings';
+    is_deeply \%mirrored, \%expected_downloads, 'foo.iso skipped because ISO_1 setting was removed'
+      or always_explain \%mirrored;
+
+    %mirrored = ();
+    delete $new_settings{ISO_2};    # asset setting removed …
+    $new_settings{UNRELATED} = 'bar.iso';    # … but an unrelated setting mentions the same file
+    delete $expected_downloads{"http://foo/tests/$job_id/asset/iso/bar.iso"};
+    combined_like { clone_job_download_assets($job_id, \%job, \%url_handler, \%options, \%new_settings) }
+    qr/downloading/, 'downloading logged with unrelated setting mentioning removed asset';
+    is_deeply \%mirrored, \%expected_downloads,
+      'bar.iso skipped: unrelated non-asset setting mentioning the file does not keep the download'
       or always_explain \%mirrored;
 };
 


### PR DESCRIPTION
Motivation:
openqa-clone-job downloads all assets associated with a job even if
their settings are overridden or cleared from the command line. This
results in unnecessary bandwidth usage.

Design Choices:
Passed the effective (post-override) job settings to the asset download
routine and skip any asset that is not referenced by an asset-typed
setting there, determined via asset_type_from_setting. This avoids
matching unrelated settings that merely mention an asset filename.

Manual Verification:
Using a local openQA instance cloned a job from o3 with HDD assets which
would be downloaded before this change:
```
script/openqa-clone-job --skip-deps https://openqa.opensuse.org/t6119608 HDD_1=
```
Observed that no asset was downloaded before creating the local openQA
job.

Benefits:
Saves time and bandwidth during clone operations.