### PR TITLE
fix(worker): enable rootless podman execution

### DIFF
--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -736,6 +736,12 @@ The following optional test variables are supported:
   `registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest`).
   `OS_AUTOINST_CONTAINER_IMAGE` requires `OS_AUTOINST_GIT_REPO` to be set.
 
+*Note*: Running `os-autoinst` in a rootless container requires that the
+`_openqa-worker` user has subuid/subgid ranges assigned in `/etc/subuid`
+and `/etc/subgid`. If they are missing, you can configure them by running:
+`usermod --add-subuids 100000-165535 --add-subgids 100000-165535 _openqa-worker`.
+Additionally, AppArmor must allow `podman` to run unconfined (e.g. `pux`).
+
 ### Automatic retries of jobs
 
 You might encounter flaky openQA tests that fail sporadically. The best way to

--- a/profiles/apparmor.d/usr.share.openqa.script.worker
+++ b/profiles/apparmor.d/usr.share.openqa.script.worker
@@ -111,7 +111,7 @@ include <tunables/global>
   /usr/bin/optipng rix,
   /usr/bin/ping rix,
   /usr/bin/pngquant rix,
-  /usr/bin/podman rix,
+  /{usr/,}bin/podman pux,
   /usr/bin/python3.* ix,
   /usr/bin/qemu-img rix,
   /usr/bin/qemu-kvm rix,

--- a/script/openqa-bootstrap
+++ b/script/openqa-bootstrap
@@ -36,7 +36,22 @@ start-database() {
     fi
 }
 
+setup-subuids() {
+    if [[ -f /etc/subuid ]] && ! grep -q "^_openqa-worker:" /etc/subuid; then
+        echo "Adding subuid/subgid ranges for _openqa-worker"
+        local start=100000
+        if [[ -s /etc/subuid ]]; then
+            local max_end
+            max_end=$(awk -F: 'BEGIN {max=100000} {end=$2+$3; if(end>max) max=end} END {print max}' /etc/subuid)
+            start=$max_end
+        fi
+        local end=$((start + 65535))
+        usermod --add-subuids "$start-$end" --add-subgids "$start-$end" _openqa-worker || true
+    fi
+}
+
 start-worker() {
+    setup-subuids
     if [[ -z $running_systemd ]]; then
         /usr/bin/install -d -m 0755 -o _openqa-worker /var/lib/openqa/pool/1
         su _openqa-worker -c "$OPENQA_DIR/script/worker --instance 1" &


### PR DESCRIPTION
Motivation:
Rootless podman execution failed under AppArmor with namespace and permission
errors due to environment scrubbing and missing subuid ranges.

Design Choices:
Change AppArmor podman rule to transition with pux to preserve critical
environment variables, and dynamically assign subuid/subgid ranges during
bootstrap.

Benefits:
Ensures seamless and secure custom os-autoinst container execution for workers
without manual user configuration.