### PR TITLE
fix: Escape `@` sign in strings and regexes

### DIFF
--- a/t/25-downloader.t
+++ b/t/25-downloader.t
@@ -50,7 +50,7 @@ subtest 'Unable to create temporary directory' => sub {
 };
 
 subtest 'Connection refused' => sub {
-    my $from = "http://127.0.0.1:0/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2";
+    my $from = 'http://127.0.0.1:0/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-textmode@64bit.qcow2';
     like $downloader->download($from, $to), qr/Download of "$to" failed: Connection refused/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
@@ -84,7 +84,7 @@ wait_for_or_bail_out { defined $ua->get($host)->res->code } 'worker';
 sub stop_server { $server_instance->stop() }
 
 subtest 'Not found' => sub {
-    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-404@64bit.qcow2";
+    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-404\@64bit.qcow2";
     like $downloader->download($from, $to), qr/Download of "$to" failed: 404 Not Found/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
@@ -109,7 +109,7 @@ subtest 'Success' => sub {
 };
 
 subtest 'Connection closed early' => sub {
-    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_close@64bit.qcow2";
+    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_close\@64bit.qcow2";
     like $downloader->download($from, $to), qr/Download of "$to" failed: Premature connection close/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
@@ -122,7 +122,7 @@ subtest 'Connection closed early' => sub {
 };
 
 subtest 'Server error' => sub {
-    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_server_error@64bit.qcow2";
+    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-200_server_error\@64bit.qcow2";
     like $downloader->download($from, $to), qr/Download of "$to" failed: 500 Internal Server Error/, 'Failed';
 
     ok !-e $to, 'File not downloaded';
@@ -135,7 +135,7 @@ subtest 'Server error' => sub {
 };
 
 subtest 'Size differs' => sub {
-    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-589@64bit.qcow2";
+    my $from = "$host/tests/922756/asset/hdd/sle-12-SP3-x86_64-0368-589\@64bit.qcow2";
     like $downloader->download($from, $to), qr/Size of .* differs, expected \d+ Byte but downloaded \d+ Byte/, 'Failed';
 
     ok !-e $to, 'File not downloaded';

--- a/t/35-script_clone_job.t
+++ b/t/35-script_clone_job.t
@@ -276,7 +276,7 @@ subtest 'get 2 nodes HA cluster with get_deps' => sub {
         WORKER_CLASS => 'tap,qemu_x86_64',
     );
     my %supportserver_settings = (
-        NAME => "00007934-sle-15-SP3-Online-x86_64-Build67.1-sles4sap_hana_supportserver@64bit-2gbram",
+        NAME => '00007934-sle-15-SP3-Online-x86_64-Build67.1-sles4sap_hana_supportserver@64bit-2gbram',
         TEST => 'sles4sap_hana_supportserver',
         HDD_1 => 'openqa_support_server_sles12sp3.x86_64.qcow2',
         HDDSIZEGB => 60,

--- a/t/ui/26-jobs_restart.t
+++ b/t/ui/26-jobs_restart.t
@@ -228,7 +228,7 @@ subtest 'check single job restart in /tests page' => sub {
         # open restart link then verify its test name
         $driver->find_child_element($td, "./a[\@title='new test']", 'xpath')->click();
         like $driver->find_element('#info_box .card-header')->get_text(),
-          qr/minimalx@32bit/, 'restarted job is correct';
+          qr/minimalx\@32bit/, 'restarted job is correct';
     };
 };
 


### PR DESCRIPTION
In perl 5.44, handling of the `@` sign changed, and in a string like
    "foo@64bit"

the `@64` would just disappear.

From perldoc perldelta:
> Fixed parsing of array names starting with a digit in double-quotish context
> under use utf8;.