### PR TITLE
feat: Avoid warning when computing diff times out

### DIFF
--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -52,6 +52,7 @@ use constant MAIN_SETTINGS => qw(DISTRI VERSION FLAVOR ARCH TEST MACHINE BUILD);
 
 use constant MAX_LENGTH_REASON => 300;
 use constant JOB_INVESTIGATE_GIT_TIMEOUT => 20;
+use constant RETURN_CODE_TIMEOUT_EXCEEDED => 124;    # see `man timeout`
 
 __PACKAGE__->table('jobs');
 __PACKAGE__->load_components(qw(InflateColumn::DateTime FilterColumn Timestamps));
@@ -1916,9 +1917,10 @@ sub git_diff ($self, $dir, $refspec_range, $limit = undef) {
     $cmd = ['timeout', $timeout, 'git', '-C', $dir, 'diff', '--stat', $refspec_range];
     $res = run_cmd_with_log_return_error($cmd, stdout => 'trace');
     $out = $res->{stdout} . $res->{stderr};
-    if ($res->{return_code}) {
-        log_warning "Problem with [@$cmd] rc=$res->{return_code}: $out";
-        return 'Cannot display diff because of a git problem';
+    if (my $return_code = $res->{return_code}) {
+        my $is_timeout = $return_code == RETURN_CODE_TIMEOUT_EXCEEDED;
+        log_warning "Problem with [@$cmd] rc=$return_code: $out" unless $is_timeout;
+        return $is_timeout ? 'Computing diff timed out' : 'Cannot display diff because of a git problem';
     }
     return $out;
 }

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -1079,6 +1079,7 @@ subtest 'git log diff' => sub {
             }
             elsif ("@$cmd" =~ m/diff --stat/) {
                 if ("@$cmd" =~ m/difffail/) { $stdout = 'git failed'; $rc = 1; }
+                elsif ("@$cmd" =~ m/longrange/) { $rc = 124; }    # see `man timeout`
                 else { $stdout = '2 files changed'; }
             }
             return {stdout => $stdout, stderr => $stderr, return_code => $rc};
@@ -1107,6 +1108,9 @@ subtest 'git log diff' => sub {
         like $fail, qr{Cannot display diff because of a git problem}, 'git diff exited with non-zero';
     }
     qr{git failed}, 'git diff exited with non-zero - warning is logged';
+
+    my $fail = $job->git_diff('/foo', 'longrange', 10);
+    like $fail, qr{Computing diff timed out}, 'timeout logged specifically';
 
     my $res = $job->git_diff('/foo', 'invalidrange', 10);
     like $res, qr{Cannot display diff: Invalid revision range}, 'error about invalid range returned';


### PR DESCRIPTION
We saw this warning once in production but it isn't really actionable. Hence this change suppresses the warning in the server logs and instead provides a more specific user-facing error.

Related ticket: https://progress.opensuse.org/issues/203886