### PR TITLE
docs: Fix explanation of `prio_throttling_patterns` in config file

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -414,8 +414,8 @@ concurrent = 0
 
 ## Throttling based on patterns in job settings: set a comma-separated list of
 ## test parameters that trigger throttling of scheduled openQA jobs by priority.
-## syntax for positive matching: parameter_n:adjustment_n:!~regex_n[,…]
-## syntax for negative matching: parameter_n:adjustment_n:!=regex_n[,…]
+## syntax for positive matching: parameter_n:adjustment_n:=~regex_n[,…]
+## syntax for negative matching: parameter_n:adjustment_n:!~regex_n[,…]
 ## Check out the "Job Priority Throttling" documentation for details.
 #prio_throttling_patterns = CASEDIR:15:!~^https?:
 


### PR DESCRIPTION
The explanation in the documentation is already correct.