### PR TITLE
fix: close AssetPack file handles via public API

### DIFF
--- a/lib/OpenQA/Assets.pm
+++ b/lib/OpenQA/Assets.pm
@@ -34,12 +34,13 @@ sub setup ($server) {
         die $e;    # uncoverable statement
     }
 
-    # Clean up file handles to avoid "Too many open files"
+    # Clean up file handles to avoid "Too many open files".
+    # This is a workaround for Mojolicious::Plugin::AssetPack keeping file descriptors open.
+    # Calling ->path() with a string replaces the underlying Mojo::Asset::File with a fresh
+    # instance where the file handle is evaluated lazily, effectively closing the old one.
     for my $asset (map { @$_ } values %{$server->asset->{by_topic} // {}}) {
-        delete $asset->{_asset}{handle} if $asset->{_asset} && $asset->{_asset}->isa('Mojo::Asset::File');
+        $asset->path($asset->path->to_string) if $asset->path;
     }
-    delete $server->asset->{input};
-    delete $server->asset->store->{assets};
 }
 
 sub _path ($url) { path('assets', ref $url eq 'Mojo::URL' ? $url->path : $url)->realpath->to_rel }


### PR DESCRIPTION
Motivation:
A prior fix directly manipulated internal 'Mojolicious::Plugin::AssetPack'
attributes and deleted private caches to prevent FD exhaustion crashes.
This broke encapsulation and raised valid reviewer concerns.

Design Choices:
Instead of reaching into 'Mojo::Asset::File' internals, we now invoke the
public '$asset->path($asset->path->to_string)' accessor. This method
replaces the internal 'Mojo::Asset::File' instance, naturally dropping the
file descriptor via 'DESTROY'. Deletion of private caches is removed as it
is unnecessary.

Benefits:
We maintain the critical prevention of "Too many open files" errors while
cleanly respecting the upstream module's encapsulation boundaries.

Related issue: https://github.com/os-autoinst/openQA/pull/7466