### PR TITLE
ci: Rebuild Perl XS module on Perl version update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,11 +103,9 @@ jobs:
       - restore_cache: *restore_fullstack_cache
       - store_artifacts: *store_logs
       - run:
-          name: "Build os-autoinst if not cached"
+          name: "Build os-autoinst (noop if cached)"
           command: |
-            if [ ! -d /var/cache/autoinst/t ]; then
-              bash -x tools/ci/build_autoinst.sh "/var/cache/autoinst"
-            fi
+            bash -x tools/ci/build_autoinst.sh "/var/cache/autoinst"
       - save_cache: *save_fullstack_cache
 
   cache-npm:

--- a/tools/ci/build_autoinst.sh
+++ b/tools/ci/build_autoinst.sh
@@ -8,8 +8,10 @@ destdir=${1:-../os-autoinst}
 sha=${2:-$(cat tools/ci/autoinst.sha)}
 
 echo "Building os-autoinst $destdir $sha"
-git clone https://github.com/os-autoinst/os-autoinst.git "$destdir"
-git -C "$destdir" checkout "${sha##*-}"
-cmake -S "$destdir" -B "$destdir" -G Ninja -DCMAKE_BUILD_TYPE=Release
+if [[ ! -d $destdir ]]; then
+    git clone https://github.com/os-autoinst/os-autoinst.git "$destdir"
+    git -C "$destdir" checkout "${sha##*-}"
+    cmake -S "$destdir" -B "$destdir" -G Ninja -DCMAKE_BUILD_TYPE=Release
+fi
 cmake --build "$destdir" --target symlinks
 chown -R 1000 "$destdir"


### PR DESCRIPTION
Together with the corresponding os-autoinst build change this will prevent errors like:

```
Perl API version v5.42.0 of /var/cache/autoinst/ppmclibs/tinycv-xs.cpp does
not match v5.44.0
```

With these changes the cached build is immediately updated (without having to wait for the next nightly job).

Tested locally by pointing it to my fork and pending os-autoinst commit and then invoking the following commands:

```
tools/ci/build_autoinst.sh "/tmp/autoinst"
tools/ci/build_autoinst.sh "/tmp/autoinst"
sudo touch /usr/bin/perl
tools/ci/build_autoinst.sh "/tmp/autoinst"
tools/ci/build_autoinst.sh "/tmp/autoinst"
```

The first invocation clones the repo and makes a full build. The second invocation does basically nothing.
The third invocation is reconfiguring but does otherwise nothing as the Perl version hasn't actually changed. (Without my os-autoinst change it does nothing.)
The forth invocation does nothing again.

Related ticket: https://progress.opensuse.org/issues/204594