### PR TITLE
fix: Remove accidentally added flash message when adding a comment

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Comment.pm
@@ -148,7 +148,6 @@ sub create ($self) {
     }
     $self->emit_event('openqa_comment_create', $comment->event_data);
     $txn_guard->commit;
-    $self->flash(info => 'The comments have been created.');
     $self->render(json => {id => $comment->id});
 }
 


### PR DESCRIPTION
This flash message was accidentally added to commit f274b14f45 but is just a leftover (as the change ended up using `document.cookie` after all).