### PR TITLE
feat(api): implement unauthenticated validate route for job templates scheduling

### DIFF
--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -452,6 +452,7 @@ sub startup ($self) {
       ->to('job_template#schedules', id => undef);
     $api_public_r->get('job_templates_scheduling/<name:str>')->to('job_template#schedules', name => undef);
     $api_ra->post('job_templates_scheduling/<id:num>')->to('job_template#update', id => undef);
+    $api_public_r->post('job_templates_scheduling/<id:num>/validate')->to('job_template#validate', id => undef);
     # Deprecated experimental aliases for the above routes
     $api_public_r->get('experimental/job_templates_scheduling/<id:num>')->name('apiv1_job_templates_schedules')
       ->to('job_template#schedules', id => undef);

--- a/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/JobTemplate.pm
@@ -124,7 +124,7 @@ sub _get_job_groups ($self, $id, $name) {
     return \%yaml;
 }
 
-sub _update_job_templates ($self, $job_template_names, $job_group, $user_errors, $json, $yaml) {
+sub _update_job_templates ($self, $job_template_names, $job_group, $user_errors, $json, $yaml, $is_preview) {
     my $job_templates = $self->schema->resultset('JobTemplates');
     my $group_id = $job_group->id;
     my @job_template_ids;
@@ -147,8 +147,8 @@ sub _update_job_templates ($self, $job_template_names, $job_group, $user_errors,
     }
 
     # Preview mode: Get the expected YAML and rollback the result
-    if ($self->validation->param('preview')) {
-        $json->{preview} = int($self->validation->param('preview'));
+    if ($is_preview) {
+        $json->{preview} = int $is_preview;
         $self->schema->txn_rollback;
     }
     else {
@@ -231,6 +231,25 @@ in the response if any changes to the database were made.
 =cut
 
 sub update ($self) {
+    return $self->_update_or_validate();
+}
+
+=over 4
+
+=item validate()
+
+Validates a job group template without writing any changes to the database.
+Behaves identically to C<update()>, but the B<preview> parameter is always forced to 1.
+
+=back
+
+=cut
+
+sub validate ($self) {
+    return $self->_update_or_validate(1);
+}
+
+sub _update_or_validate ($self, $force_preview = 0) {
     my $validation = $self->validation;
     # Note: id is a regular param because it's part of the path
     $validation->required('name') unless $self->param('id');
@@ -248,6 +267,7 @@ sub update ($self) {
     my $to_expand = $validation->param('expand');
     my $id = $self->param('id');
     my $name = $validation->param('name');
+    my $preview = $force_preview || $validation->param('preview');
     try {
         $data = load_yaml(string => $validation->param('template'));
         $user_errors
@@ -262,7 +282,8 @@ sub update ($self) {
     my $json = {};
     my @server_errors;
     try {
-        $self->_perform_update($id, $name, $json, $data, $yaml, $template_reference, $to_expand, $user_errors);
+        $self->_perform_update($id, $name, $json, $data, $yaml, $template_reference, $to_expand, $user_errors,
+            $preview);
     }
     catch ($e) {
         # Push the exception to the list of errors without the trailing new line
@@ -281,11 +302,11 @@ sub update ($self) {
             json => {json => $json, status => (@server_errors ? HTTP_INTERNAL_SERVER_ERROR : HTTP_BAD_REQUEST)});
     }
 
-    $self->emit_event('openqa_jobtemplate_create', $json) unless $validation->param('preview');
+    $self->emit_event('openqa_jobtemplate_create', $json) unless $preview;
     $self->respond_to(json => {json => $json});
 }
 
-sub _perform_update ($self, $id, $name, $json, $data, $yaml, $reference, $to_expand, $user_errors) {
+sub _perform_update ($self, $id, $name, $json, $data, $yaml, $reference, $to_expand, $user_errors, $preview) {
     my $job_groups = $self->schema->resultset('JobGroups');
     my $job_group
       = $job_groups->find($id ? {id => $id} : ($name ? {name => $name} : undef), {select => [qw(id name template)]});
@@ -311,7 +332,7 @@ sub _perform_update ($self, $id, $name, $json, $data, $yaml, $reference, $to_exp
         $json->{result} = $job_group->expand_yaml($job_template_names);
     }
     $self->schema->txn_do(
-        sub { $self->_update_job_templates($job_template_names, $job_group, $user_errors, $json, $yaml) });
+        sub { $self->_update_job_templates($job_template_names, $job_group, $user_errors, $json, $yaml, $preview) });
 }
 
 =over 4

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -1286,6 +1286,34 @@ $t->post_ok(
     })->status_is(403);
 $t->delete_ok("/api/v1/job_templates/$job_template_id1")->status_is(403);
 
+subtest 'validate route (public)' => sub {
+    client($t, apikey => undef, apisecret => undef);
+    my $template = path("$FindBin::Bin/../data/08-create-modify-group.yaml")->slurp;
+    my %val_form = (
+        schema => $schema_filename,
+        template => $template,
+    );
+
+    $opensuse->update({template => $template});
+
+    $t->post_ok('/api/v1/job_templates_scheduling/' . $opensuse->id . '/validate', form => \%val_form)
+      ->status_is(200, 'POST request to /validate without authentication is 200');
+
+    my $res = $t->tx->res->json;
+    is $res->{preview}, 1, 'Validate route is always in preview mode';
+    ok !exists $res->{changes}, 'No changes expected';
+
+    $val_form{template} =~ s/removed later/replaced after/;
+    $val_form{preview} = 0;
+
+    $t->post_ok('/api/v1/job_templates_scheduling/' . $opensuse->id . '/validate', form => \%val_form)
+      ->status_is(200, 'POST after altering template returns 200');
+
+    $res = $t->tx->res->json;
+    is $res->{preview}, 1, 'Validate route is always in preview mode';
+    ok exists $res->{changes}, 'Changes were detected';
+};
+
 is_deeply \@logged_errors, [], 'no errors logged' or always_explain \@logged_errors;
 
 done_testing();


### PR DESCRIPTION
To allow external CI tools (like GitHub Actions workflows in the
jobgroups repository) to run pre-merge validation checks on
their job templates without needing write API keys, we introduce
a public unauthenticated `validate` route.

- Refactor `update` in `OpenQA::WebAPI::Controller::API::V1::JobTemplate`
  to extract core validation/transactional processing to `_update_or_validate`.
- Allow forcing transaction rollback via a parameterized `$preview` flag.
- Define a `validate` controller action with POD documentation to handle
  the validation request.
- Register `job_templates_scheduling/<id>/validate` under the
  unauthenticated `$api_public_r` router.
- Add test cases verifying authentication-free access and correctness
  in `t/api/08-jobtemplates.t

This is so we can rollback https://github.com/os-autoinst/opensuse-jobgroups/pull/898 too.
