### PR TITLE
feat(ui): copy button for status badges

### DIFF
--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -813,6 +813,41 @@ if (typeof window !== 'undefined' && window.jQuery) {
         };
       }
     }
+
+    document.addEventListener('click', function (event) {
+      const button = event.target.closest('.copy-badge-btn');
+      if (!button) return;
+      event.preventDefault();
+      const text = button.dataset.clipboardText;
+      if (text) {
+        navigator.clipboard
+          .writeText(text)
+          .then(() => {
+            const icon = button.querySelector('i');
+            if (icon) {
+              icon.classList.remove('fa-image');
+              icon.classList.add('fa-check', 'text-success');
+              setTimeout(() => {
+                icon.classList.remove('fa-check', 'text-success');
+                icon.classList.add('fa-image');
+              }, 2000);
+            }
+            const tooltip = bootstrap.Tooltip.getInstance(button);
+            if (tooltip) {
+              const originalTitle = button.getAttribute('data-bs-original-title') || button.getAttribute('title');
+              tooltip.setContent({'.tooltip-inner': 'Copied!'});
+              tooltip.show();
+              setTimeout(() => {
+                tooltip.setContent({'.tooltip-inner': originalTitle});
+                tooltip.hide();
+              }, 2000);
+            }
+          })
+          .catch(err => {
+            console.error('Failed to copy text: ', err);
+          });
+      }
+    });
   })(window.jQuery);
 
   $(document).ready(function () {

--- a/assets/stylesheets/overall.scss
+++ b/assets/stylesheets/overall.scss
@@ -317,3 +317,6 @@ h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
     border: $table-border-color-dark solid 0.5px;
   }
 }
+.badge-dropdown-menu {
+  width: 320px;
+}

--- a/assets/stylesheets/test-details.scss
+++ b/assets/stylesheets/test-details.scss
@@ -3,11 +3,13 @@
   background-color: $color-softfailed;
   color: $color-result;
 }
-.modules-badge {
-  font-size: 85%;
+.modules-badge-container {
   position: absolute;
   top: 8px;
   right: 8px;
+}
+.modules-badge {
+  font-size: 85%;
 }
 
 // test result

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -175,6 +175,24 @@ sub register ($self, $app, $config) {
             return $c->t(a => (tabindex => 0, class => $class, role => 'button', data => \%d, @args));
           });
 
+
+
+    $app->helper(
+        badge_markdown_copy_button => sub ($c, $id, $markdown, $outer_classes = 'd-inline') {
+            my $button = $c->t(
+                button => (
+                    class => "btn btn-sm btn-outline-secondary copy-badge-btn $outer_classes",
+                    type => 'button',
+                    id => "badgeCopyButton-$id",
+                    'data-clipboard-text' => $markdown,
+                    'data-bs-toggle' => 'tooltip',
+                    title => 'Copy Markdown snippet to embed this status badge'
+                ) => sub {
+                    $c->t(i => (class => 'fa-solid fa-image') => '') . ' Badge';
+                });
+            return Mojo::ByteStream->new($button);
+        });
+
     $app->helper(
         help_popover_todo => sub ($c) {
             $c->help_popover(

--- a/t/10-tests_overview.t
+++ b/t/10-tests_overview.t
@@ -47,6 +47,8 @@ $jobs->find($_)->comments->create({text => 'foobar', user_id => 99901}) for 9994
 
 subtest 'Basic overview display' => sub {
     $t->get_ok('/tests/overview' => form => {distri => 'opensuse', version => '13.1', build => '0091'})->status_is(200);
+    $t->element_exists('button#badgeCopyButton-overview', 'Badge copy button is displayed on tests overview page');
+    $t->element_exists('button.copy-badge-btn', 'Copy badge button is displayed on tests overview page');
 
     my $summary = get_summary;
     like $summary, qr/Overall Summary of opensuse 13\.1 build 0091/i, 'Summary header shows distri, version and build';

--- a/t/ui/01-list.t
+++ b/t/ui/01-list.t
@@ -207,6 +207,8 @@ is_deeply \@header_texts, \@expected, 'limit for finished tests can be adjusted 
 
 $t->get_ok('/tests/99963')->status_is(200);
 $t->content_like(qr/State.*running/, 'Running jobs are marked');
+$t->element_exists('button[id^="badgeCopyButton-"]', 'Badge copy button is displayed on job details page');
+$t->element_exists('button.copy-badge-btn', 'Copy badge button is displayed on job details page');
 
 $t->get_ok('/tests/list_running_ajax')->status_is(200);
 
@@ -343,6 +345,23 @@ is $driver->find_element('#results #job_99938 .test .status.result_failed')->get
 like $driver->find_element('#results #job_99938 td.test a')->get_attribute('href'), qr{.*/tests/99938}, 'right link';
 $driver->find_element('#results #job_99938 td.test a')->click();
 $driver->title_is('openQA: opensuse-Factory-DVD-x86_64-Build0048-doc@64bit test results', 'tests/99938 followed');
+
+subtest 'copy badge button click' => sub {
+    $driver->execute_script(
+        'navigator.clipboard.writeText = function(text) { window.copiedText = text; return Promise.resolve(); };');
+    my $copy_btn = $driver->find_element('button#badgeCopyButton-99938');
+    ok $copy_btn, 'Copy badge button is displayed on job details page' or return;
+    $copy_btn->click();
+    wait_until sub {
+        my $copied = $driver->execute_script('return window.copiedText;');
+        return $copied && $copied =~ qr/!\[opensuse-Factory-DVD-x86_64-Build0048-doc\@64bit test result\]/;
+    }, 'clipboard contains markdown status badge snippet';
+
+    my $icon = $driver->find_child_element($copy_btn, 'i', 'css');
+    wait_until sub {
+        return $icon->get_attribute('class') =~ /fa-check/;
+    }, 'icon class changes to fa-check';
+};
 
 # return
 is $driver->get('/tests'), 1, '/tests gets';

--- a/templates/webapi/test/infopanel.html.ep
+++ b/templates/webapi/test/infopanel.html.ep
@@ -18,29 +18,33 @@
                 % }
             >
                 <div class="col-xl">
+                    <div class="d-flex align-items-center gap-1 modules-badge-container">
+                        %= badge_markdown_copy_button($job->id, '[![' . $job->name . ' test result](' . url_for('test_result_badge', testid => $job->id)->to_abs . ')](' . url_for('test', testid => $job->id)->to_abs . ')')
+                        % if ($job->state eq DONE) {
+                            <div class="badge rounded-pill text-bg-light modules-badge">
+                                %= $job->passed_module_count
+                                <i class='fa-solid module_passed fa-star' title='modules passed'></i>
+                                % if ($job->softfailed_module_count) {
+                                    %= $job->softfailed_module_count
+                                    <i class='fa-solid module_softfailed fa-star-half-stroke' title='modules with warnings'></i>
+                                % }
+                                % if ($job->failed_module_count) {
+                                    %= $job->failed_module_count
+                                    <i class='fa-solid module_failed fa-star' title='modules failed'></i>
+                                % }
+                                % if ($job->skipped_module_count) {
+                                    %= $job->skipped_module_count
+                                    <i class='fa-solid module_none fa-ban' title='modules skipped'></i>
+                                % }
+                                % if ($job->externally_skipped_module_count) {
+                                    %= $job->externally_skipped_module_count
+                                    <i class='fa-solid module_skipped fa-angles-right' title='modules externally skipped'></i>
+                                % }
+                            </div>
+                        % }
+                    </div>
                 <div>
                     % if ($job->state eq DONE) {
-                        <div class="badge rounded-pill text-bg-light modules-badge">
-                            %= $job->passed_module_count
-                            <i class='fa-solid module_passed fa-star' title='modules passed'></i>
-                            % if ($job->softfailed_module_count) {
-                                %= $job->softfailed_module_count
-                                <i class='fa-solid module_softfailed fa-star-half-stroke' title='modules with warnings'></i>
-                            % }
-                            % if ($job->failed_module_count) {
-                                %= $job->failed_module_count
-                                <i class='fa-solid module_failed fa-star' title='modules failed'></i>
-                            % }
-                            % if ($job->skipped_module_count) {
-                                %= $job->skipped_module_count
-                                <i class='fa-solid module_none fa-ban' title='modules skipped'></i>
-                            % }
-                            % if ($job->externally_skipped_module_count) {
-                                %= $job->externally_skipped_module_count
-                                <i class='fa-solid module_skipped fa-angles-right' title='modules externally skipped'></i>
-                            % }
-                        </div>
-
                         Result: <b><%= $job->result %></b>\
                     % }
                     % else {

--- a/templates/webapi/test/overview.html.ep
+++ b/templates/webapi/test/overview.html.ep
@@ -14,6 +14,7 @@
     <h2>Test result overview</h2>
     <div id="summary" class="card <%= ($aggregate_status =~ /^(?:failed|not_complete)$/) ? 'border-danger' : 'border-success' %>">
         <div class="card-header">
+            %= badge_markdown_copy_button('overview', '[![openQA build status](' . (url_with('tests_overview_badge')->to_abs->to_string =~ s/\.svg\b//r) . ')](' . url_with->to_abs . ')', 'float-end')
             Overall Summary of
             % if (@$groups) {
                 <strong>


### PR DESCRIPTION
Motivation:
Provide a convenient way for users to copy Markdown snippets of test and build
status badges, improving integration with external documents and wikis.

Design Choices:
Add small direct-copy buttons to the individual test info panel and the overview
card header, with tooltip-based "Copied!" feedback and zero inline styles.

Benefits:
Users can quickly and effortlessly obtain the Markdown snippet for any status
badge with a single click and without having to manually construct the URLs.

Screenshots:
<img width="611" height="465" alt="Screenshot_20260729_081241_test_badge_copy" src="https://github.com/user-attachments/assets/c196d684-680c-491f-b3ef-91a559caa393" />

<img width="488" height="465" alt="Screenshot_20260729_080523_build_badge_copy" src="https://github.com/user-attachments/assets/50120112-9c27-4ed0-a64b-10374b0bf1fb" />

