### PR TITLE
feat: Allow unsetting lock for individual worker slots

### DIFF
--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -121,7 +121,7 @@ sub guard ($self, @args) { $self->app->minion->guard(@args) }
 
 sub _job_guard ($self) {
     my $settings = $self->settings->global_settings;
-    return undef unless defined(my $lock_name = $settings->{LOCK_NAME});
+    return undef unless my $lock_name = $settings->{LOCK_NAME};
     return $self->guard($lock_name, ONE_HOUR, {limit => $settings->{LOCK_LIMIT} // 5})
       // "Limited by configured lock '$lock_name'";
 }


### PR DESCRIPTION
Without this, if one tries to unset the lock configuration for a particular worker slot via `LOCK_NAME =`, the worker tries to acquire a lock with an empty name. This change prevents that and the worker does not try to acquire the lock.

Related ticket: https://progress.opensuse.org/issues/203478