### PR TITLE
Add forge.fedoraproject.org to the bugurl/bugref complex

### DIFF
--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -55,6 +55,7 @@ BEGIN {
         pio => 'https://pagure.io/',
         ggo => 'https://gitlab.gnome.org/',
         gfs => 'https://gitlab.com/fedora/sigs/',
+        ffo => 'https://forge.fedoraproject.org/',
     );
     %BUGURLS = (
         'https://bugzilla.novell.com/show_bug.cgi?id=' => 'bsc',
@@ -73,6 +74,7 @@ BEGIN {
         $BUGREFS{pio} => 'pio',
         $BUGREFS{ggo} => 'ggo',
         $BUGREFS{gfs} => 'gfs',
+        $BUGREFS{ffo} => 'ffo',
     );
 
     $MARKER_REFS = join '|', keys %BUGREFS;
@@ -473,7 +475,7 @@ sub href_to_bugref ($text) {
     # gitlab URLs have an odd /-/ after the repo name, e.g.
     # https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/5244
     $regex
-      = qr{(?<!["\(\[])(?<url_root>$regex)((?<repo>.*?)/(-/)?(issues?|pull|work_items)/)?(?<id>([A-Z]+-)?\d+)(?![\w])};
+      = qr{(?<!["\(\[])(?<url_root>$regex)((?<repo>.*?)/(-/)?(issues?|pulls?|work_items)/)?(?<id>([A-Z]+-)?\d+)(?![\w])};
     $text =~ s{$regex}{@{[$BUGURLS{$+{url_root}} . ($+{repo} ? '#' . $+{repo} : '')]}#$+{id}}gi;
     return $text;
 }

--- a/t/16-utils.t
+++ b/t/16-utils.t
@@ -144,6 +144,11 @@ is href_to_bugref('https://gitlab.com/fedora/sigs/flatpak/fedora-flatpaks/-/issu
   'Fedora SIGs gitlab url to bugref';
 is href_to_bugref('https://invent.kde.org/plasma/systemsettings/-/work_items/49'), 'kdi#plasma/systemsettings#49',
   'KDE Invent gitlab url to bugref (with newer "work_items" name)';
+is bugurl('ffo#foo/bar#1234'), 'https://forge.fedoraproject.org/foo/bar/issues/1234', 'forge.fp.o bugurl';
+is href_to_bugref('https://forge.fedoraproject.org/foo/bar/issues/1234'), 'ffo#foo/bar#1234',
+  'forge.fp.o url to bugref';
+is href_to_bugref('https://forge.fedoraproject.org/foo/bar/pulls/1235'), 'ffo#foo/bar#1235',
+  'forge.fp.o PR url to bugref';
 is find_bug_number('yast_roleconf-ntp-servers-empty-bsc1114818-20181115.png'), 'bsc1114818',
   'find the bug number from the needle name';
 


### PR DESCRIPTION
This is Fedora's new forge (replacing pagure.io). It follows github behavior for issues/pull requests (they're interchangeable). The URL for pull requests is `pulls/`, not `pull/`, so we need to handle this in the regex.