### PR TITLE
perf: Only show builds on first group_overview page

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -158,7 +158,10 @@ sub _group_overview ($self, $resultset, $template) {
     my $pinned_cond = {like => '%pinned-description%'};
     my @pinned_comments = grep { $_->user->is_operator } $comments->search({text => $pinned_cond})->all;
 
-    my $tags = $group->tags;
+    # Avoid reloading all builds just for browsing comments
+    $limit_builds = 0 if $page > 1;
+    my $tags = $page > 1 ? {} : $group->tags;
+
     my $max_jobs_limit = $self->app->config->{misc_limits}->{job_groups_overview_max_jobs};
     my $ignored_groups = $self->app->ignored_groups;
     my $cbr;

--- a/templates/webapi/main/comment_area.html.ep
+++ b/templates/webapi/main/comment_area.html.ep
@@ -1,3 +1,8 @@
+% if (!@$build_results && $comments_pager->current_page > 0) {
+<div class="alert alert-info">
+    Builds are only shown on the first page and not when browsing through the comments.
+</div>
+% }
 <h2>Comments</h2>
 <div id="comments-preview">
     % for my $comment (@$comments) {


### PR DESCRIPTION
This is a simple first mitigation to avoid crawlers going through all comment pages to always load the builds again.

Issues:
* https://progress.opensuse.org/issues/204954
* https://progress.opensuse.org/issues/204963


Will probably be obsoleted when comments are loaded via ajax.

<img width="609" height="244" alt="group-overview-comments-no-builds" src="https://github.com/user-attachments/assets/0ddcad64-f5d0-4ec5-82d5-7106721319bf" />
