### PR TITLE
fix(dockerfile): Use preferred JSON notation

### DIFF
--- a/container/single-instance/Dockerfile
+++ b/container/single-instance/Dockerfile
@@ -27,4 +27,4 @@ ENV OPENQA_SERVICE_PORT_DELTA=0
 ENV LC_ALL=C.UTF-8
 
 ENTRYPOINT ["/usr/share/openqa/script/openqa-bootstrap"]
-HEALTHCHECK CMD curl -f http://localhost || exit 1
+HEALTHCHECK CMD ["curl", "-f", "http://localhost"]


### PR DESCRIPTION
hadolint was warning:

    container/single-instance/Dockerfile:30 DL3025 warning: Use arguments JSON
    notation for CMD and ENTRYPOINT arguments

According to gemini the `|| 1` was redundant anyway.