### PR TITLE
feat(MCP): support MCP spec 2026-07-28

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -52,7 +52,7 @@ requires 'JSON::Validator';
 requires 'JavaScript::Minifier::XS', '>= 0.11';
 requires 'LWP::Protocol::https';
 requires 'LWP::UserAgent';
-requires 'MCP', '>= 0.80.0';
+requires 'MCP', '>= 0.150.0';
 requires 'Minion', '>= 10.25';
 requires 'Minion::Backend::SQLite', '>= 5.0.7';
 requires 'Module::Load::Conditional';

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -185,7 +185,7 @@ worker_requires:
   psmisc:
 
 mcp_requires:
-  perl(MCP): '>= 0.80.0'
+  perl(MCP): '>= 0.150.0'
 
 test_requires:
   '%common_requires':

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -73,7 +73,7 @@
 # The following line is generated from dependencies.yaml
 %define worker_requires bsdtar openQA-client optipng os-autoinst perl(Capture::Tiny) perl(File::Map) perl(Minion::Backend::SQLite) >= 5.0.7 perl(Mojo::IOLoop::ReadWriteProcess) >= 0.26 perl(Mojo::SQLite) psmisc sqlite3 >= 3.24.0
 # The following line is generated from dependencies.yaml
-%define mcp_requires perl(MCP) >= 0.80.0
+%define mcp_requires perl(MCP) >= 0.150.0
 %if 0%{?suse_version} < 1570
 # SLE <= 15 has older Perl not providing a sufficiently recent
 # ExtUtils::ParseXS needed by ExtUtils::CppGuess

--- a/t/api/17-mcp.t
+++ b/t/api/17-mcp.t
@@ -31,13 +31,10 @@ subtest 'Authentication' => sub {
     $t->get_ok('/mcp')->status_is(405);
 };
 
-subtest 'Start session' => sub {
-    is $client->session_id, undef, 'no session id';
-    my $result = $client->initialize_session;
-    is $result->{serverInfo}{name}, 'openQA', 'server name';
-    is $result->{serverInfo}{version}, '1.0.0', 'server version';
+subtest 'Discover server' => sub {
+    my $result = $client->discover;
+    ok $result->{supportedVersions}, 'has supported versions';
     ok $result->{capabilities}, 'has capabilities';
-    ok $client->session_id, 'session id set';
 };
 
 subtest 'List tools' => sub {


### PR DESCRIPTION
Motivation:
The new Model Context Protocol (MCP) 2026-07-28 specification removes
the stateful session handshakes in favor of a clean, stateless design.
We must update our dependency requirements and tests to be compatible
with this stateless architecture.

Design Choices:
1. Update perl-MCP dependency constraint to version 0.150.0.
2. Refactor openQA integration tests to use stateless discover and
eliminate stateful session assertions.

Benefits:
- Alignment with the standard stateless MCP specification.
- Seamless horizontal scaling of openQA web UI instances.