### PR TITLE
fix: Check for pages greater than 1

### DIFF
--- a/templates/webapi/main/comment_area.html.ep
+++ b/templates/webapi/main/comment_area.html.ep
@@ -1,4 +1,4 @@
-% if (!@$build_results && $comments_pager->current_page > 0) {
+% if (!@$build_results && $comments_pager->current_page > 1) {
 <div class="alert alert-info">
     Builds are only shown on the first page and not when browsing through the comments.
 </div>


### PR DESCRIPTION
I accidentally compared to zero insted of one for showing the hint. That means currently the hint would be shown for any group that has no builds.

Issues:
* https://progress.opensuse.org/issues/204954
* https://progress.opensuse.org/issues/204963