### PR TITLE
feat: Add NGINX-level rate limiting for details_ajax route

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -489,6 +489,33 @@ memory segment according to the formula: page_size \* 8
 For openQA you need to set `httpsonly = 0` as described in the TLS/SSL section
 below, if you do not setup NGINX for SSL.
 
+#### Rate limiting
+The example NGINX configurations include a rate-limiting setup for the
+potentially resource-intensive `/tests/<testid:num>/details_ajax` endpoint to
+protect the web UI from being overwhelmed by too many simultaneous Ajax requests
+(e.g., from automated scripts or heavy browser sessions).
+
+This is configured in:
+* `openqa.conf.template` via the `limit_req_zone` directive, defining a shared
+  memory zone `details_ajax_limit`.
+* `openqa-endpoints.inc` via the matching location block applying `limit_req`.
+
+##### Load balancer and reverse proxy consideration
+If your openQA instance is hosted behind an upstream load balancer or an
+external reverse proxy (like HAProxy, AWS ALB, or Cloudflare), NGINX's
+`$binary_remote_addr` will evaluate to the IP address of that load balancer
+instead of the actual client's IP. This would cause all client requests to share
+the same rate-limiting bucket, causing premature HTTP `429 Too Many Requests`
+responses.
+
+To resolve this, make sure the NGINX `real_ip` module is configured in your main
+NGINX setup to extract the true client IP from the `X-Forwarded-For` header:
+
+```nginx
+real_ip_header X-Forwarded-For;
+set_real_ip_from <your-balancer-ip-or-subnet>;
+```
+
 ### TLS/SSL
 
 By default openQA expects to be run with HTTPS. The `openqa-ssl.conf.template`

--- a/etc/nginx/vhosts.d/openqa-endpoints.inc
+++ b/etc/nginx/vhosts.d/openqa-endpoints.inc
@@ -10,6 +10,16 @@ client_body_buffer_size 12m;
 # Default is exact which would need an exact match of Last-Modified
 if_modified_since before;
 
+# Default proxy settings inherited by locations forwarding to Mojolicious
+tcp_nodelay        on;
+proxy_read_timeout 900;
+proxy_send_timeout 900;
+proxy_set_header Host $host;
+proxy_set_header X-Forwarded-Host $host:$server_port;
+proxy_set_header X-Forwarded-Server $host;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+
 ## Optional to make use of auth_request to require authentication for asset downloads
 #location /api/v1/auth {
 #    internal;
@@ -58,27 +68,20 @@ location /liveviewhandler/ {
 
 location / {
     proxy_pass "http://webui";
-    tcp_nodelay        on;
-    proxy_read_timeout 900;
-    proxy_send_timeout 900;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Host $host:$server_port;
-    proxy_set_header X-Forwarded-Server $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
 }
 
 location ~ /tests/[0-9]+/(livelog|liveterminal)$ {
-    # Duplicate settings for location /, nginx can't merge locations :-(
+    # Default settings inherited from server block; only buffering needs tuning here
     proxy_pass "http://webui";
-    tcp_nodelay        on;
-    proxy_read_timeout 900;
-    proxy_send_timeout 900;
-    proxy_set_header Host $host;
-    proxy_set_header X-Forwarded-Host $host:$server_port;
-    proxy_set_header X-Forwarded-Server $host;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-
     proxy_buffering off;
+}
+
+location ~ ^/tests/[0-9]+/details_ajax$ {
+    # Apply rate limiting to details_ajax
+    limit_req zone=details_ajax_limit burst=10 nodelay;
+    limit_req_status 429;
+    add_header Retry-After 5 always;
+
+    # Backend settings are inherited from the server block
+    proxy_pass "http://webui";
 }

--- a/etc/nginx/vhosts.d/openqa.conf.template
+++ b/etc/nginx/vhosts.d/openqa.conf.template
@@ -1,5 +1,8 @@
 include vhosts.d/openqa-upstreams.inc;
 
+# Define rate limiting zone for details_ajax endpoint (10MB zone allows ~160,000 IPs)
+limit_req_zone $binary_remote_addr zone=details_ajax_limit:10m rate=5r/s;
+
 server {
     listen       80 default_server;
     listen       [::]:80 default_server;


### PR DESCRIPTION
Implement rate limiting at the NGINX level for the potentially resource-intensive `/tests/$job_id/details_ajax` endpoint to protect the web UI from being overwhelmed:

* Add a `limit_req_zone` directive using `$binary_remote_addr` in the HTTP context inside `openqa.conf.template`
* Deduplicate existing proxy configurations in `openqa-endpoints.inc` by moving common `proxy_*` and `tcp_nodelay` settings to the top-level server context so they are inherited by all backend locations (`/`, livelog, liveterminal, details_ajax) without duplication
* Create a regex location block inside `openqa-endpoints.inc` matching the `/details_ajax` route with rate-limiting using the configured zone
* Documenting the new rate-limiting feature in `docs/Installing.md`, including critical considerations for when the deployment is behind an external reverse proxy or load balancer

Related ticket: https://progress.opensuse.org/issues/204900

---

Still a draft because I haven't tested this yet.