### PR TITLE
fix: Ensure valid format for HTML element ids

### DIFF
--- a/templates/webapi/test/overview_result_table.html.ep
+++ b/templates/webapi/test/overview_result_table.html.ep
@@ -35,7 +35,7 @@
                         <td>-</td>
                         % next;
                     % }
-                    % my $resultid = join('_', $type, $arch, $config) =~ tr/ /_/r;
+                    % my $resultid = join('_', $type, $arch, $config) =~ tr/ #/_/r;
                     %= include 'test/tr_job_result', resultid => $resultid, res => $res, state => $state, jobid => $jobid
                 % }
             </tr>


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/205233

A hash / pound sign in a HTML element id can break JS / CSS selectors.

See also 0c899e0ddd5796c3ca2658097cce194a55054cdd