### PR TITLE
fix: set client_body_buffer_size 12m everywhere

### DIFF
--- a/container/helm/openqa/templates/configmap.yaml
+++ b/container/helm/openqa/templates/configmap.yaml
@@ -75,6 +75,11 @@ data:
             listen 80;
             server_name _;
 
+            # The "client_body_buffer_size" value should usually be larger
+            # than the UPLOAD_CHUNK_SIZE used by openQA workers, so there is
+            # no excessive buffering to disk
+            client_body_buffer_size 12m;
+
             client_max_body_size 0;
 
             # WebSocket endpoint

--- a/container/webui/nginx.conf
+++ b/container/webui/nginx.conf
@@ -18,6 +18,11 @@ http {
         server_name  localhost;
         client_max_body_size 0;
 
+        # The "client_body_buffer_size" value should usually be larger
+        # than the UPLOAD_CHUNK_SIZE used by openQA workers, so there is
+        # no excessive buffering to disk
+        client_body_buffer_size 12m;
+
         ssl_certificate     /etc/ssl/certs/openqa.crt;
         ssl_certificate_key /etc/ssl/certs/openqa.key;
         ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;


### PR DESCRIPTION
It's set in etc/nginx/vhosts.d/openqa-endpoints.inc, also copy it over to other nginx configurations to improve performance.

Semi-related ticket: https://progress.opensuse.org/issues/205236