### PR TITLE
fix(ci): pin chromedriver/chromium in CI image

### DIFF
--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -7,10 +7,23 @@
 # hadolint ignore=DL3006
 FROM opensuse/tumbleweed
 
+# t/33-developer_mode.t exposes a real bug in the isotovideo <-> backend IPC
+# (poo#205206): a reply is lost, so the test keeps waiting for something that
+# never happens and runs into the runtime limit. Downgrading chromedriver and
+# chromium to 150 empirically avoids it; why it makes a difference is not
+# understood, so this is only a stopgap to keep CI usable, not a fix and not a
+# claim that chromedriver is at fault. Remove once the IPC bug is fixed.
+# x86_64-only: the history mirror publishes no other architecture.
 # hadolint ignore=DL3037
 RUN zypper ar -p 95 -f 'https://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed' devel_openQA && \
     zypper --gpg-auto-import-keys ref && \
     zypper in -y os-autoinst-devel openQA-devel nodejs-default perl-TAP-Harness-JUnit && \
+    if [ "$(uname -m)" = "x86_64" ]; then \
+        zypper in -y --oldpackage \
+            'https://download.opensuse.org/history/20260731/tumbleweed/repo/oss/x86_64/chromedriver-150.0.7871.186-1.1.x86_64.rpm' \
+            'https://download.opensuse.org/history/20260731/tumbleweed/repo/oss/x86_64/chromium-150.0.7871.186-1.1.x86_64.rpm' && \
+        zypper al chromedriver chromium; \
+    fi && \
     zypper clean -a
 
 ENV OPENQA_DIR=/opt/openqa


### PR DESCRIPTION
## Why

@Martchus was right in review: this is not a chromedriver bug and the test is
not broken — it surfaces a real defect in openQA/os-autoinst. Rewritten
accordingly, and now actually verified locally.

`t/33-developer_mode.t` hits the IPC problem described in poo#205206: the reply
to `reload_needles` is lost, isotovideo reads the _following_ message instead,
the `json_cmd_token` no longer matches, and autotest is left waiting for an
answer that never arrives. The test does not get slower — it stops making
progress, and the fullstack job bails out at its 200s runtime limit. Every
fullstack run in both repos has failed this way since the Tumbleweed 20260802
snapshot.

Downgrading chromedriver/chromium to 150.0.7871.186 makes it pass again. **Why
the browser version decides whether the race is hit is not understood.** So
this is deliberately a stopgap to make CI usable, not a fix, and not a claim
that chromedriver is at fault. The real fix belongs in the os-autoinst IPC —
drop this pin once that lands.

## What changed

`container/ci/Dockerfile`: after the usual CI packages, reinstall
chromedriver/chromium `150.0.7871.186` from the Tumbleweed history mirror and
`zypper al` them so nothing later in the build pulls them back to 151.

x86_64-only — not a CI-arch preference, but because
`download.opensuse.org/history` publishes **no other architecture**
(`.../20260731/tumbleweed/repo/oss/aarch64/` is a 404). The aarch64 image
therefore keeps 151.

## Testing

Built the image and ran the test inside it, varying **only** the
chromedriver/chromium version in one long-running container — same openQA
checkout, same os-autoinst, same postgres, same qemu, same everything else:

| chromedriver/chromium     | runs | result                                     |
| ------------------------- | ---- | ------------------------------------------ |
| `150.0.7871.186` (pinned) | 3    | **PASS** — 38s, 49s, 48s                   |
| `151.0.7922.71`           | 2    | **FAIL** — both bail out at the 200s limit |

Both 151 failures reproduce the CI signature exactly:

```
Bailout called.  Further testing stopped:
  test 't/33-developer_mode.t' exceeds runtime limit of '200' seconds
```

and `autoinst-log.txt` shows the poo#205206 cause:

```
!!! main: ERROR: the token does not match - questions and answers not in
the right order at .../myjsonrpc.pm line 93.
```

Other checks:

- `hadolint container/ci/Dockerfile`: clean.
- Resulting x86_64 image: `chromium-150.0.7871.186`,
  `chromedriver-150.0.7871.186`, both locked; `zypper up chromium` refuses to
  cross the lock.
- Browser smoke test in the image (same flags as
  `t/lib/OpenQA/SeleniumTest.pm`): starts, navigates, queries the DOM, runs JS
  — the downgraded pair is functional, no version-mismatch fallout.
- arm64 image built too: guard correctly skipped, no locks added, 151 retained
  — so the aarch64/riscv64 OBS builds are unaffected.
- `make test-shellcheck` clean (inside the container; it fails on a macOS host
  for an unrelated pre-existing reason — `/etc/os-release` missing).

## Notes for review

Two things I did not change but that a reviewer may want to weigh in on:

1. The build installs chromium 151 (~160 MiB) and then immediately replaces it
   with 150. Wasteful, but folding the pinned URLs into the main `zypper in`
   risks entangling `--oldpackage` with the rest of the resolution, so I left
   the straightforward version.
2. Reproducing this needed a workaround unrelated to the change: building the
   image locally on x86_64 currently fails in the _first_ `zypper in`, because
   the published `opensuse/tumbleweed` image (snapshot 20260804) is one
   snapshot ahead of the repo it points at (20260803), and
   `crypto-policies-scripts` — pulled in by the preinstalled
   `patterns-base-fips` as soon as `openssh-clients` is installed — requires an
   exact-NEVR match on `crypto-policies`. `master` fails identically, OBS build
   roots are unaffected, and it self-heals once the repo catches up. Filed
   separately as poo#205278 with a verified fix (`zypper dup` first), kept out
   of this PR.

Ref: poo#205206
