### PR TITLE
test: Work around command processing issues of os-autoinst

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -206,6 +206,7 @@ subtest 'pause at assert_screen timeout' => sub {
     wait_for_developer_console_like($driver, qr/\"resume_test_execution\":/, 'resume');
 
     # skip timeout (again)
+    sleep 5;    # workaround command processing issue, see https://progress.opensuse.org/issues/205206
     enter_developer_console_cmd $driver, '{"cmd":"set_assert_screen_timeout","timeout":0}';
     wait_for_developer_console_like(
         $driver,


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/205206