### PR TITLE
feat: make privacy policy links configurable

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -5,6 +5,9 @@
 ## type of branding - [ openSUSE, plain, openqa.suse.de ]
 #branding = plain
 
+## Link to the privacy policy of the openQA instance
+#privacy_policy_url = https://github.com/os-autoinst/openQA/blob/master/docs/PrivacyPolicy.md
+
 ## space separated list of domains from which asset download with
 ## _URL params is allowed. Matched at the end of the hostname in
 ## the URL. with these values downloads from opensuse.org,

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -119,6 +119,7 @@ sub default_config () {
             appname => 'openQA',
             base_url => undef,
             branding => 'openSUSE',
+            privacy_policy_url => 'https://github.com/os-autoinst/openQA/blob/master/docs/PrivacyPolicy.md',
             download_domains => undef,
             suse_mirror => undef,
             # deprecated alternate for git_auto_commit below

--- a/t/22-dashboard.t
+++ b/t/22-dashboard.t
@@ -608,6 +608,18 @@ subtest 'SUSE branding' => sub {
     $t->attr_like('a.fa-unlink', 'data-template', qr/\@review:acceptable_for/, 'review marker on test overview page');
 };
 
+subtest 'Privacy policy configuration' => sub {
+    $t->get_ok('/')->status_is(200)->text_like('#footer-legal a', qr/Privacy Policy/)
+      ->attr_like('#footer-legal a', 'href', qr|docs/PrivacyPolicy.md|);
+
+    my $original_url = $t->app->config->{global}->{privacy_policy_url};
+    $t->app->config->{global}->{privacy_policy_url} = 'https://custom-privacy-policy.org';
+    $t->get_ok('/')->status_is(200)->text_like('#footer-legal a', qr/Privacy Policy/)
+      ->attr_like('#footer-legal a', 'href', qr|^https://custom-privacy-policy\.org$|);
+
+    $t->app->config->{global}->{privacy_policy_url} = $original_url;
+};
+
 subtest 're-routing' => sub {
     # enable re-routing like it can be enabled via Mojolicious::Plugin::RequestBase
     $t->app->hook(before_dispatch => sub ($c) { $c->req->url->base->path('/base') });

--- a/templates/webapi/api_key/index.html.ep
+++ b/templates/webapi/api_key/index.html.ep
@@ -53,7 +53,7 @@
                 <li>Anonymize audit log entries (your username will be replaced)</li>
                 <li>Replace your username, email, and profile information with placeholder values</li>
             </ul>
-            <p>See our <a href="https://github.com/os-autoinst/openQA/blob/master/docs/PrivacyPolicy.md" target="_blank">Privacy Policy</a> for more information about how we handle your data.</p>
+            <p>See our <a href="<%= app->config->{global}->{privacy_policy_url} %>" target="_blank">Privacy Policy</a> for more information about how we handle your data.</p>
             <div class="alert alert-warning">
                 <strong>This action cannot be undone.</strong>
             </div>

--- a/templates/webapi/layouts/bootstrap.html.ep
+++ b/templates/webapi/layouts/bootstrap.html.ep
@@ -67,7 +67,7 @@
                   </span>
               </div>
               <div id='footer-legal' class="text-center">
-                  <a href='https://github.com/os-autoinst/openQA/blob/master/docs/PrivacyPolicy.md'>Privacy Policy</a> -
+                  <a href="<%= app->config->{global}->{privacy_policy_url} %>">Privacy Policy</a> -
                   openQA is licensed under
                   %= link_to 'GPL-2.0' => 'https://github.com/os-autoinst/openQA'
                   % if ($current_version) {


### PR DESCRIPTION
Motivation:
The privacy policy links were hardcoded to point to the openQA repository on
GitHub, preventing downstream openQA instances from supplying their own.

Design Choices:
Introduced the `privacy_policy_url` global configuration option in openqa.ini
with the upstream URL as fallback, and updated the templates to use it.

Benefits:
Downstream openQA deployments can now customize the privacy policy URL directly
in their openqa.ini file without having to create custom branding templates.