### PR TITLE
feat(Worker): send graceful SIGTERM to isotovideo, not its process group

### DIFF
--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -77,6 +77,12 @@
 # their versions in plain text.
 #PACKAGES_CMD = rpm -qa
 
+# Grace period in seconds between the graceful SIGTERM sent to isotovideo when a
+# job is cancelled and the whole-group SIGKILL that sweeps any remaining
+# processes. Increase this if tests run always_run modules after cancellation
+# that need longer to finish. The default is 30 seconds.
+#ISOTOVIDEO_KILL_TIMEOUT = 30
+
 # Specifies the threshold to consider the load on the machine critical. If the
 # average load (over the last 15 minutes) exceeds the specified value the worker
 # will not accept new jobs (until the load decreases again).

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -383,8 +383,11 @@ sub _checkout_path ($url_or_path, $is_url) {
 
 sub _engine_workit_step_2 ($job, $job_settings, $vars, $shared_cache, $callback) {
     my $worker = $job->worker;
+    my $global_settings = $worker->settings->global_settings;
     my $pooldir = $worker->pool_directory;
     my $job_info = $job->info;
+
+    my $stop_timeout = $global_settings->{ISOTOVIDEO_KILL_TIMEOUT} // 30;
 
     $vars->{ASSETDIR} //= OpenQA::Utils::assetdir;
 
@@ -457,10 +460,10 @@ sub _engine_workit_step_2 ($job, $job_settings, $vars, $shared_cache, $callback)
     my $child = process(
         set_pipes => 0,    # disable additional pipes for process communication
         internal_pipes => 0,    # disable additional pipes for retrieving process return/errors
-        kill_whole_group => 1,    # terminate/kill whole process group
+        kill_whole_group => 0,    # signal isotovideo only, not the whole process group
         max_kill_attempts => 1,    # stop the process by sending SIGTERM one time …
         sleeptime_during_kill => .1,    # … and checking for termination every 100 ms …
-        total_sleeptime_during_kill => 30,    # … for 30 seconds …
+        total_sleeptime_during_kill => $stop_timeout,    # … for the configured grace period …
         kill_sleeptime => 0,    # … and wait not any longer …
         blocking_stop => 1,    # … before sending SIGKILL
         code => sub {

--- a/lib/OpenQA/Worker/Job.pm
+++ b/lib/OpenQA/Worker/Job.pm
@@ -15,7 +15,7 @@ use OpenQA::Utils qw(find_video_files usleep_backoff);
 
 use Digest::MD5;
 use Fcntl;
-use POSIX 'strftime';
+use POSIX qw(strftime SIGKILL);
 use File::Basename 'basename';
 use File::stat;
 use File::Which 'which';
@@ -291,9 +291,19 @@ sub _handle_engine_startup ($self, $engine, $max_job_time) {
     $self->_set_status(running => {});
 }
 
-sub kill ($self) {
+# sends SIGKILL to the whole process group of isotovideo
+sub _kill_process_group ($self, $pid) { kill SIGKILL, -$pid }
+
+sub kill ($self, $force = 0) {
     return undef unless my $engine = $self->engine;
-    if (my $child = $engine->{child}) { $child->stop }
+    my $child = $engine->{child} or return undef;
+    my $pid = $child->pid or return undef;
+
+    if ($force) { $self->_kill_pgrp($pid); return undef }
+
+    # graceful stop
+    $child->stop;
+    $self->_kill_process_group($pid);
     return undef;
 }
 
@@ -312,7 +322,10 @@ sub stop ($self, $reason = undef) {
 
     # ignore calls to stop if already stopped or stopping
     # note: This method might be called at any time (including when an interrupted happens).
-    return undef if $self->is_stopped_or_stopping;
+    if ($self->is_stopped_or_stopping) {
+        $self->kill(1) if $self->status eq 'stopping';
+        return undef;
+    }
 
     my $status = $self->status;
     $self->_set_status(stopped => {reason => $reason}) and return undef


### PR DESCRIPTION
When a job is cancelled the worker spawned isotovideo with kill_whole_group => 1, so a signel SIGTERM can terminate the whole process group at once. Send the SIGTERM to the main isotovideo process only so it can manage the related group.

Related: https://progress.opensuse.org/issues/197822

TODO: Need to do some E2E test and add unit tests