### PR TITLE
docs: Revise definition of scenario to include history isolation

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -143,7 +143,12 @@ Types" in the web interface of openQA
 
 **scenario**
 : A composition of `<distri>-<version>-<flavor>-<arch>-<test_suite>@<machine>`,
-e.g. "openSUSE-Tumbleweed-DVD-x86_64-gnome@64bit", nicknamed _koala_
+e.g. "openSUSE-Tumbleweed-DVD-x86_64-gnome@64bit", nicknamed _koala_.
+This composition establishes the base identity of a test used for grouping jobs
+into a common history. Jobs sharing the same scenario can be further
+partitioned into independent histories (e.g. to separate pull requests or
+incident tests) using history isolation settings like `SUBMISSION_ID` so that
+unrelated test runs do not pollute each other's history.
 
 **build**
 : Different versions of a product as tested, can be considered a "sub-version"


### PR DESCRIPTION
The merger of openSUSE/qem-bot#655 means that jobs can now have a proper
SUBMISSION_ID to isolate them into separate job histories. As a result, the
definition of a "scenario" (nicknamed koala) has been updated to reflect
that jobs sharing the same scenario can be partitioned into independent
histories to prevent unrelated test runs from polluting each other's history.

Related issue: https://progress.opensuse.org/issues/200952