### PR TITLE
test: Preserve exit code in END block

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -376,7 +376,7 @@ done_testing;
 
 # in case it dies
 END {
+    local $?;
     kill_driver;
     turn_down_stack;
-    $? = 0;
 }

--- a/t/full-stack.t
+++ b/t/full-stack.t
@@ -465,9 +465,9 @@ subtest 'Cache tests' => sub {
 done_testing;
 
 END {
+    local $?;
     kill_driver;
     turn_down_stack;
     session->clean;
-    $? = 0;
     $tempdir->list_tree->grep(qr/\.txt$/)->each(sub { print "$_:\n" . $_->slurp }) if defined $tempdir;
 }


### PR DESCRIPTION
Motivation:
Unconditionally setting `$? = 0` in the END block suppresses any non-zero exit
codes from `BAIL_OUT` or other errors, causing `prove` to report successful test
runs despite failures (e.g. timeouts).

Design Choices:
Use `local $?` instead of `$? = 0`. Originally, `$? = 0` was introduced in
commit 94be89f7b ("Run the full stack in an extra test on travis") to prevent
cleanup side-effects (like waitpid on killed children) from failing tests.
Using `local $?` prevents these cleanup side-effects from leaking while still
preserving the original legitimate test exit code.

Benefits:
Ensures test runner correctly reports failures such as timeouts while still
allowing the END block cleanup routines to run safely.

Related issue: https://github.com/os-autoinst/os-autoinst/pull/3068