### PR TITLE
test: Fix race conditions and revert workaround in developer mode fullstack test

### DIFF
--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -206,7 +206,6 @@ subtest 'pause at assert_screen timeout' => sub {
     wait_for_developer_console_like($driver, qr/\"resume_test_execution\":/, 'resume');
 
     # skip timeout (again)
-    sleep 5;    # workaround command processing issue, see https://progress.opensuse.org/issues/205206
     enter_developer_console_cmd $driver, '{"cmd":"set_assert_screen_timeout","timeout":0}';
     wait_for_developer_console_like(
         $driver,

--- a/t/33-developer_mode.t
+++ b/t/33-developer_mode.t
@@ -201,9 +201,27 @@ subtest 'pause at assert_screen timeout' => sub {
         'paused after assert_screen timeout'
     );
 
+    # clear console so subsequent wait_for_developer_console_like calls don't see old output
+    $driver->execute_script('document.getElementById("log").value = ""');
+
     # try to resume
     enter_developer_console_cmd $driver, '{"cmd":"resume_test_execution"}';
     wait_for_developer_console_like($driver, qr/\"resume_test_execution\":/, 'resume');
+
+    # run some command immediately after resuming to stress test command processing
+    # note: This might not have an effect as the backend might not be on the next assert screen yet.
+    #       However, the backend must also not crash or get stuck just because we send a command immediately
+    #       after resuming (like in https://progress.opensuse.org/issues/205206).
+    enter_developer_console_cmd $driver, '{"cmd":"set_assert_screen_timeout","timeout":1000}';
+
+    # wait until asserting 'on_prompt' again
+    # note: Do not just skip the timeout directly after resuming; we need to wait for the backend to
+    #       enter the state where it asserts something before we can skip the assertion.
+    wait_for_developer_console_like(
+        $driver,
+        qr/(\"tags\":\[\"on_prompt\"\]|\"mustmatch\":\"on_prompt\")/,
+        'asserting on_prompt'
+    );
 
     # skip timeout (again)
     enter_developer_console_cmd $driver, '{"cmd":"set_assert_screen_timeout","timeout":0}';
@@ -334,8 +352,8 @@ subtest 'resume test execution and 2nd tab' => sub {
     # go back to the live view
     $driver->get($job_page_url);
     $driver->find_element_by_link_text('Live View')->click();
-    wait_for_session_info(qr/owned by Demo.*2 tabs open/,
-        '2 browser tabs open (live view and tab from previous subtest)');
+    wait_for_session_info(qr/owned by Demo.*([2-9]|1\d+) tabs open/,
+        'more than one browser tab open (live view and tab from previous subtest)');
 
     # open developer console
     $driver->get($developer_console_url);


### PR DESCRIPTION
Check out individual commit messages and https://progress.opensuse.org/issues/205206 for details.

So there's a problem with the developer mode fullstack test after all. However, there's nevertheless an even bigger problem in os-autoinst. I have a fix for that now but I still have to update https://github.com/os-autoinst/os-autoinst/pull/3078 accordingly. This also means that CI is supposed to fail here with a high likelihood (showing that the now explicit stress test can expose issues in os-autoinst).