### PR TITLE
feat(comments): load comments via AJAX

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -187,3 +187,100 @@ function insertTemplate(button) {
   const template = button.dataset.template;
   textarea.value += textarea.value ? '\n' + template : template;
 }
+
+function getUrlWithoutHash(urlStr) {
+  const url = new URL(urlStr, window.location.href);
+  url.hash = '';
+  return url.toString();
+}
+
+let lastLoadedUrl = getUrlWithoutHash(window.location.href);
+
+document.addEventListener('click', event => {
+  const link = event.target.closest('#comment-area .comments-pagination a');
+  if (!link) return;
+  event.preventDefault();
+
+  const urlStr = link.href;
+  if (!urlStr) return;
+
+  loadComments(urlStr, true);
+});
+
+function loadComments(urlStr, pushState) {
+  const wrapper = document.getElementById('comment-area');
+  if (!wrapper) return;
+
+  const url = new URL(urlStr, window.location.href);
+  // Transform the regular overview URL into the AJAX endpoint URL
+  url.pathname = url.pathname.replace(/\/?$/, '/comments_ajax');
+
+  fetch(url.toString(), {
+    headers: {
+      Accept: 'text/html'
+    }
+  })
+    .then(response => {
+      if (!response.ok) throw new Error(`Server returned ${response.status}: ${response.statusText}`);
+      return response.text();
+    })
+    .then(html => {
+      wrapper.innerHTML = html;
+      lastLoadedUrl = getUrlWithoutHash(urlStr);
+      if (pushState) {
+        history.pushState({commentsUrl: urlStr}, '', urlStr);
+      }
+      if (typeof updateTimeago === 'function') {
+        updateTimeago();
+      }
+      // If the URL has a hash (e.g. #comment-123), scroll to it after AJAX loads
+      if (window.location.hash) {
+        // Try/catch in case the hash is an invalid CSS selector
+        try {
+          const target = document.querySelector(window.location.hash);
+          if (target) {
+            target.scrollIntoView();
+          }
+        } catch (e) {
+          // ignore
+        }
+      }
+    })
+    .catch(error => {
+      addFlash('danger', `Failed to load comments: ${error.message || error}`);
+    });
+}
+
+// A boolean to distinguish actual popstate events (user navigating history)
+// from the initial popstate event that some browsers (like older Safari/Chrome)
+// fire on page load.
+let popstateActive = false;
+
+// Load comments automatically when the DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+  const wrapper = document.getElementById('comment-area');
+  if (wrapper) {
+    loadComments(window.location.href, false);
+  }
+});
+
+// We use setTimeout to defer setting popstateActive to true until after
+// the current execution queue is empty, effectively waiting until any
+// auto-triggered popstate event from page load has already fired.
+window.addEventListener('load', () => {
+  setTimeout(() => {
+    popstateActive = true;
+  }, 0);
+});
+
+// Handle browser back/forward navigation within the comment pagination.
+window.addEventListener('popstate', event => {
+  if (!popstateActive) return;
+  const wrapper = document.getElementById('comment-area');
+  if (!wrapper) return;
+
+  const targetUrl = (event.state && event.state.commentsUrl) || window.location.href;
+  if (getUrlWithoutHash(targetUrl) === lastLoadedUrl) return;
+
+  loadComments(targetUrl, false);
+});

--- a/lib/OpenQA/Schema/ResultSet/Comments.pm
+++ b/lib/OpenQA/Schema/ResultSet/Comments.pm
@@ -129,4 +129,24 @@ sub comment_data_for_jobs ($self, $jobs, $args = {}) {
     return \%res;
 }
 
+=over 4
+
+=item pinned_descriptions()
+
+Return comments matching pinned descriptions from operators.
+
+=back
+
+=cut
+
+sub pinned_descriptions ($self) {
+    return $self->search(
+        {
+            text => {like => '%pinned-description%'},
+            user_id => {
+                -in => $self->result_source->schema->resultset('Users')->search({is_operator => 1})->get_column('id')
+                  ->as_query
+            }});
+}
+
 1;

--- a/lib/OpenQA/WebAPI.pm
+++ b/lib/OpenQA/WebAPI.pm
@@ -210,8 +210,12 @@ sub startup ($self) {
     $r->get('/image/:md5_1/:md5_2/.thumbs/#md5_basename')->to('file#thumb_image');
     $r->get('/group_overview/<groupid:num>' => [format => ['json', 'html']])->name('group_overview')
       ->to('main#job_group_overview', format => undef);
+    $r->get('/group_overview/<groupid:num>/comments_ajax' => [format => ['html']])->name('job_group_comments_ajax')
+      ->to('main#job_group_comments_ajax', format => undef);
     $r->get('/parent_group_overview/<groupid:num>' => [format => ['json', 'html']])->name('parent_group_overview')
       ->to('main#parent_group_overview', format => undef);
+    $r->get('/parent_group_overview/<groupid:num>/comments_ajax' => [format => ['html']])
+      ->name('parent_group_comments_ajax')->to('main#parent_group_comments_ajax', format => undef);
 
     # Favicon
     $r->get('/favicon.ico' => sub ($c) { $c->render_static('favicon.ico') });

--- a/lib/OpenQA/WebAPI/Controller/Main.pm
+++ b/lib/OpenQA/WebAPI/Controller/Main.pm
@@ -160,32 +160,17 @@ sub _group_overview ($self, $resultset, $template) {
     my $group_id = $self->stash('groupid');
     return $self->reply->not_found unless my $group = $self->schema->resultset($resultset)->find($group_id);
 
-    my $page = $validation->param('comments_page') // 1;
-    my $page_limit = $validation->param('comments_limit') // 5;
-
     $self->inactivity_timeout(OPENQA_WEBUI_OVERVIEW_INACTIVITY_TIMEOUT);
-    # find comments
-    my $comments = $group->comments;
-    my $ordered_comments = $comments->search(
-        undef,
-        {
-            page => $page,
-            rows => $page_limit,
-            order_by => {-desc => 't_created'},
-        });
-    $self->stash('comments_pager', $ordered_comments->pager());
-    my @comments = $ordered_comments->all;
 
-    # find "pinned descriptions" (comments by operators with the word 'pinned-description' in it)
-    my $pinned_cond = {like => '%pinned-description%'};
-    my @pinned_comments = grep { $_->user->is_operator } $comments->search({text => $pinned_cond})->all;
-
-    # Avoid reloading all builds just for browsing comments
-    $limit_builds = 0 if $page > 1;
-    my $tags = $page > 1 ? {} : $group->tags;
+    my $tags = $group->tags;
 
     my $max_jobs_limit = $self->app->config->{misc_limits}->{job_groups_overview_max_jobs};
     my $ignored_groups = $self->app->ignored_groups;
+    my $build_results = [];
+    my $max_jobs = 0;
+    my $limit_exceeded = 0;
+    my $children = undef;
+
     my $cbr;
     try {
         $cbr
@@ -197,11 +182,12 @@ sub _group_overview ($self, $resultset, $template) {
         die $e unless $e =~ qr/^invalid regex: /;
         return $self->_respond_error_for_group_overview($e);
     }
-    my $build_results = $cbr->{build_results};
-    my $max_jobs = $cbr->{max_jobs};
-    my $limit_exceeded = $cbr->{limit_exceeded};
+    $build_results = $cbr->{build_results};
+    $max_jobs = $cbr->{max_jobs};
+    $limit_exceeded = $cbr->{limit_exceeded};
+    $children = $cbr->{children};
 
-    $self->stash(children => $cbr->{children});
+    $self->stash(children => $children);
     $self->stash(
         build_results => $build_results,
         max_jobs => $max_jobs,
@@ -211,6 +197,9 @@ sub _group_overview ($self, $resultset, $template) {
     my $is_parent_group = $group->can('children');
     my $comment_context = $is_parent_group ? 'parent_group' : 'group';
     my $comment_context_route_suffix = $comment_context . '_comment';
+    my $comments = $group->comments;
+    my @pinned_comments = $comments->pinned_descriptions->all;
+
     my $group_hash = {
         id => $group->id,
         name => $group->name,
@@ -230,7 +219,6 @@ sub _group_overview ($self, $resultset, $template) {
         limit_builds => $limit_builds,
         limit_builds_preset => \@limit_builds_preset,
         only_tagged => $only_tagged,
-        comments => \@comments,
         pinned_comments => \@pinned_comments,
         comment_context => $comment_context,
         comment_post_action => 'apiv1_post_' . $comment_context_route_suffix,
@@ -239,8 +227,17 @@ sub _group_overview ($self, $resultset, $template) {
     );
     $self->respond_to(
         json => sub ($self) {
-            @comments = map { $_->hash } @comments;
-            @pinned_comments = map { $_->hash } @pinned_comments;
+            my $page = $validation->param('comments_page') // 1;
+            my $page_limit = $validation->param('comments_limit') // 5;
+            my $ordered_comments = $group->comments->search(
+                undef,
+                {
+                    page => $page,
+                    rows => $page_limit,
+                    order_by => {-desc => 't_created'},
+                });
+            my @comments_hashes = map { $_->hash } $ordered_comments->all;
+            my @pinned_comments_hashes = map { $_->hash } @pinned_comments;
             $self->render(
                 json => {
                     group => $group_hash,
@@ -249,15 +246,63 @@ sub _group_overview ($self, $resultset, $template) {
                     limit_exceeded => $limit_exceeded ? $max_jobs_limit : 0,
                     description => $group->description,
                     children => $self->stash('children'),
-                    comments => \@comments,
-                    pinned_comments => \@pinned_comments
+                    comments => \@comments_hashes,
+                    pinned_comments => \@pinned_comments_hashes,
                 });
         },
-        html => {template => $template});
+        html => sub ($self) {
+            $self->render(template => $template);
+        });
+}
+
+sub _group_comments_ajax ($self, $resultset, $pagination_route) {
+    my $validation = $self->validation;
+    $validation->optional('comments_page')->num;
+    $validation->optional('comments_limit')->num;
+    return $self->reply->validation_error({format => $self->accepts('html')}) if $validation->has_error;
+
+    my $group_id = $self->stash('groupid');
+    return $self->reply->not_found unless my $group = $self->schema->resultset($resultset)->find($group_id);
+
+    my $page = $validation->param('comments_page') // 1;
+    my $page_limit = $validation->param('comments_limit') // 5;
+
+    $self->inactivity_timeout(OPENQA_WEBUI_OVERVIEW_INACTIVITY_TIMEOUT);
+    # find comments
+    my $comments = $group->comments;
+    my $ordered_comments = $comments->search(
+        undef,
+        {
+            page => $page,
+            rows => $page_limit,
+            order_by => {-desc => 't_created'},
+        });
+    $self->stash('comments_pager', $ordered_comments->pager());
+    my @comments = $ordered_comments->all;
+
+    my $is_parent_group = $group->can('children');
+    my $comment_context = $is_parent_group ? 'parent_group' : 'group';
+    my $comment_context_route_suffix = $comment_context . '_comment';
+
+    $self->stash(
+        group => {id => $group->id, name => $group->name},
+        comments => \@comments,
+        comment_context => $comment_context,
+        pagination_route => $pagination_route,
+        build_results => [],
+        is_ajax => 1,
+        comment_post_action => 'apiv1_post_' . $comment_context_route_suffix,
+        comment_put_action => 'apiv1_put_' . $comment_context_route_suffix,
+        comment_delete_action => 'apiv1_delete_' . $comment_context_route_suffix
+    );
+
+    $self->render(template => 'main/comment_area', layout => undef);
 }
 
 sub job_group_overview ($self) { $self->_group_overview('JobGroups', 'main/group_overview') }
+sub job_group_comments_ajax ($self) { $self->_group_comments_ajax('JobGroups', 'group_overview') }
 sub parent_group_overview ($self) { $self->_group_overview('JobGroupParents', 'main/parent_group_overview') }
+sub parent_group_comments_ajax ($self) { $self->_group_comments_ajax('JobGroupParents', 'parent_group_overview') }
 
 sub changelog ($self) {
     my $file = path($self->app->config->{global}->{changelog_file});

--- a/t/ui/15-comments.t
+++ b/t/ui/15-comments.t
@@ -422,6 +422,7 @@ EOM
 
 subtest 'commenting on parent group overview' => sub {
     $driver->get('/parent_group_overview/1');
+    wait_for_ajax;
     test_comment_editing(0);
 
     # add another comment to have an equal amount of comments in the parent group and in the job group
@@ -467,6 +468,7 @@ subtest 'editing when logged in as regular user' => sub {
     subtest 'group overview: ' . $_ => sub {
         my $group_url = $_;
         $driver->get($group_url);
+        wait_for_ajax;
         no_edit_no_remove_on_other_comments_expected;
         write_comment 'test by nobody', 'comment for group added by regular user';
         only_edit_for_own_comments_expected;
@@ -481,14 +483,17 @@ subtest 'editing when logged in as regular user' => sub {
         my %cond = (-or => [{group_id => $group_id}, {parent_group_id => $group_id}]);
         is $comments->search(\%cond)->count, 5, 'expected number of comments present in database at this point';
 
+        wait_for_ajax;
         # pagination present
         is scalar @{$driver->find_elements('.comments-pagination a')}, 1, 'one pagination button present';
         $driver->get($group_url . '?comments_limit=2');
+        wait_for_ajax;
         my @pagination_buttons = $driver->find_elements('.comments-pagination a', 'css');
         is scalar @pagination_buttons, 4, 'four pagination buttons present (one is >>)';
         is scalar @{$driver->find_elements('.comment-row')}, 2, 'only 2 comments present';
         $pagination_buttons[2]->click();
-        is scalar @{$driver->find_elements('.comment-row')}, 1, 'only 1 comment present on last page';
+        wait_for_ajax;
+        wait_until sub { scalar @{$driver->find_elements('.comment-row')} == 1 }, 'only 1 comment present on last page';
       }
       for (@group_overview_urls);
 };

--- a/templates/webapi/comments/pagination.html.ep
+++ b/templates/webapi/comments/pagination.html.ep
@@ -5,12 +5,13 @@
           <ul class="pagination">
             % my $current_page_is_the_first = $comments_pager->current_page == $comments_pager->first_page;
             % my $current_page_is_the_last = $comments_pager->current_page == $comments_pager->last_page;
+            % my $route = stash('pagination_route');
 
             % if ($current_page_is_the_first) {
                 <li class="disabled"><span
             % }
             % else {
-                <li><a href="<%= url_with->query({comments_page => $comments_pager->current_page - 1}) %>"
+                <li><a href="<%= url_with($route // ())->query({comments_page => $comments_pager->current_page - 1}) %>" rel="nofollow"
             % }
               class="page-link" aria-label="Previous">
                 <span aria-hidden="true">&laquo;</span>
@@ -22,10 +23,20 @@
                 </a>
             % }
 
-            % for (my $i = $comments_pager->first_page; $i <= $comments_pager->last_page; $i++) {
-                %= tag 'li', class => ($i == $comments_pager->current_page ? 'active' : undef) => sub {
-                %    link_to $i => url_with->query({comments_page => $i}) => (class => 'page-link')
+            % my $first = $comments_pager->first_page;
+            % my $last = $comments_pager->last_page;
+            % my $current = $comments_pager->current_page;
+            % my $prev = 0;
+            % for (my $i = $first; $i <= $last; $i++) {
+            %     if ($i == $first || $i == $last || ($i >= $current - 2 && $i <= $current + 2)) {
+            %         if ($prev && $i > $prev + 1) {
+                          <li class="disabled"><span class="page-link">&hellip;</span></li>
+            %         }
+            %         $prev = $i;
+                %= tag 'li', class => ($i == $current ? 'active' : undef) => sub {
+                %    link_to $i => url_with($route // ())->query({comments_page => $i}) => (class => 'page-link', rel => 'nofollow')
                 % };
+            %     }
             % }
 
 
@@ -33,7 +44,7 @@
                 <li class="disabled"><span
             % }
             % else {
-                <li><a href="<%= url_with->query({comments_page => $comments_pager->current_page + 1}) %>"
+                <li><a href="<%= url_with($route // ())->query({comments_page => $comments_pager->current_page + 1}) %>" rel="nofollow"
             % }
                 class="page-link" aria-label="Next">
                   <span aria-hidden="true">&raquo;</span>

--- a/templates/webapi/main/comment_area.html.ep
+++ b/templates/webapi/main/comment_area.html.ep
@@ -1,4 +1,4 @@
-% if (!@$build_results && $comments_pager->current_page > 1) {
+% if (!stash('is_ajax') && !@$build_results && $comments_pager->current_page > 1) {
 <div class="alert alert-info">
     Builds are only shown on the first page and not when browsing through the comments.
 </div>

--- a/templates/webapi/main/group_overview.html.ep
+++ b/templates/webapi/main/group_overview.html.ep
@@ -39,4 +39,4 @@
     %= include 'main/group_builds', build_results => $build_results, group => $group, children => undef, default_expanded => 1
 </div>
 %= include 'main/more_builds', limit_builds => $limit_builds
-%= include 'main/comment_area'
+<div id="comment-area"></div>

--- a/templates/webapi/main/parent_group_overview.html.ep
+++ b/templates/webapi/main/parent_group_overview.html.ep
@@ -63,4 +63,4 @@
   </div>
 </div>
 
-%= include 'main/comment_area'
+<div id="comment-area"></div>


### PR DESCRIPTION
Motivation:
Navigating through comment pages on group overview reloaded the entire page,
including heavy build results, leading to high backend load and poor UX.
Implementing AJAX comments pagination resolves this without hiding builds.

Design Choices:
- Added dedicated `.../comments_ajax` routes and a `_group_comments_ajax`
  controller to bypass fetching tags and build results during pagination.
- Implemented AJAX fetching and popstate history traversal in comments.js.
- Restored the limit_builds check for page > 1 in `_group_overview`
  to prevent search crawlers from triggering heavy queries.
- Maintained the "Builds are only shown on the first page" warning,
  but hide it dynamically during AJAX requests.
- Added `rel="nofollow"` to pagination links.

Benefits:
- Reduces load on openQA hosts by avoiding costly DB queries.
- Prevents full page reloads, offering a fast and seamless user experience.

Manual verification:
Started `NOT_HEADLESS=1 perl -Ilib -d t/ui/01-list.t`, stepped through
until the browser loads, entered
```
$schema->resultset('Comments')->create({
  group_id => 1001, text => "Comment $_", user_id => 1 }) for 1 .. 1000;
```

to create 1k comments and test visual behavior.

Related issue: https://progress.opensuse.org/issues/204963

Demonstration video:
[group_overview_comments_cropped.webm](https://github.com/user-attachments/assets/b8923dd7-b195-440a-af2b-df3a2008412f)

<img width="960" height="880" alt="group_overview_comments_cropped" src="https://github.com/user-attachments/assets/aa9d70f1-9023-43a0-abbe-96d128e22603" />

Comment pages selector abbreviated with ellipsis:
<img width="435" height="76" alt="Screenshot_20260814_174850_oqa_comments_ellipsis" src="https://github.com/user-attachments/assets/e4d8b715-cd1d-4bd6-85e7-d8a68dda7190" />
