### PR TITLE
feat: Throttle jobs without `CASEDIR` and thus not specifying a Git-URL

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -741,6 +741,10 @@ where:
   latter applies `adjustment_n` if `regex_n` does not match
 - `regex_n`: a regex to match the value of `parameter_n` against
 
+Patterns like `…:=~^$` can be used to adjust the priority if a parameter does
+*not* exist or is empty. (Patterns are normally ignored if the parameter they
+refer to does not exist.)
+
 The final priority of a job is the sum of a base priority, defined in the job
 templates or scenario definitions, plus all adjustments calculated for the
 configured parameters that match the job settings.

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -425,6 +425,8 @@ concurrent = 0
 ## test parameters that trigger throttling of scheduled openQA jobs by priority.
 ## syntax for positive matching: parameter_n:adjustment_n:=~regex_n[,…]
 ## syntax for negative matching: parameter_n:adjustment_n:!~regex_n[,…]
+## The default patterns will add 15 to the prio value of all jobs that do not
+## specify a URL as CASEDIR to promote use of Git-URLs.
 ## Check out the "Job Priority Throttling" documentation for details.
 #prio_throttling_patterns = CASEDIR:15:!~^https?:,CASEDIR:15:=~^$
 

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -426,7 +426,7 @@ concurrent = 0
 ## syntax for positive matching: parameter_n:adjustment_n:=~regex_n[,…]
 ## syntax for negative matching: parameter_n:adjustment_n:!~regex_n[,…]
 ## Check out the "Job Priority Throttling" documentation for details.
-#prio_throttling_patterns = CASEDIR:15:!~^https?:
+#prio_throttling_patterns = CASEDIR:15:!~^https?:,CASEDIR:15:=~^$
 
 ## Concurrency limit of archive generation (ZIP creation) jobs in parallel
 #create_zip_archive_limit = 2

--- a/lib/OpenQA/Schema/ResultSet/Jobs.pm
+++ b/lib/OpenQA/Schema/ResultSet/Jobs.pm
@@ -230,22 +230,24 @@ sub _apply_prio_throttling ($self, $settings, $new_job_args, $group = undef) {
             push @throttling_info, $info if $info;
         }
         for my $resource (sort keys %$throttling) {
-            next unless defined(my $value = $settings->{$resource});
             for my $rule (@{$throttling->{$resource}}) {
-                my $op = $rule->{operator};
-                if (!defined $op) {
+                my $value = $settings->{$resource};
+                my $op = $rule->{operator} // '';
+                if (defined $value && !$op) {
                     push @throttling_info, $resource . _update_priority($value, $rule, $new_job_args)
                       if $resource ne 'MAX_JOB_TIME';
                     next;
                 }
-                my $val = $value;
+                my $regex_str = $rule->{regex_str} // '';
+                next if !defined $value && $op ne '=~' && $regex_str ne '^$';
+                my $val = $value // '';
                 my $regex = $rule->{regex};
                 my $adj = $rule->{adjustment};
                 my $matches = $val =~ $regex;
                 if (($op eq '=~' && $matches) || ($op eq '!~' && !$matches)) {
                     my $sign = _change_prio_returning_sign($new_job_args, $adj);
                     push @throttling_info, sprintf '%s [%s%s: value %s %s %s]', $resource, $sign, $adj, $val, $op,
-                      $rule->{regex_str};
+                      $regex_str;
                 }
             }
         }

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -316,7 +316,7 @@ sub default_config () {
             throttle_failing_job_prio_step => 10,
             throttle_failing_job_history_length => 20,
             prio_throttling_parameters => 'MAX_JOB_TIME:0.007',
-            prio_throttling_patterns => 'CASEDIR:15:!~^https?:',
+            prio_throttling_patterns => 'CASEDIR:15:!~^https?:,CASEDIR:15:=~^$',
             prio_throttling_data => undef,
             prio_group_parameters => 'full_name:Development:50',
             prio_group_data => undef,

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -55,8 +55,12 @@ my $job_dependencies = $schema->resultset('JobDependencies');
 my $workers = $schema->resultset('Workers');
 my $t = Test::Mojo->new('OpenQA::Scheduler');
 my $app = OpenQA::WebAPI->new;
+my $cfg = $app->config;
+my $limits = $cfg->{misc_limits};
 OpenQA::App->set_singleton($app);
-$app->config->{'scm git'}->{git_auto_update} = 'no';
+$cfg->{'scm git'}->{git_auto_update} = 'no';
+$limits->{prio_throttling_patterns} = '';
+$limits->{prio_throttling_data} = {};
 
 subtest 'Authentication' => sub {
     my $app = $t->app;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -117,7 +117,11 @@ my $webapi = OpenQA::Test::Utils::create_webapi($mojo_port, sub { });
 # we possibly want to adjust without going into the details of this test
 my $app = $t->app;
 my $minion = $app->minion;
-$app->config->{default_group_limits}->{asset_size_limit} = 100;
+my $cfg = $app->config;
+my $limits = $cfg->{misc_limits};
+$cfg->{default_group_limits}->{asset_size_limit} = 100;
+$limits->{prio_throttling_patterns} = '';
+$limits->{prio_throttling_data} = {};
 
 # Non-Gru task
 # uncoverable statement

--- a/t/api/02-iso-yaml.t
+++ b/t/api/02-iso-yaml.t
@@ -17,9 +17,14 @@ use Mojo::File 'path';
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '03-users.pl');
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
-my $schema = $t->app->schema;
+my $app = $t->app;
+my $cfg = $app->config;
+my $schema = $app->schema;
 my $jobs = $schema->resultset('Jobs');
 my %iso = (ISO => 'foo.iso', DISTRI => 'opensuse', VERSION => '13.1', FLAVOR => 'DVD', ARCH => 'i586', BUILD => '0091');
+my $limits = $cfg->{misc_limits};
+$limits->{prio_throttling_patterns} = '';
+$limits->{prio_throttling_data} = {};
 
 subtest 'schedule from yaml file: error cases' => sub {
     my $file = 'does-not-exist.yaml';

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -20,13 +20,18 @@ use OpenQA::Schema::Result::ScheduledProducts;
 
 OpenQA::Test::Case->new->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 04-products.pl');
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
-my $schema = $t->app->schema;
+my $app = $t->app;
+my $cfg = $app->config;
+my $schema = $app->schema;
 my $job_templates = $schema->resultset('JobTemplates');
 my $products = $schema->resultset('Products');
 my $test_suites = $schema->resultset('TestSuites');
 my $jobs = $schema->resultset('Jobs');
 my $scheduled_products = $schema->resultset('ScheduledProducts');
 my $gru_tasks = $schema->resultset('GruTasks');
+my $limits = $cfg->{misc_limits};
+$limits->{prio_throttling_patterns} = '';
+$limits->{prio_throttling_data} = {};
 assume_all_assets_exist;
 
 sub lj {

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1220,11 +1220,20 @@ subtest 'priority correctly assigned when posting job' => sub {
         subtest 'CASEDIR with URL: prio adjusted because CASEDIR does match positive regex' => sub {
             my %new_job_args = (priority => $default_prio);
             local $jobs_post_params{CASEDIR} = 'https://some-url/distri';
-            local $limits->{prio_throttling_patterns} = 'CASEDIR:15:=~^https?:';
+            local $limits->{prio_throttling_patterns} = 'CASEDIR:15:=~^https?:,CASEDIR:10:=~^$';
             $config = OpenQA::Setup::read_config($t->app);
             $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($t->app, $config);
             OpenQA::Schema::ResultSet::Jobs::_apply_prio_throttling($jobs, \%jobs_post_params, \%new_job_args);
             is $new_job_args{priority}, $default_prio + 15, 'prio adjusted because CASEDIR matches https?: with =~';
+        };
+        subtest 'empty CASEDIR: prio adjusted for non-existing variable via "$^" pattern' => sub {
+            my %new_job_args = (priority => $default_prio);
+            delete local $jobs_post_params{CASEDIR};
+            local $limits->{prio_throttling_patterns} = 'CASEDIR:15:=~^https?:,CASEDIR:10:=~^$';
+            $config = OpenQA::Setup::read_config($t->app);
+            $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($t->app, $config);
+            OpenQA::Schema::ResultSet::Jobs::_apply_prio_throttling($jobs, \%jobs_post_params, \%new_job_args);
+            is $new_job_args{priority}, $default_prio + 10, 'prio adjusted because CASEDIR does not exist';
         };
     };
 

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -63,10 +63,14 @@ sub calculate_file_md5 ($file) {
 $ENV{MOJO_MAX_MESSAGE_SIZE} = 207_741_824;
 
 my $t = client(Test::Mojo->new('OpenQA::WebAPI'));
-my $cfg = $t->app->config;
+my $app = $t->app;
+my $cfg = $app->config;
 $cfg->{'scm git'}->{git_auto_clone} = 'no';
 $cfg->{'scm git'}->{git_auto_update} = 'no';
 is $cfg->{audit}->{blocklist}, 'job_grab', 'blocklist updated';
+my $limits = $cfg->{misc_limits};
+$limits->{prio_throttling_patterns} = '';
+$limits->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $cfg);
 
 my $schema = $t->app->schema;
 my $assets = $schema->resultset('Assets');

--- a/t/config.t
+++ b/t/config.t
@@ -303,39 +303,33 @@ subtest 'Lookup precedence/hiding' => sub {
 subtest 'check throttling configuration validation and application' => sub {
     my $app = OpenQA::App->singleton();
     my $config = $app->config;
-    local $config->{misc_limits}->{prio_throttling_patterns} = '';
+    my $limits = $config->{misc_limits};
+    my $setup_throttling = sub ($params = '', $patterns = '') {
+        $limits->{prio_throttling_parameters} = $params;
+        $limits->{prio_throttling_patterns} = $patterns;
+        $limits->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
+    };
 
     subtest 'invalid prio_throttling_parameters' => sub {
-        $config->{misc_limits}->{prio_throttling_parameters} = 'invalid';
-        stderr_like {
-            $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        }
-        qr/Wrong format/, 'warn expected';
-        is_deeply $config->{misc_limits}->{prio_throttling_data}, {},
-          'prio_throttling_data is empty hash for invalid parameters';
+        stderr_like { $setup_throttling->('invalid') } qr/Wrong format/, 'warn expected';
+        is_deeply $limits->{prio_throttling_data}, {}, 'prio_throttling_data is empty hash for invalid parameters';
     };
     subtest 'no prio_throttling_parameters' => sub {
-        $config->{misc_limits}->{prio_throttling_parameters} = undef;
-        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is_deeply $config->{misc_limits}->{prio_throttling_data}, {},
-          'prio_throttling_data is empty when no parameters';
+        $setup_throttling->(undef, undef);
+        is_deeply $limits->{prio_throttling_data}, {}, 'prio_throttling_data is empty when no parameters';
     };
     subtest 'empty string' => sub {
-        $config->{misc_limits}->{prio_throttling_parameters} = '';
-        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is_deeply $config->{misc_limits}->{prio_throttling_data}, {}, 'prio_throttling_data is empty for empty string';
+        $setup_throttling->();
+        is_deeply $limits->{prio_throttling_data}, {}, 'prio_throttling_data is empty for empty string';
     };
     subtest 'valid prio_throttling_parameter with space separators' => sub {
-        $config->{misc_limits}->{prio_throttling_parameters} = 'KEY1ONE:  1.5';
-        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is_deeply $config->{misc_limits}->{prio_throttling_data},
-          {KEY1ONE => [{scale => 1.5, reference => 0}]},
+        $setup_throttling->('KEY1ONE:  1.5');
+        is_deeply $limits->{prio_throttling_data}, {KEY1ONE => [{scale => 1.5, reference => 0}]},
           'prio_throttling_data parsed correctly';
     };
     subtest 'valid multiple prio_throttling_parameters keys' => sub {
-        $config->{misc_limits}->{prio_throttling_parameters} = 'A:1.04,B:2:3,C:0.04:5';
-        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is_deeply $config->{misc_limits}->{prio_throttling_data},
+        $setup_throttling->('A:1.04,B:2:3,C:0.04:5');
+        is_deeply $limits->{prio_throttling_data},
           {
             A => [{scale => 1.04, reference => 0}],
             B => [{scale => 2, reference => 3}],
@@ -345,28 +339,19 @@ subtest 'check throttling configuration validation and application' => sub {
     };
 
     subtest 'invalid prio_throttling_patterns' => sub {
-        local $config->{misc_limits}->{prio_throttling_parameters} = '';
-        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:invalid';
-        stderr_like {
-            $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        }
+        stderr_like { $setup_throttling->('', 'CASEDIR:invalid') }
         qr/Wrong format in openqa.ini 'prio_throttling_patterns'/, 'warn expected';
-        is_deeply $config->{misc_limits}->{prio_throttling_data}, {},
-          'prio_throttling_data is empty for invalid patterns';
+        is_deeply $limits->{prio_throttling_data}, {}, 'prio_throttling_data is empty for invalid patterns';
     };
     subtest 'valid prio_throttling_patterns' => sub {
-        local $config->{misc_limits}->{prio_throttling_parameters} = '';
-        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:';
-        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is_deeply $config->{misc_limits}->{prio_throttling_data},
+        $setup_throttling->('', 'CASEDIR:15:!~^https?:');
+        is_deeply $limits->{prio_throttling_data},
           {CASEDIR => [{adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'}]},
           'prio_throttling_data parses patterns correctly';
     };
     subtest 'valid multiple prio_throttling_patterns keys with spaces' => sub {
-        local $config->{misc_limits}->{prio_throttling_parameters} = '';
-        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:,  FOO:-10:=~^bar$';
-        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is_deeply $config->{misc_limits}->{prio_throttling_data},
+        $setup_throttling->('', 'CASEDIR:15:!~^https?:,  FOO:-10:=~^bar$');
+        is_deeply $limits->{prio_throttling_data},
           {
             CASEDIR => [{adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'}],
             FOO => [{adjustment => -10, operator => '=~', regex => qr/^bar$/, regex_str => '^bar$'}],
@@ -374,10 +359,8 @@ subtest 'check throttling configuration validation and application' => sub {
           'prio_throttling_data parses multiple patterns with spaces correctly';
     };
     subtest 'multiple prio_throttling_patterns for one variable; pattern for matching empty variable' => sub {
-        local $config->{misc_limits}->{prio_throttling_parameters} = '';
-        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:,CASEDIR:10:=~^$';
-        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is_deeply $config->{misc_limits}->{prio_throttling_data},
+        $setup_throttling->('', 'CASEDIR:15:!~^https?:,CASEDIR:10:=~^$');
+        is_deeply $limits->{prio_throttling_data},
           {
             CASEDIR => [
                 {adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'},
@@ -387,10 +370,8 @@ subtest 'check throttling configuration validation and application' => sub {
           'prio_throttling_data parses multiple patterns with spaces correctly';
     };
     subtest 'combining parameters and patterns' => sub {
-        local $config->{misc_limits}->{prio_throttling_parameters} = 'MAX_JOB_TIME:0.007';
-        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:';
-        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
-        is_deeply $config->{misc_limits}->{prio_throttling_data},
+        $setup_throttling->('MAX_JOB_TIME:0.007', 'CASEDIR:15:!~^https?:');
+        is_deeply $limits->{prio_throttling_data},
           {
             MAX_JOB_TIME => [{scale => 0.007, reference => 0}],
             CASEDIR => [{adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'}],
@@ -400,9 +381,8 @@ subtest 'check throttling configuration validation and application' => sub {
 
     subtest 'prio_group_parameters' => sub {
         subtest 'valid multiple rules' => sub {
-            $config->{misc_limits}->{prio_group_parameters} = 'name:open:10,name:suse:5';
-            my $rules = OpenQA::Setup::_load_prio_group_throttling($app, $config);
-            is_deeply $rules,
+            $limits->{prio_group_parameters} = 'name:open:10,name:suse:5';
+            is_deeply OpenQA::Setup::_load_prio_group_throttling($app, $config),
               [
                 {property => 'name', regex => qr/open/, increment => 10},
                 {property => 'name', regex => qr/suse/, increment => 5}
@@ -411,7 +391,7 @@ subtest 'check throttling configuration validation and application' => sub {
         };
 
         subtest 'invalid rule format' => sub {
-            $config->{misc_limits}->{prio_group_parameters} = 'invalid';
+            $limits->{prio_group_parameters} = 'invalid';
             stderr_like {
                 my $rules = OpenQA::Setup::_load_prio_group_throttling($app, $config);
                 is $rules, undef, 'returns undef for invalid';

--- a/t/config.t
+++ b/t/config.t
@@ -78,7 +78,10 @@ subtest 'Test configuration default modes' => sub {
     $test_config->{global}->{service_port_delta} = 2;
     $test_config->{misc_limits}->{prio_throttling_data} = {
         MAX_JOB_TIME => [{scale => '0.007', reference => 0}],
-        CASEDIR => [{adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'}]};
+        CASEDIR => [
+            {adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'},
+            {adjustment => 15, operator => '=~', regex => qr/^$/, regex_str => '^$'},
+        ]};
     $test_config->{misc_limits}->{prio_group_data}
       = [{property => 'full_name', regex => qr/Development/, increment => 50}];
     is ref delete $config->{global}->{auto_clone_regex}, 'Regexp', 'auto_clone_regex parsed as regex';

--- a/t/config.t
+++ b/t/config.t
@@ -370,6 +370,19 @@ subtest 'check throttling configuration validation and application' => sub {
           },
           'prio_throttling_data parses multiple patterns with spaces correctly';
     };
+    subtest 'multiple prio_throttling_patterns for one variable; pattern for matching empty variable' => sub {
+        local $config->{misc_limits}->{prio_throttling_parameters} = '';
+        local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:,CASEDIR:10:=~^$';
+        $config->{misc_limits}->{prio_throttling_data} = OpenQA::Setup::_load_prio_throttling($app, $config);
+        is_deeply $config->{misc_limits}->{prio_throttling_data},
+          {
+            CASEDIR => [
+                {adjustment => 15, operator => '!~', regex => qr/^https?:/, regex_str => '^https?:'},
+                {adjustment => 10, operator => '=~', regex => qr/^$/, regex_str => '^$'},
+            ],
+          },
+          'prio_throttling_data parses multiple patterns with spaces correctly';
+    };
     subtest 'combining parameters and patterns' => sub {
         local $config->{misc_limits}->{prio_throttling_parameters} = 'MAX_JOB_TIME:0.007';
         local $config->{misc_limits}->{prio_throttling_patterns} = 'CASEDIR:15:!~^https?:';


### PR DESCRIPTION
A follow-up of https://github.com/os-autoinst/openQA/commit/d6d066f893bd711ff4a1e8b6eead031800ff9c36 to cover jobs that don't specify `CASEDIR` at all as well.

Check out other commit messages for details.

Related ticket: https://progress.opensuse.org/issues/205617