### PR TITLE
fix(layout): Avoid horizontal scrollbar on the whole page

### DIFF
--- a/assets/stylesheets/dashboard.scss
+++ b/assets/stylesheets/dashboard.scss
@@ -173,6 +173,9 @@ h2 [class*="fa-"] {
 #results_filter label {
   vertical-align: top;
 }
+#results td.links {
+  max-width: 0; /* Forces cell to obey overflow rules of inner content */
+}
 .corner-buttons {
   display: inline-block;
   float: right;


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/198881

For long text in result boxes (that aren't wrapped because of
`<pre>`), we were getting a horizontal scrollbar for the whole page, and
the table was wider than the browser window.

Now it looks as expected:
<img width="870" height="455" alt="logview-long-text-overflow" src="https://github.com/user-attachments/assets/ea8d0def-18fd-4a1d-8aeb-dcb72b11c5a4" />

It works for me in firefox and chromium.
