### PR TITLE
chore(docs): add Prettier markdown formatting checks

### DIFF
--- a/docs/Branding.md
+++ b/docs/Branding.md
@@ -1,4 +1,5 @@
 <a id="branding"></a>
+
 # Branding
 
 You can alter the appearance of the openQA web UI to some extent through
@@ -15,9 +16,6 @@ You can copy the files from `branding/openSUSE` or `branding/plain` to
 use as starting points, and adjust as necessary.
 
 ## Web UI template
-
-
-
 
 openQA uses the [Mojolicious](https://mojolicious.org/) framework's templating
 system; the branding files are included into the openQA templates at

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -1,4 +1,5 @@
 <a id="client"></a>
+
 # Client
 
 There are two ways to interact with openQA as a user. The web UI and the REST
@@ -10,14 +11,14 @@ overview of its capabilities. To get started all you need is an openQA instance
 with a few jobs and `curl`. Just replace `openqa.example.com` in the examples
 below with the hostname of your openQA instance.
 
-``` sh
+```sh
 curl http://openqa.example.com/api/v1/jobs/overview
 ```
 
 That one-liner will show you the latest jobs from the overview in JSON format.
 You could also append various query parameters to filter the jobs further.
 
-``` sh
+```sh
 curl http://openqa.example.com/api/v1/jobs/overview?result=failed
 ```
 
@@ -29,7 +30,7 @@ For those cases openQA also contains a dedicated client to help you with that.
 It is called `openqa-cli` and can usually be installed with an `openQA-client`
 package (the name will vary depending on your Linux distribution).
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com jobs/overview result=failed
 ```
 
@@ -43,14 +44,14 @@ The `api` subcommand is not the only one available and more will be added over
 time. To get a complete list of all currently available subcommands you can use
 the `--help` option.
 
-``` sh
+```sh
 openqa-cli --help
 ```
 
 And each subcommand also contains descriptions for all its available options, as
 well as many common usage examples.
 
-``` sh
+```sh
 openqa-cli api --help
 ```
 
@@ -65,7 +66,7 @@ file or use them ad-hoc from the command line. There are two config files
 `openqa-cli` will try, the global `/etc/openqa/client.conf`, and your personal
 `~/.config/openqa/client.conf`. The format is the same for both.
 
-``` ini
+```ini
 [openqa.example.com]
 key = 1234567890ABCDEF
 secret = ABCDEF1234567890
@@ -76,7 +77,7 @@ and `OPENQA_API_SECRET`. For ad-hoc use all `openqa-cli` subcommands use the `--
 `--apisecret` options which will override whatever the environment or config
 files may contain.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com --apikey 1234567890ABCDEF \
     --apisecret ABCDEF1234567890 -X POST jobs/2/comments text=hello
 ```
@@ -94,7 +95,7 @@ This access token is made up of your username, and the same key/secret combo
 the `openqa-cli` authentication mechanism uses. All you have to do is combine them as `USERNAME:KEY:SECRET` and you can use `curl` to access operator and
 admin REST endpoints (depending on user privileges of course).
 
-``` sh
+```sh
 curl -u arthur:1234567890ABCDEF:ABCDEF1234567890 -X DELETE \
     https://openqa.example.com/api/v1/assets/1
 ```
@@ -103,7 +104,7 @@ And for HTTP clients that don't support Basic authentication or where the use
 of plain HTTP headers might be more convenient, you can also send the
 personal access token in the form of a Bearer token.
 
-``` sh
+```sh
 curl -H 'Authorization: Bearer arthur:1234567890ABCDEF:ABCDEF1234567890'\
     -X DELETE https://openqa.example.com/api/v1/assets/1
 ```
@@ -112,7 +113,7 @@ When using `curl` or `wget` one can utilise the `~/.netrc` file to
 automatically add those credentials. See the following template for
 openqa.example.com and the user arthur
 
-``` txt
+```txt
 machine openqa.example.com login arthur password 1234567890ABCDEF:ABCDEF1234567890
 ```
 
@@ -129,7 +130,7 @@ the [HTTP protocol](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) a
 
 The `--method` option (or `-X` for short) allows you to change the HTTP request method from `GET` to something else. In the openQA API you will most commonly encounter `POST`, `PUT` and `DELETE`. For example to start testing a new ISO image you would use `POST`.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com -X POST isos \
     ISO=openSUSE-Factory-NET-x86_64-Build0053-Media.iso DISTRI=opensuse \
     VERSION=Factory FLAVOR=NET ARCH=x86_64 BUILD=0053
@@ -142,7 +143,7 @@ HTTP headers to your request. This feature is currently not used much, but can
 be handy if for example the REST endpoint you are using supports content
 negotiation.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com -a 'Accept: application/json' \
     jobs/overview
 ```
@@ -154,7 +155,7 @@ simplest being `--data` (or `-d` for short), which allows you to use a plain
 string as request body. This can be useful for example to change the group id of
 a job.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com -X PUT jobs/1 \
     --data '{"group_id":2}'
 ```
@@ -162,14 +163,14 @@ openqa-cli api --host http://openqa.example.com -X PUT jobs/1 \
 With the `--data-file` option (or `-D` for short) you can also use a file
 instead.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com -X PUT jobs/1 \
     --data-file ./test.json
 ```
 
 Or just pipe the data to `openqa-cli`.
 
-``` sh
+```sh
 echo '{"group_id":2}' | openqa-cli api --host http://openqa.example.com -X PUT \
     jobs/1
 ```
@@ -185,20 +186,20 @@ the key/value pairs.
 Form parameters are most commonly passed as additional arguments after the path.
 For example to post a comment to a job.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com -X POST jobs/2/comments text=abc
 ```
 
 This value can also be quoted to include whitespace characters.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com -X POST jobs/2/comments \
     text="Hello openQA!"
 ```
 
 And you can use interpolation to include files.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com -X POST jobs/2/comments \
     text="$(cat ./comment.markdown)"
 ```
@@ -208,7 +209,7 @@ provide all form parameters in JSON format. Here you would reuse the HTTP body
 options, such as `--data` and `--data-file`, to pass the JSON document to be
 turned into form parameters.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com --form --data '{"text":"abc"}' \
     -X POST jobs/2/comments
 ```
@@ -218,25 +219,25 @@ openqa-cli api --host http://openqa.example.com --form --data '{"text":"abc"}' \
 The primary data exchange format in the openQA API is JSON. And you will even
 see error messages in JSON format most of the time.
 
-``` json
-{"error":"no api key","error_status":403}
+```json
+{"error": "no api key", "error_status": 403}
 ```
 
 By default the returned JSON is often compressed, for better performance, and
 can be hard to read if the response gets larger. But if you add the `--pretty`
 option (or `-p` for short), `openqa-cli` can reformat it for you.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com --pretty jobs/overview
 ```
 
 The JSON will be re-encoded with newlines and indentation for much better
 readability.
 
-``` json
+```json
 {
-   "error" : "no api key",
-   "error_status" : 403
+  "error": "no api key",
+  "error_status": 403
 }
 ```
 
@@ -244,7 +245,7 @@ The `--json` option (or `-j` for short) can be used to set a
 `Content-Type: application/json` request header. Whenever you need to upload a
 JSON document.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com -X PUT jobs/1 --json \
     --data '{"group_id":2}'
 ```
@@ -254,14 +255,14 @@ openqa-cli api --host http://openqa.example.com -X PUT jobs/1 --json \
 Just use a UTF-8 locale for your terminal and Unicode will pretty much just
 work.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com -X POST jobs/2/comments \
     text="I ♥ Unicode"
 ```
 
 JSON documents are always expected to be UTF-8 encoded.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com --form \
     --data '{"text":"I ♥ Unicode"}' -X POST jobobs/407/comments \
     -X POST jobs/2/comments
@@ -271,14 +272,14 @@ openqa-cli api --host http://openqa.example.com --form \
 
 Aside from the `--host` option, there are also a few shortcuts available. If you leave out the `--host` option completely, the default value will be [`http://localhost`](http://localhost), which is very convenient for debugging purposes.
 
-``` sh
+```sh
 openqa-cli api jobs/overview
 ```
 
 And organisations that contribute to openQA and are invested in the project can
 also get their very own personalised shortcuts. Currently we have `--osd` for [`http://openqa.suse.de`](http://openqa.suse.de), and `--o3` for `openqa.opensuse.org`.
 
-``` sh
+```sh
 openqa-cli api --o3 jobs/overview
 ```
 
@@ -288,7 +289,7 @@ Often times just seeing the HTTP response body might not be enough to debug a
 problem. With the `--verbose` option (or `-v` for short) you can also get
 additional information printed.
 
-``` sh
+```sh
 openqa-cli api --host http://openqa.example.com --verbose -X POST \
     jobs/407/comments text="Hello openQA!"
 ```
@@ -307,7 +308,7 @@ This includes the HTTP response status line, as well as headers.
 And if that is not enough, you can experiment with the `MOJO_CLIENT_DEBUG`
 environment variable.
 
-``` sh
+```sh
 MOJO_CLIENT_DEBUG=1 openqa-cli api --host http://openqa.example.com -X POST \
     jobs/407/comments text="Hello openQA!"
 ```

--- a/docs/ContainerizedSetup.md
+++ b/docs/ContainerizedSetup.md
@@ -1,4 +1,5 @@
 <a id="containerizedsetup"></a>
+
 # Containerized Setup
 
 The installation guide already contains simple one-liners for starting
@@ -77,6 +78,7 @@ docker, as a workaround, run:
 on the host machine.
 
 <a id="run_the_data_and_web_ui_containers"></a>
+
 ### Run the data and web UI containers
 
     podman run -d -h openqa_data --name openqa_data -v "$PWD"/data/factory:/data/factory -v "$PWD"/data/tests:/data/tests fedoraqa/openqa_data
@@ -99,6 +101,7 @@ command substituting `KEY` and `SECRET` with the generated values:
     exec -it openqa_data /scripts/client-conf set -l KEY SECRET
 
 <a id="run_the_worker_container"></a>
+
 ### Run the worker container
 
     podman run -d -h openqa_worker_1 --name openqa_worker_1 --link openqa_webui:openqa_webui --volumes-from openqa_data --privileged fedoraqa/openqa_worker
@@ -319,6 +322,7 @@ Worker instances always expect to find the server as `openqa_webui`; if this wil
 adjust these files if you use non-standard ports (see above).
 
 <a id="keeping_all_data_in_the_data_volume_container"></a>
+
 ### Keeping all data in the Data Volume container
 
 If you decided to keep all the data in the Volume container (`openqa_data`), run the following commands:
@@ -341,6 +345,7 @@ And finally, download the tests and ISOs directly into the container:
 The rest of the steps should be the same.
 
 <a id="keeping_all_data_on_the_host_system"></a>
+
 ### Keeping all data on the host system
 
 If you want to keep all the data in the host system and you prefer not to use

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -1,4 +1,5 @@
 <a id="contributing"></a>
+
 # Contributing
 
 ## Introduction
@@ -24,8 +25,6 @@ are available at the
 As mentioned, the central point of development is the
 [os-autoinst organization on GitHub](https://github.com/os-autoinst) where several
 repositories can be found.
-
-
 
 ### Repository URLs
 
@@ -61,8 +60,6 @@ are the right way to contribute improvements and fixes.
   you create a pull request, but you **should** run the tidy scripts locally, i.e.
   before every commit call:
 
-
-
 ```sh
 make tidy
 ```
@@ -94,8 +91,6 @@ requests for consideration or create an issue with a code change proposal.
 <a id="code_style_suggestions"></a>
 
 - In Perl files:
-
-
 
 - Sort the use statements in this order from top to bottom:
   - `strict`, `warnings` or other modules that provide static checks
@@ -136,8 +131,6 @@ openSUSE's project management tool. This Redmine instance is used to coordinate
 the main development effort organizing the existing issues (bugs and desired
 features) into 'target versions'.
 
-
-
 [Future improvements](https://progress.opensuse.org/versions/490) groups
 features that are in the developers' and users' wish list but that have little
 chances to be addressed in the short term, normally because they are out of
@@ -164,8 +157,6 @@ develop openQA. Of course, in addition to bare Perl, several libraries and
 additional tools are required. The easiest way to install all needed
 dependencies is using the available os-autoinst and openQA packages, as
 described in the Installation Guide.
-
-
 
 In the case of [os-autoinst](https://github.com/os-autoinst/os-autoinst), some
 [CPAN](http://www.cpan.org/) modules are required. Additionally, several external
@@ -551,6 +542,7 @@ Also find more details in
   [openQA-helper repository](https://github.com/Martchus/openQA-helper).
 
 <a id="quick-container-development-setup"></a>
+
 ### Quick container development setup
 
 #### Requirements
@@ -845,7 +837,7 @@ any statements) you can just drop the migration again.
 <!-- -->
 
 3.  Afterwards you need to generate the deployment files for existing installations,
-    this is done by running `./script/upgradedb --prepare_upgrade`. After doing so, the directories `dbicdh/$ENGINE/deploy/<new version>` and  `dbicdh/$ENGINE/upgrade/<prev version>-<new version>` for PostgreSQL
+    this is done by running `./script/upgradedb --prepare_upgrade`. After doing so, the directories `dbicdh/$ENGINE/deploy/<new version>` and `dbicdh/$ENGINE/upgrade/<prev version>-<new version>` for PostgreSQL
     should have been created with some SQL files inside containing the statements to
     initialize the schema and to upgrade from one version
     to the next in the corresponding database engine.
@@ -951,8 +943,6 @@ specific to that environment.
 
 Be sure to install all required dependencies. The package `openQA-devel` will
 provide them.
-
-
 
 For more information look into
 [Development Dependencies](Contributing.md#development-dependencies).
@@ -1085,6 +1075,7 @@ be set to a higher value. See
 <https://metacpan.org/pod/Selenium>::Chrome#startup_timeout for details.
 
 <a id="circleci-local-container"></a>
+
 ### Run tests using the circleci tool
 
 After installing the `circleci` tool the following commands will be available.
@@ -1179,11 +1170,11 @@ consistent look, and make the UI menu available everywhere.
 
 For UI plugins there are two named authentication routes defined:
 
-1.  `ensure_operator`: under `/admin/`, only allows logged in users with `operator` privileges 2.  `ensure_admin`: under `/admin/`, only allows logged in users with `admin` privileges
+1.  `ensure_operator`: under `/admin/`, only allows logged in users with `operator` privileges 2. `ensure_admin`: under `/admin/`, only allows logged in users with `admin` privileges
 
 And for HTTP API plugins there are four named authentication routes defined:
 
-1.  `api_public`: under `/api/v1/`, allows access to everyone 2.  `api_ensure_user`: under `/api/v1/`, only allows authenticated users 3.  `api_ensure_operator`: under `/api/v1/`, only allows authenticated users with `operator` privileges 4.  `api_ensure_admin`: under `/api/v1/`, only allows authenticated nusers with `admin` privileges
+1.  `api_public`: under `/api/v1/`, allows access to everyone 2. `api_ensure_user`: under `/api/v1/`, only allows authenticated users 3. `api_ensure_operator`: under `/api/v1/`, only allows authenticated users with `operator` privileges 4. `api_ensure_admin`: under `/api/v1/`, only allows authenticated nusers with `admin` privileges
 
 To generate a minimal installable plugin with a CPAN distribution directory
 structure you can use the Mojolicious tools. It can be packaged just like any

--- a/docs/ExternalResults.md
+++ b/docs/ExternalResults.md
@@ -1,4 +1,5 @@
 <a id="externalresults"></a>
+
 # External Results
 
 ## Introduction

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,4 +1,5 @@
 <a id="gettingstarted"></a>
+
 # Getting Started
 
 ## Introduction
@@ -42,12 +43,9 @@ available in the [official repository](https://github.com/os-autoinst/openQA).
 
 ## Architecture
 
-
 Although the project as a whole is referred to as openQA, there are in fact
 several components that are hosted in separate repositories as shown in
 [the following figure](#arch_img).
-
-
 
 <a id="arch_img"></a>
 
@@ -55,8 +53,6 @@ several components that are hosted in separate repositories as shown in
 <img src="images/openqa_architecture.png" alt="openQA architecture" />
 <figcaption aria-hidden="true">openQA architecture</figcaption>
 </figure>
-
-
 
 The heart of the test engine is a standalone application called 'os-autoinst'
 (blue). In each execution, this application creates a virtual machine and uses
@@ -252,6 +248,7 @@ tags.
 ```
 
 #### Areas
+
 There are three kinds of areas:
 
 - **Regular areas** define relevant parts of the screenshot. Those must match
@@ -272,6 +269,7 @@ There are three kinds of areas:
   In the needle view exclude areas are displayed as gray boxes.
 
 #### Click points
+
 Each regular match area in a needle can optionally contain a **click point**.
 This is used with the `testapi::assert_and_click` function to match GUI
 elements such as buttons and then click inside the matched area.
@@ -288,6 +286,7 @@ Each click point can have an `id`, and if a needle contains multiple click point
 to use.
 
 <a id="configuration"></a>
+
 ### Configuration
 
 The different components of openQA read their configuration from the following
@@ -305,7 +304,7 @@ files:
   files are used to configure the openQA worker including its additional cache
   service.
 
-- `client.conf`, `client.conf.d/*.conf`: These files contain API credentials and are used by the openQA worker and other tooling such as `openqa-cli` and  `openqa-clone-job` to authenticate with the web interface. One API key/secret
+- `client.conf`, `client.conf.d/*.conf`: These files contain API credentials and are used by the openQA worker and other tooling such as `openqa-cli` and `openqa-clone-job` to authenticate with the web interface. One API key/secret
   can be configured per web UI host.
 
 If these files are not present, defaults are used.
@@ -406,8 +405,6 @@ section for details.
 
 ## Using the client script
 
-
-
 Just as the worker uses an API key+secret every user of the `client script`
 must do the same. The same API key+secret as previously created can be used or
 a new one created over the webUI.
@@ -416,6 +413,7 @@ The personal configuration should be stored in a file
 `~/.config/openqa/client.conf` in the same format as previously described for the `client.conf`, i.e. sections for each machine, e.g. `localhost`.
 
 <a id="get-testing"></a>
+
 ## Testing openSUSE or Fedora
 
 An easy way to start using openQA is to start testing openSUSE or Fedora as they
@@ -505,7 +503,7 @@ openqa-cli api -X POST isos \
 If your openQA is not running on port 80 on 'localhost', you can add option
 `--host=http://otherhost:9526` to specify a different port or host.
 
-> **WARNING:** 
+> **WARNING:**
 > Use only the ISO filename in the 'client' command. You must place the
 > file in `/var/lib/openqa/share/factory/iso`. You cannot place the file elsewhere and
 > specify its path in the command. However, openQA also supports a

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -1,4 +1,5 @@
 <a id="installing"></a>
+
 # Installing
 
 ## Introduction
@@ -24,17 +25,19 @@ setup suitable to develop openQA itself, have a look at the
 [Development setup](Contributing.md#development-setup) section.
 
 <a id="container_setup"></a>
+
 ## Container based setup
 
 openQA is provided in containers. Multiple variants exist.
 
 <a id="single-instance-container"></a>
+
 ### Single-instance container
 
 The easiest and quickest way to spawn a single instance of openQA with a
 single command line using the `podman` container engine is the following:
 
-``` sh
+```sh
 podman run --name openqa --device /dev/kvm -p 1080:80 -p 1443:443 --rm -it \
   registry.opensuse.org/devel/openqa/containers/openqa-single-instance
 ```
@@ -44,11 +47,7 @@ or <https://localhost:1443>.
 
 #### How to run a test with single-instance container in 5 minutes
 
-
-
 ![](images/openqa-in-5-minutes.webm)
-
-
 
 #### Triggering and cloning existing jobs within single-instance container
 
@@ -57,13 +56,13 @@ which is conveniently available inside the container. The quickest and easiest
 way would be to enter an interactive session inside the already running
 single-instance container. You can spawn a new shell via:
 
-``` sh
+```sh
 podman exec -ti openqa /bin/bash
 ```
 
 From there, you can trigger a new job or clone an existing one, e.g.:
 
-``` sh
+```sh
 openqa-cli schedule --monitor async=1 \
     SCENARIO_DEFINITIONS_YAML_FILE=https://raw.githubusercontent.com/os-autoinst/os-autoinst-distri-example/refs/heads/main/scenario-definitions.yaml \
     DISTRI=example VERSION=0 FLAVOR=DVD ARCH=x86_64 \
@@ -80,7 +79,7 @@ More details on triggering tests can also be found in the
 
 You can also run the container and directly clone tests, e.g.:
 
-``` sh
+```sh
 podman run -e skip_suse_specifics= -e skip_suse_tests= \
  --name openqa --device /dev/kvm -p 1080:80 -p 1443:443 --rm \
  -it registry.opensuse.org/devel/openqa/containers/openqa-single-instance \
@@ -101,13 +100,13 @@ and worker.
 For example the web UI container can be pulled and started using the `podman`
 container engine:
 
-``` sh
+```sh
 podman run -p 1080:80 -p 1443:443 --rm -it registry.opensuse.org/devel/openqa/containers16.0/openqa_webui:latest
 ```
 
 The worker container can be pulled and started with:
 
-``` sh
+```sh
 podman run --rm -it registry.opensuse.org/devel/openqa/containers16.0/openqa_worker:latest
 ```
 
@@ -120,7 +119,7 @@ By default, the web UI container uses the self-signed certificate that comes
 with Mojolicious. To supply a different certificate, use the `-v` parameter.
 Example for running openQA with a custom config and certificate:
 
-``` sh
+```sh
 podman run -p 1080:80 -p 1443:443 \
   -v ./container/webui/test-cert.pem:/etc/apache2/ssl.crt/server.crt:z \
   -v ./container/webui/test-key.pem:/etc/apache2/ssl.key/server.key:z \
@@ -132,7 +131,7 @@ podman run -p 1080:80 -p 1443:443 \
 The same works for the workers container where you most likely want to to
 supply `workers.ini` and `client.conf`:
 
-``` sh
+```sh
 podman run \
   -v ./container/worker/conf/workers.ini:/data/conf/workers.ini:z \
   -v ./container/worker/conf/client.conf:/data/conf/client.conf:z \
@@ -153,7 +152,7 @@ For creating a first test job, check out the
 [Triggering tests section](UsersGuide.md#triggering_tests). Note that the
 commands mentioned there can also be invoked within a container, e.g.:
 
-``` sh
+```sh
 podman run \
    --rm -it registry.opensuse.org/devel/openqa/containers16.0/openqa_webui:latest \
    openqa-cli --help
@@ -180,21 +179,19 @@ To quickly get a working openQA installation, you can use the openqa-bootstrap
 script. It essentially automates the steps mentioned in the
 [Custom installation](#custom_installation) section.
 
-
-
 ### Directly on your machine
 
 On openSUSE Leap and openSUSE Tumbleweed to setup openQA on your machine
 simply download and execute the openqa-bootstrap script as root - it will do
 the rest for you:
 
-``` sh
+```sh
 curl -s https://raw.githubusercontent.com/os-autoinst/openQA/master/script/openqa-bootstrap | bash -x
 ```
 
 The script is also available from an openSUSE package to install from:
 
-``` sh
+```sh
 zypper in openQA-bootstrap
 /usr/share/openqa/script/openqa-bootstrap
 ```
@@ -202,7 +199,7 @@ zypper in openQA-bootstrap
 openQA-bootstrap supports to immediately clone an existing job simply by
 supplying `openqa-clone-job` parameters directly for a quickstart:
 
-``` sh
+```sh
 /usr/share/openqa/script/openqa-bootstrap --from openqa.opensuse.org 12345 SCHEDULE=tests/boot/boot_to_desktop,tests/x11/kontact
 ```
 
@@ -254,7 +251,7 @@ commands.
 and you need to have no application listening on port 80 yet because the container
 will share the host system's network stack.
 
-``` sh
+```sh
 zypper in openQA-bootstrap
 /usr/share/openqa/script/openqa-bootstrap-container
 
@@ -268,12 +265,12 @@ in your computer.
 
 The images are available directly from the [o3](https://openqa.opensuse.org) site.
 Download the HDD image `opensuse-Tumbleweed-x86_64@uefi-4G-<…>.qcow2` (~3.2 GB)
-from the *Assets* in the test scenario [openqa_install+publish](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=openqa&flavor=dev&machine=uefi-4G&test=openqa_install%2Bpublish&version=Tumbleweed&result=passed#downloads).
+from the _Assets_ in the test scenario [openqa_install+publish](https://openqa.opensuse.org/tests/latest?arch=x86_64&distri=openqa&flavor=dev&machine=uefi-4G&test=openqa_install%2Bpublish&version=Tumbleweed&result=passed#downloads).
 
 #### The VM
 
 The downloaded image can be used to launch a local VM from, running the
-*openSUSE Tumbleweed* system, a graphical user interface and a network access
+_openSUSE Tumbleweed_ system, a graphical user interface and a network access
 to your local machine's networks.
 
 Upon starting the VM, you can login as the root user. The login credentials
@@ -294,7 +291,7 @@ environment and log in as the default openQA Demo user.
 Once you have the VM's IP address, you can also access the web UI from any
 browser on your machine by navigating to http://<VM_IP>/.
 
-The drop-down menu in the UI top-left corner allows you to open an *Example test*
+The drop-down menu in the UI top-left corner allows you to open an _Example test_
 page, to run a simple test and verify the setup.
 
 Other tests can be cloned via the VM console or an SSH session from your machine,
@@ -308,8 +305,6 @@ refer to the `openqa-clone-job` documentation).
 Keep in mind that there can be disruptive changes between openQA versions.
 You need to be sure that the webui and the worker that you are using have the
 same version number or, at least, are compatible.
-
-
 
 For example, the packages distributed with older versions of openSUSE Leap are
 not compatible with the version on Tumbleweed. And the package distributed
@@ -333,7 +328,7 @@ You can find the development version of openQA in OBS in the
 
 To add the development repository to your system, you can use these commands.
 
-``` sh
+```sh
 # openSUSE Tumbleweed
 zypper ar -p 95 -f 'https://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed' devel_openQA
 
@@ -344,7 +339,7 @@ zypper ar -p 90 -f 'https://download.opensuse.org/repositories/devel:openQA:Leap
 
 If you installed openQA from the official repository first, you may need to change the vendor of the dependencies.
 
-``` sh
+```sh
 # openSUSE Tumbleweed and Leap
 zypper dup --from devel_openQA --allow-vendor-change
 
@@ -355,12 +350,13 @@ zypper dup --from devel_openQA_Leap --allow-vendor-change
 ### Installation
 
 <a id="preparations_on_sle"></a>
+
 #### Preparations on SLE
 
 On SLE certain modules have to be enabled.
 Afterwards the instructions for openSUSE apply.
 
-``` sh
+```sh
 . /etc/os-release
 SUSEConnect -p sle-module-desktop-applications/$VERSION_ID/$CPU
 SUSEConnect -p sle-module-development-tools/$VERSION_ID/$CPU
@@ -372,7 +368,7 @@ SUSEConnect -p PackageHub/$VERSION_ID/$CPU
 
 You can install the main openQA server package using these commands.
 
-``` sh
+```sh
 # openSUSE
 zypper in openQA
 
@@ -382,7 +378,7 @@ dnf install openqa openqa-httpd
 
 To install the openQA worker package use the following.
 
-``` sh
+```sh
 # SLE/openSUSE
 zypper in openQA-worker
 ```
@@ -400,7 +396,7 @@ To install openQA from sources make sure to install all dependencies as
 explained in [Dependencies](Contributing.md#dependencies). Then one can
 call
 
-``` sh
+```sh
 make install
 ```
 
@@ -421,11 +417,12 @@ specifications are recommended per openQA worker instance:
 - 40GB HDD (preferably SSD or NVMe)
 
 <a id="basic-configuration"></a>
+
 ## Basic configuration
 
 For a local instance setup you can simply execute the script:
 
-``` sh
+```sh
 /usr/share/openqa/script/configure-web-proxy
 ```
 
@@ -434,7 +431,7 @@ also supports NGINX and a custom port to listen on. Try `--help` to
 learn about the available options. Read on for more detailed setup
 instructions with all the details.
 
-> **NOTE:** 
+> **NOTE:**
 > The web proxy might not be allowed to connect to openQA when SELinux is enabled.
 > Therefore the `configure-web-proxy` script will automatically run `semanage boolean -m -1 httpd_can_network_connect` on SELinux systems to change that.
 
@@ -449,7 +446,7 @@ To make everything work correctly on openSUSE when using Apache, you
 need to enable the 'headers', 'proxy', 'proxy_http', 'proxy_wstunnel' and 'rewrite'
 modules using the command 'a2enmod'. This is not necessary on Fedora.
 
-``` sh
+```sh
 # openSUSE Only
 # You can check what modules are enabled by using 'a2enmod -l'
 a2enmod headers
@@ -463,7 +460,7 @@ For a basic setup, you can copy **openqa.conf.template** to **openqa.conf**
 and modify the `ServerName` setting if required.
 This will direct all HTTP traffic to openQA.
 
-``` sh
+```sh
 cp /etc/apache2/vhosts.d/openqa.conf.template /etc/apache2/vhosts.d/openqa.conf
 ```
 
@@ -473,7 +470,7 @@ For a basic setup, you can copy **openqa.conf.template** to **openqa.conf**
 and modify the `server_name` setting if required.
 This will direct all HTTP traffic to openQA.
 
-``` sh
+```sh
 cp /etc/nginx/vhosts.d/openqa.conf.template /etc/nginx/vhosts.d/openqa.conf
 ```
 
@@ -490,17 +487,20 @@ For openQA you need to set `httpsonly = 0` as described in the TLS/SSL section
 below, if you do not setup NGINX for SSL.
 
 #### Rate limiting
+
 The example NGINX configurations include a rate-limiting setup for the
 potentially resource-intensive `/tests/<testid:num>/details_ajax` endpoint to
 protect the web UI from being overwhelmed by too many simultaneous Ajax requests
 (e.g., from automated scripts or heavy browser sessions).
 
 This is configured in:
-* `openqa.conf.template` via the `limit_req_zone` directive, defining a shared
+
+- `openqa.conf.template` via the `limit_req_zone` directive, defining a shared
   memory zone `details_ajax_limit`.
-* `openqa-endpoints.inc` via the matching location block applying `limit_req`.
+- `openqa-endpoints.inc` via the matching location block applying `limit_req`.
 
 ##### Load balancer and reverse proxy consideration
+
 If your openQA instance is hosted behind an upstream load balancer or an
 external reverse proxy (like HAProxy, AWS ALB, or Cloudflare), NGINX's
 `$binary_remote_addr` will evaluate to the IP address of that load balancer
@@ -526,7 +526,7 @@ ensure a key and certificate are installed to the appropriate location
 cert location in the config file). On openSUSE, you should also add **SSL** to the
 **APACHE_SERVER_FLAGS** so it looks like this in `/etc/sysconfig/apache2`:
 
-``` sh
+```sh
 APACHE_SERVER_FLAGS="SSL"
 ```
 
@@ -534,12 +534,13 @@ If you don't have a TLS/SSL certificate for your host you must turn HTTPS off.
 You can do that in
 [the web UI configuration](GettingStarted.md#webui-configuration):
 
-``` ini
+```ini
 [openid]
 httpsonly = 0
 ```
 
 <a id="database"></a>
+
 ### Database
 
 openQA requires PostgreSQL 14 or newer. By default, a database with name
@@ -552,14 +553,14 @@ value format can be found in the <https://metacpan.org/pod/DBD>::Pg#DBI-Class-Me
 
 #### Example for connecting to local PostgreSQL database
 
-``` ini
+```ini
 [production]
 dsn = dbi:Pg:dbname=openqa
 ```
 
 #### Example for connecting to remote PostgreSQL database
 
-``` ini
+```ini
 [production]
 dsn = dbi:Pg:dbname=openqa;host=db.example.org
 user = openqa
@@ -575,7 +576,7 @@ Use the `auth` section in
 [the web UI configuration](GettingStarted.md#webui-configuration) to configure
 the method:
 
-``` ini
+```ini
 [auth]
 # method name is case sensitive!
 method = OpenID
@@ -602,7 +603,7 @@ By default openQA uses OpenID with opensuse.org as OpenID provider.
 OpenID method has its own `openid` section in
 [the web UI configuration](GettingStarted.md#webui-configuration):
 
-``` ini
+```ini
 [auth]
 # method name is case sensitive!
 method = OpenID
@@ -620,14 +621,14 @@ This method supports OpenID version up to 2.0.
 
 An additional Mojolicious plugin is required to use this feature:
 
-``` sh
+```sh
 # openSUSE
 zypper in 'perl(Mojolicious::Plugin::OAuth2)'
 ```
 
 Example for configuring OAuth2 with GitHub:
 
-``` ini
+```ini
 [auth]
 # method name is case sensitive!
 method = OAuth2
@@ -658,7 +659,7 @@ To ease worker testing, an API key and secret are created (or updated) for the
 login.
 You can then use the following as `/etc/openqa/client.conf`:
 
-``` ini
+```ini
 [auth]
 # method name is case sensitive!
 method = Fake
@@ -688,7 +689,7 @@ authenticated as the 'admin' user.
 If you still want to use API keys (e.g. for testing specific key-based
 logic), you can still create them on the `Manage API keys` page.
 
-``` ini
+```ini
 [auth]
 # method name is case sensitive!
 method = None
@@ -767,7 +768,7 @@ By default, job groups with "Development" in the name add +50 to the priority.
 
 To start openQA and enable it to run on each boot call
 
-``` sh
+```sh
 systemctl enable --now postgresql
 systemctl enable --now openqa-webui
 systemctl enable --now openqa-scheduler
@@ -799,6 +800,7 @@ there is no corresponding setting for IPv6 but the setting for IPv4 seems to
 help with IPv6 connections as well.
 
 <a id="run_openqa_workers"></a>
+
 ## Run openQA workers
 
 Workers are services running backends to perform the actual testing. The
@@ -821,7 +823,7 @@ multiple machines while still using only one web UI.
 
 If you are using SLE make sure to [add the required repos](#preparations_on_sle) first.
 
-``` sh
+```sh
 # openSUSE
 zypper in openQA-worker
 # Fedora
@@ -840,14 +842,14 @@ features directly from the worker node. This feature is disabled by default.
 To install and automatically enable the LLM server via Podman Quadlets,
 install the dedicated sub-package:
 
-``` sh
+```sh
 zypper in openQA-llm-server
 ```
 
 To configure a unified API endpoint across multiple LLM-enabled workers,
 copy and configure the provided Nginx template on your web UI server:
 
-``` sh
+```sh
 cp /etc/nginx/vhosts.d/openqa-llm.conf.template /etc/nginx/vhosts.d/openqa-llm.conf
 ```
 
@@ -865,7 +867,7 @@ for scripted deployments of openQA. Copy and paste the key and secret into
 sure to put in a section reflecting your webserver URL. In the simplest case,
 your `client.conf` may look like this:
 
-``` ini
+```ini
 [localhost]
 key = 1234567890ABCDEF
 secret = 1234567890ABCDEF
@@ -873,7 +875,7 @@ secret = 1234567890ABCDEF
 
 To start the workers you can use the provided systemd files via:
 
-``` sh
+```sh
 systemctl start openqa-worker@1
 ```
 
@@ -883,7 +885,7 @@ many workers as you need, you just need to supply a different 'instance number'
 
 You can also run workers manually from command line.
 
-``` sh
+```sh
 install -d -m 0755 -o _openqa-worker /var/lib/openqa/pool/X
 sudo -u _openqa-worker /usr/share/openqa/script/worker --instance X
 ```
@@ -922,7 +924,7 @@ If your tests and needles are stored in Git, openQA can perform various operatio
 
 - Automatically update the repository when scheduling tests
 
-- Update the server's tests and needles from Git repos specified in a job's `CASEDIR` and  `NEEDLES_DIR` variables
+- Update the server's tests and needles from Git repos specified in a job's `CASEDIR` and `NEEDLES_DIR` variables
 
 - Attempt to have the web UI display the correct needles each job was executed with via
   temporary Git checkouts, based on its variables
@@ -930,7 +932,7 @@ If your tests and needles are stored in Git, openQA can perform various operatio
 By default, cloning based on `CASEDIR` and `NEEDLES_DIR` is enabled, but the other
 features are disabled. To control these features, you can use these config settings:
 
-``` ini
+```ini
 [scm git]
 git_auto_commit = yes|no
 git_auto_clone = yes|no
@@ -942,7 +944,7 @@ checkout_needles_sha = yes|no
   value is the empty string '').
 
 - `git_auto_update` controls automatic test/needle updating when scheduling tests.
-- `git_auto_clone` controls the automatic cloning of repos referenced by `CASEDIR` and  `NEEDLES_DIR`, at job schedule time.
+- `git_auto_clone` controls the automatic cloning of repos referenced by `CASEDIR` and `NEEDLES_DIR`, at job schedule time.
   Check out the
   [section about directories](Installing.md#terms-and-variables-for-certain-directories-used-by-openqa-and-isotovideo)
   for where the repositories will be stored.
@@ -957,7 +959,7 @@ UI.
 You can do so by setting your configuration in the repository
 (`/var/lib/os-autoinst/needles/.git/config`) to some reasonable defaults such as:
 
-``` ini
+```ini
 [user]
     email = whatever@example.com
     name = openQA web UI
@@ -966,7 +968,7 @@ You can do so by setting your configuration in the repository
 To enable automatic pushing of the repo as well, you need to add the following
 to [the web UI configuration](GettingStarted.md#webui-configuration):
 
-``` ini
+```ini
 [scm git]
 do_push = yes
 ```
@@ -977,7 +979,7 @@ ssh keys for user 'geekotest' to be able to push.
 It might also be useful to rebase first. To enable that, add the remote to get the
 latest updates from and the branch to rebase against to your openqa.ini:
 
-``` ini
+```ini
 [scm git]
 update_remote = origin
 update_branch = origin/master
@@ -987,7 +989,7 @@ If rebasing, it may be useful to perform a hard reset of the local repository
 to ensure that the rebase will not fail. To enable that, add the following to
 your openqa.ini (along with the previous snippet):
 
-``` ini
+```ini
 [scm git]
 do_cleanup = yes
 ```
@@ -996,7 +998,7 @@ If you clone the needle repository via HTTP, you can still make `geekotest`
 able to push via SSH with a Git configuration. For GitHub, it would look like
 this:
 
-``` sh
+```sh
 git config --global url."git@github.com:".pushInsteadOf https://github.com/
 ```
 
@@ -1005,7 +1007,7 @@ repository, even if it's already cloned.
 
 Or put it in the `~/.gitconfig` file manually:
 
-``` ini
+```ini
 [url "git@github.com:"]
   pushInsteadOf = https://github.com/
 ```
@@ -1024,7 +1026,7 @@ important.
 List of recognized referrers is space separated list configured in
 [the web UI configuration file](GettingStarted.md#webui-configuration):
 
-``` ini
+```ini
 [global]
 recognized_referers = bugzilla.suse.com bugzilla.opensuse.org
 ```
@@ -1041,15 +1043,9 @@ which captures CPU contention, I/O wait, and runnable process count.
 The feature is disabled by default. To enable it, configure the `[scheduler]` section of
 `openqa.ini`:
 
-
-
-
-
 openqa.ini
 
-
-
-``` ini
+```ini
 [scheduler]
 # Enable dynamic job limit scaling based on system load (default: 0 = disabled)
 dynamic_job_limit_enabled = 1
@@ -1076,8 +1072,6 @@ max_running_jobs = 500
 #dynamic_job_limit_interval = 60
 ```
 
-
-
 The scaling algorithm:
 
 - **Increases** the limit by `step` when all load averages are well below the threshold (\< 70% of threshold)
@@ -1096,7 +1090,7 @@ in [the worker configuration](GettingStarted.md#worker-configuration). For
 example to point the workers to the FQDN of your host (needed if test cases need
 to access files of the host) use the following setting:
 
-``` ini
+```ini
 [global]
 HOST = http://openqa.example.com
 ```
@@ -1105,7 +1099,7 @@ HOST = http://openqa.example.com
 
 The load of the system can affect test stability and causing VM boot problems
 and failures due to delays of command execution and
-[thrashing](https://en.wikipedia.org/wiki/Thrashing_(computer_science)). If the
+[thrashing](<https://en.wikipedia.org/wiki/Thrashing_(computer_science)>). If the
 average over a period of 15 minutes exceeds the specified value, the worker will
 not accept new jobs. This can be controlled via the setting
 `CRITICAL_LOAD_AVG_THRESHOLD`. For this to be more effective,
@@ -1152,7 +1146,7 @@ to the worker being restarted without interrupting currently running jobs. This
 can be useful to apply configuration changes and updates without interfering
 ongoing testing. Example:
 
-``` sh
+```sh
 systemctl reload 'openqa-worker-auto-restart@*.service' # sends SIGHUP to worker
 ```
 
@@ -1163,7 +1157,7 @@ under `/etc/openqa/workers.ini` changes. This unit is not enabled by default and
 This kind of setup makes it easy to take out worker slots temporarily without
 interrupting currently running jobs:
 
-``` sh
+```sh
 # prevent worker services from restarting and being automatically reloaded
 systemctl stop openqa-reload-worker-auto-restart@{1..28}.{service,path}
 systemctl mask openqa-worker-auto-restart@{1..28}.service
@@ -1173,6 +1167,7 @@ systemctl kill --kill-who=main --signal HUP openqa-worker-auto-restart@{1..28}
 ```
 
 <a id="configuring_remote_workers"></a>
+
 ### Configuring remote workers
 
 There are some additional requirements to get remote worker running. First is to
@@ -1185,13 +1180,13 @@ storage for her specific needs.
 Example of NFS configuration:
 NFS server is where openQA web UI is running. Content of `/etc/exports`
 
-``` sh
+```sh
 /var/lib/openqa/share *(fsid=0,rw,no_root_squash,sync,no_subtree_check)
 ```
 
 NFS clients are where openQA workers are running. Run following command:
 
-``` sh
+```sh
 mount -t nfs openQA-webUI-host:/var/lib/openqa/share /var/lib/openqa/share
 ```
 
@@ -1211,7 +1206,7 @@ first make sure that the `perl-Mojo-RabbitMQ-Client` RPM is installed.
 Then you will need to configure AMQP in
 [the web UI configuration file](GettingStarted.md#webui-configuration):
 
-``` ini
+```ini
 # Enable the AMQP plugin
 [global]
 plugins = AMQP
@@ -1243,7 +1238,7 @@ In [the worker configuration](GettingStarted.md#worker-configuration), enter
 space-separated instance hosts and optionally configure where the shared storage
 is mounted. Example:
 
-``` ini
+```ini
 [global]
 HOST = openqa.opensuse.org openqa.fedora.fedoraproject.org
 
@@ -1274,6 +1269,7 @@ It is possible to mix local openQA instance with remote instances or use only
 remote instances.
 
 <a id="asset-caching"></a>
+
 ### Asset and test/needle caching
 
 If your network is slow or you experience long time to load needles you might
@@ -1282,7 +1278,7 @@ want to consider enabling caching on your remote workers. To enable caching,
 [the worker configuration](GettingStarted.md#worker-configuration). There are
 also further settings one can optionally configure. Example:
 
-``` ini
+```ini
 [global]
 HOST = http://webui
 CACHEDIRECTORY = /var/lib/openqa/cache # desired cache location
@@ -1311,7 +1307,7 @@ assets end.
 The caching is provided by two additional services which need to be started
 on the worker host:
 
-``` sh
+```sh
 systemctl enable --now \
     openqa-worker-cacheservice openqa-worker-cacheservice-minion
 ```
@@ -1320,7 +1316,7 @@ The rsync server daemon needs to be configured and started on the web UI host.
 
 Example `/etc/rsyncd.conf`:
 
-``` ini
+```ini
 gid = users
 read only = true
 use chroot = true
@@ -1336,7 +1332,7 @@ path = /var/lib/openqa/share/tests
 comment = openQA test distributions
 ```
 
-``` sh
+```sh
 systemctl enable --now rsyncd
 ```
 
@@ -1370,7 +1366,7 @@ You can configure openQA to display links to these files within the job settings
 To enable particular settings to be presented as a link within the settings tab
 one can setup the relevant keys in `/etc/openqa/openqa.ini`.
 
-``` ini
+```ini
 [job_settings_ui]
 keys_to_render_as_links=FOO,AUTOYAST
 ```
@@ -1380,6 +1376,7 @@ of `CASEDIR` or the data folder within `CASEDIR`.
 
 <a id="custom_hook_scripts_job_done"></a>
 <a id="enable_custom_hook_scripts_on_job_done_based_on_result"></a>
+
 ### Enable custom hook scripts on "job done" based on result
 
 If a job is done, especially if no label could be found for carry-over, often
@@ -1387,8 +1384,6 @@ more steps are needed for the review of the test result or providing the
 information to either external systems or users. As there can be very custom
 requirements openQA offers a point for optional configuration to let the
 instance administrators define specific actions.
-
-
 
 By setting custom hooks it is possible to call external scripts defined in
 either environment variables or config settings.
@@ -1454,6 +1449,7 @@ General status and stdout output is visible in the GRU minion job dashboard on t
 `/minion/jobs?offset=0&task=finalize_job_results` of the openQA instance.
 
 <a id="automatic_cloning_incomplete_jobs"></a>
+
 ### Automatic cloning of incomplete jobs
 
 By default, when a worker reports an incomplete job due to a cache service related
@@ -1461,8 +1457,6 @@ problem, the job is automatically cloned. It is possible to extend the regex to 
 other types of incompletes as well by adjusting `auto_clone_regex` in the `global`
 section of the config file. It is also possible to assign `0` to prevent the automatic
 cloning.
-
-
 
 Note that jobs marked as incomplete by the stale job detection are not affected by this
 configuration and cloned in any case.
@@ -1475,9 +1469,7 @@ An optional systemd service, `openqa-dump-db.service`, can be enabled to
 perform daily database backups. This service is triggered by the
 `openqa-dump-db.timer`. To enable automatic database backup, run:
 
-
-
-``` sh
+```sh
 systemctl enable --now openqa-dump-db.timer
 ```
 
@@ -1494,7 +1486,7 @@ Audit log is directly accessible from `Admin menu`.
 Auditing, by default enabled, can be disabled by global configuration option in
 [the web UI configuration file](GettingStarted.md#webui-configuration):
 
-``` ini
+```ini
 [global]
 audit_enabled = 0
 ```
@@ -1503,7 +1495,7 @@ The `audit` section of
 [the web UI configuration](GettingStarted.md#webui-configuration) allows to
 exclude some events from logging using a space separated blocklist:
 
-``` ini
+```ini
 [audit]
 blocklist = job_grab job_done
 ```
@@ -1512,7 +1504,7 @@ The `audit/storage_duration` section of
 [the web UI configuration](GettingStarted.md#webui-configuration) allows to set
 the retention policy for different audit event types:
 
-``` ini
+```ini
 [audit/storage_duration]
 startup = 10
 jobgroup = 365
@@ -1570,9 +1562,7 @@ The distribution package `openQA-auto-update` offers automatic system
 upgrades and reboots of openQA hosts. To use that feature install the package
 `openQA-auto-update` and enable the corresponding systemd timer:
 
-
-
-``` sh
+```sh
 systemctl enable openqa-auto-update.timer
 ```
 
@@ -1605,7 +1595,7 @@ likely be used for other setups as well. These instructions can migrate big
 databases in seconds without requiring additional disk space. However, services
 need to be stopped during the (short) migration.
 
-1.  Locate the `data`-directory. Its path is configured in  `/etc/sysconfig/postgresql` and should be `/var/lib/pgsql/data` by default. The
+1.  Locate the `data`-directory. Its path is configured in `/etc/sysconfig/postgresql` and should be `/var/lib/pgsql/data` by default. The
     paths in the next steps assume the default.
 
 <!-- -->
@@ -1614,7 +1604,7 @@ need to be stopped during the (short) migration.
     to a versioned directory. So the file system layout would look for example like
     this:
 
-    ``` sh
+    ```sh
     $ sudo -u postgres ls -l /var/lib/pgsql | grep data
     lrwxrwxrwx  1 root     root        7  8. Sep 2019  data -> data.10
     drwx------ 20 postgres postgres 4096 30. Aug 00:00 data.10
@@ -1628,7 +1618,7 @@ need to be stopped during the (short) migration.
 3.  Install same set of postgresql\* packages as are installed for the old
     version:
 
-    ``` sh
+    ```sh
     oldver=17 newver=18
     sudo zypper in postgresql$newver-server postgresql$newver-contrib
     ```
@@ -1638,7 +1628,7 @@ need to be stopped during the (short) migration.
 4.  Change to a directory where the user postgres will be able to write logs to,
     e.g.:
 
-    ``` sh
+    ```sh
     cd /tmp
     ```
 
@@ -1646,15 +1636,15 @@ need to be stopped during the (short) migration.
 
 5.  Prepare the migration:
 
-    ``` sh
+    ```sh
     sudo -u postgres /usr/lib/postgresql$newver/bin/initdb [locale-settings] -D /var/lib/pgsql/data.$newver
     ```
 
-    > **IMPORTANT:** 
+    > **IMPORTANT:**
     > Be sure to use initdb from the target version (like it is done here)
     > and also no newer version which is possibly installed on the system as well.
 
-    > **IMPORTANT:** 
+    > **IMPORTANT:**
     > Lookup the locale settings in
     > `/var/lib/pgsql/data.$oldver/postgresql.conf` or via `sudo -u geekotest psql`
     > `openqa -c 'show all;' | grep lc_` to pass locale settings listed by `initdb`
@@ -1668,13 +1658,13 @@ need to be stopped during the (short) migration.
 
 6.  Take over any relevant changes from the old config to the new one, e.g.:
 
-    ``` sh
+    ```sh
     sudo -u postgres vimdiff \
         /var/lib/pgsql/data.$oldver/postgresql.conf \
         /var/lib/pgsql/data.$newver/postgresql.conf
     ```
 
-    > **IMPORTANT:** 
+    > **IMPORTANT:**
     > There shouldn't be a diff in the locale settings, otherwise
     > `pg_upgrade` will complain.
 
@@ -1683,7 +1673,7 @@ need to be stopped during the (short) migration.
 7.  Shutdown postgres server and related services as appropriate for your setup,
     e.g.:
 
-    ``` sh
+    ```sh
     sudo systemctl stop openqa-{webui,websockets,scheduler,livehandler,gru}
     sudo systemctl stop postgresql
     ```
@@ -1692,7 +1682,7 @@ need to be stopped during the (short) migration.
 
 8.  Perform the migration:
 
-    ``` sh
+    ```sh
     sudo -u postgres /usr/lib/postgresql$newver/bin/pg_upgrade --link \
         --old-bindir=/usr/lib/postgresql$oldver/bin \
         --new-bindir=/usr/lib/postgresql$newver/bin \
@@ -1700,13 +1690,13 @@ need to be stopped during the (short) migration.
         --new-datadir=/var/lib/pgsql/data.$newver
     ```
 
-    > **IMPORTANT:** 
+    > **IMPORTANT:**
     > Be sure to use pg_upgrade from the target version (like it is done here) and
     > also no newer version which is possibly installed on the system as well.
     > Check out the [PostgreSQL documentation](https://www.postgresql.org/docs/current/pgupgrade.html)
     > for details.
 
-    > **NOTE:** 
+    > **NOTE:**
     > This step only takes a few seconds for multiple production DBs because the `--link`
     > option is used.
 
@@ -1714,7 +1704,7 @@ need to be stopped during the (short) migration.
 
 9.  Change symlink (shown in step 2) to use the new data directory:
 
-    ``` sh
+    ```sh
     sudo ln --force --no-dereference --relative --symbolic /var/lib/pgsql/data.$newver /var/lib/pgsql/data
     ```
 
@@ -1722,12 +1712,12 @@ need to be stopped during the (short) migration.
 
 10. Start services again as appropriate for your setup, e.g.:
 
-    ``` sh
+    ```sh
     sudo systemctl start postgresql
     sudo systemctl start openqa-{webui,websockets,scheduler,livehandler,gru}
     ```
 
-    > **NOTE:** 
+    > **NOTE:**
     > There is no need to take care of starting the new version of the PostgreSQL service.
     > The start script checks the version of the data directory and starts the correct version.
 
@@ -1735,7 +1725,7 @@ need to be stopped during the (short) migration.
 
 11. Check whether usual role and database are present and running on the new version:
 
-    ``` sh
+    ```sh
     sudo -u geekotest psql -c 'select version();' openqa
     ```
 
@@ -1743,7 +1733,7 @@ need to be stopped during the (short) migration.
 
 12. Remove old postgres packages if not needed anymore:
 
-    ``` sh
+    ```sh
     sudo zypper rm postgresql$oldver-server postgresql$oldver-contrib postgresql$oldver
     ```
 
@@ -1751,7 +1741,7 @@ need to be stopped during the (short) migration.
 
 13. Delete the old data directory if not needed anymore:
 
-    ``` sh
+    ```sh
     sudo -u postgres rm -r /var/lib/pgsql/data.$oldver
     ```
 
@@ -1793,7 +1783,7 @@ are using indexes (and not just sequential scans).
 ### Further things to try
 
 1.  Try to tweak database configuration parameters. For example increasing
-    `work_mem` in `postgresql.conf` might help with some heavy queries. 2.  Run `VACUUM VERBOSE ANALYZE table_name;` for any table that shows to be impacting
+    `work_mem` in `postgresql.conf` might help with some heavy queries. 2. Run `VACUUM VERBOSE ANALYZE table_name;` for any table that shows to be impacting
     the performance. This can take some seconds or minutes but can help to improve
     performance in particular after bigger schema migrations for example type
     changes.
@@ -1821,12 +1811,11 @@ Tests, needles, assets, results and working directories (a.k.a. "pool directorie
 subdirectories within `/var/lib/openqa`. This directory is configurable (see
 [Customize base directory](Contributing.md#customize-base-directory)). Here we assume the default is in place.
 
-
-
 Note that the sub directories within `/var/lib/openqa` must be accessible by the user that runs the openQA web UI
 (by default 'geekotest') or by the user that runs the worker/isotovideo (by default '\_openqa-worker').
 
 These are the most important sub directories within `/var/lib/openqa`:
+
 - `db` contains the web UI's database lockfile
 - `images` is where the web UI stores test screenshots and thumbnails
 - `testresults` is where the web UI stores test logs and test-generated assets
@@ -1869,6 +1858,7 @@ own tests, or use existing tests for some distribution or other piece of
 software.
 
 The worker needs to own `/var/lib/openqa/pool/$INSTANCE`, e.g.
+
 - `/var/lib/openqa/pool/1`
 
 - `/var/lib/openqa/pool/2`
@@ -1936,12 +1926,12 @@ the workers create their own instance directories.
     under the mentioned default location if it does not already exist
 
 #### Further notes
+
 - The mentioned `git_auto_clone` setting is part of the general
   [Git support](Installing.md#setting-up-git-support) and works best if used
   consistently. If e.g. only specifying a Git URL for `CASEDIR` but not for
   `NEEDLES_DIR`, only the former will be cloned and needles will be missing if
   they are provided by a separate repository.
-
   - As mentioned, there is no de-duplication of checkouts. So when cloning a job
     with e.g. `CASEDIR=https://github.com/…/…-distri-opensuse.git` and
     `DISTRI=microos` but no `NEEDLES_DIR`, needles will be missing despite being
@@ -1963,8 +1953,6 @@ As a maintainer of an openQA infrastructure running multiple openQA worker
 machines one likely wants to use installation recipes for automatic
 installations to provide a consistent and easy setup of new machines.
 
-
-
 For this [AutoYaST](https://doc.opensuse.org/projects/autoyast/) can be used. An
 example template that provides the bare basics of installing a machine with
 SSH and salt, e.g. to be used with
@@ -1983,13 +1971,13 @@ For WireGuard using wg-quick is recommended.
 
 To generate a private (first line) and a public (second line) key for each peer use this command:
 
-``` sh
+```sh
 wg genkey | tee /dev/stderr | wg pubkey
 ```
 
 Create a config in `/etc/wireguard/openqa.conf` on the webui host:
 
-``` ini
+```ini
 [Interface]
 Address = fd0a::1/128
 PrivateKey = +++ INSERT PRIVATE KEY of webui +++
@@ -2011,7 +1999,7 @@ PersistentKeepalive = 60
 
 Create a config in `/etc/wireguard/openqa.conf` on the worker1 host (and analog on other worker hosts):
 
-``` ini
+```ini
 [Interface]
 Address = fd0a::2/128
 PrivateKey = +++ INSERT PRIVATE KEY HERE +++
@@ -2025,7 +2013,7 @@ AllowedIPs = fd0a::1/128
 
 On all peers run now:
 
-``` sh
+```sh
 zypper -n in wireguard-tools
 systemctl enable --now wg-quick@openqa
 ```
@@ -2033,7 +2021,7 @@ systemctl enable --now wg-quick@openqa
 Then update [the worker configuration](GettingStarted.md#worker-configuration)
 on the workers like this:
 
-``` ini
+```ini
 [global]
 HOST=[fd0a::1]
 
@@ -2043,13 +2031,13 @@ TESTPOOLSERVER = rsync://[fd0a::1]/tests
 
 Same for `/etc/openqa/client.conf`
 
-``` ini
+```ini
 [[fd0a::1]]
 key = FOO
 secret = BAR
 ```
 
-> **NOTE:** 
+> **NOTE:**
 > The IPv6 address is written in square brackets as it is internally
 > converted to a URL which requires this notation.
 > This is also the reason why host specific section headers need to
@@ -2078,6 +2066,7 @@ least still run as a distinct user (when using upstream-provided systemd unit
 files).
 
 <a id="authentication"></a>
+
 ### Authentication
 
 Authentication via OpenID is enabled by default. Do **not** change the
@@ -2132,7 +2121,7 @@ www.opensuse.org's OpenID provider may have trouble with IPv6. openQA shows a me
 To avoid that switch off IPv6 or add a special route that prevents the system
 from trying to use IPv6 with www.opensuse.org:
 
-``` sh
+```sh
 ip -6 r a to unreachable 2620:113:8044:66:130:57:66:6/128
 ```
 
@@ -2143,7 +2132,7 @@ caching downloads take too long it makes sense to cross-check the networking
 performance. This can be done via `iperf3`. Launch the server via `iperf3 -s` on one host (e.g. the openQA web UI host).
 Then run a test on another host (e.g. an openQA worker host) like this:
 
-``` sh
+```sh
 iperf3 -c serverhost -i 1 -t 30  # 30 second tests, giving results every second
 ```
 

--- a/docs/Networking.md
+++ b/docs/Networking.md
@@ -1,4 +1,5 @@
 <a id="networking"></a>
+
 # Networking
 
 For tests using the QEMU backend the networking type used is controlled by the
@@ -16,9 +17,8 @@ be ensured externally where needed as means for machines to be able to access
 each other.
 
 <a id="qemu-user-networking"></a>
+
 ## QEMU User Networking
-
-
 
 With QEMU [user networking](http://wiki.qemu.org/Documentation/Networking#User_Networking_.28SLIRP.29) each jobs gets its own isolated network with
 TCP and UDP routed to the outside. DHCP is provided by QEMU. The MAC address of
@@ -26,6 +26,7 @@ the machine can be controlled with the `NICMAC` variable. If not set, it is
 `52:54:00:12:34:56`.
 
 <a id="tap-based-network"></a>
+
 ## TAP Based Network
 
 os-autoinst can connect QEMU to TAP devices of the host system to
@@ -61,12 +62,12 @@ versions) for NAT and _wicked_ or _NetworkManager_ as network manager. Keep in
 mind that a firewall is not strictly necessary for operation. The operation
 without firewall is not covered in all necessary details in this documentation.
 
-> **NOTE:** 
+> **NOTE:**
 > Another way to setup the environment with _iptables_ and _firewalld_ is
 > described on the
 > [Fedora wiki](https://fedoraproject.org/wiki/OpenQA_advanced_network_guide).
 
-> **NOTE:** 
+> **NOTE:**
 > Alternatively
 > [salt-states-openqa](https://github.com/os-autoinst/salt-states-openqa) contains
 > necessities to establish such a setup and configure it for all workers with the
@@ -87,7 +88,7 @@ instances=30 bash -x $(which os-autoinst-setup-multi-machine)
 The script will install and configure Open vSwitch as well as
 a service called _os-autoinst-openvswitch.service_.
 
-> **NOTE:** 
+> **NOTE:**
 > _os-autoinst-openvswitch.service_ is a support service that sets the
 > vlan number of Open vSwitch ports based on `NICVLAN` variable - this separates the groups of tests from each other. The `NICVLAN` variable is dynamically
 > assigned by the openQA scheduler.
@@ -109,7 +110,7 @@ masquerading rules.
 The script will add the bridge device and the tap devices for every
 multi-machine worker instance.
 
-> **NOTE:** 
+> **NOTE:**
 > The bridge device will also call a script at
 > `/etc/wicked/scripts/gre_tunnel_preup.sh` on _PRE_UP_.
 > This script needs **manual** touch if you want to set up multiple
@@ -118,7 +119,7 @@ multi-machine worker instance.
 
 ##### Configure NAT with firewalld
 
-> **NOTE:** 
+> **NOTE:**
 > `os-autoinst-setup-multi-machine` can set this up for you, but using > plain NFT instead of firewalld (which `os-autoinst-setup-multi-machine` can
 > setup as well) is recommended due to firewalld's suboptimal performance with
 > many tap interfaces present.
@@ -136,6 +137,7 @@ firewall-cmd --list-all-zones
 #### What is left to do after running os-autoinst-setup-multi-machine
 
 <a id="gre-tunnels"></a>
+
 ##### GRE tunnels
 
 By default all multi-machine workers have to be on a single physical machine.
@@ -170,7 +172,7 @@ PRE_UP_SCRIPT="wicked:gre_tunnel_preup.sh"
 
 Ensure to make gre_tunnel_preup.sh executable.
 
-> **NOTE:** 
+> **NOTE:**
 > When using GRE tunnels keep in mind that virtual machines inside the ovs
 > bridges have to use MTU=1458 for their physical interfaces (eth0, eth1). If
 > you are using support_server/setup.pm the MTU will be set automatically to
@@ -187,7 +189,7 @@ Allow worker instances to run multi-machine jobs by modifying
 WORKER_CLASS = qemu_x86_64,tap
 ```
 
-> **NOTE:** 
+> **NOTE:**
 > The number of tap devices should correspond to the number of the running
 > worker instances. For example, if you have set up 3 worker instances, the same
 > number of tap devices should be configured.
@@ -242,14 +244,14 @@ assign a unique MAC address (e.g. by adjusting the last two figures in the
 example; this will not conflict with MAC addresses used by os-autoinst) and use
 a tap device not used at the same time by a SUT-VM.
 
-> **NOTE:** 
+> **NOTE:**
 > Different from the qemu user mode network setup there is no DHCP or
 > router advertisement on the multi machine network. IP addresses, routes and DNS
 > needs to be set up by test scripts. By default IP ranges are similar to the
 > ones used by qemu usermode networking - except for the IPv6 default route which
 > is via `fec0::2` for MM networks instead of `fe80::2` for usermode networks.
 
-> **NOTE:** 
+> **NOTE:**
 > There is no default/builtin DNS server on MM networks - if you need DNS,
 > use an upstream dns server on the local network of the worker host or the internet.
 
@@ -324,11 +326,11 @@ Bridge "br0"
   ovs_version: "2.11.1"
 ```
 
-> **NOTE:** 
+> **NOTE:**
 > Notice the tag numbers are assigned to tap1 and tap2. They should have
 > the same number.
 
-> **NOTE:** 
+> **NOTE:**
 > If the balance of the tap devices is wrong in
 > [the worker configuration](GettingStarted.md#worker-configuration), the tag
 > cannot be assigned and the communication will be broken.
@@ -337,7 +339,7 @@ To list the rules which are effectively configured in the underlying netfilter
 (`nftables` or `iptables`) use one of the following commands depending on which
 netfilter is used.
 
-> **NOTE:** 
+> **NOTE:**
 > Whether firewalld is using `nftables` or `iptables` is determined by the > setting `FirewallBackend` in `/etc/firewalld/firewalld.conf`. SuSEfirewall2 is > always using `iptables`.
 
 ```sh
@@ -363,7 +365,7 @@ Check the flow of packets over the network:
 As long as the SUT has access to external network, there should be a non-zero
 packet count in the forward chain between the br1 and external interface.
 
-> **NOTE:** 
+> **NOTE:**
 > To list the package count when `nftables` is used one needed to use
 > [counters](https://wiki.nftables.org/wiki-nftables/index.php/Counters) (which can
 > be [added to existing rules](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/getting-started-with-nftables_configuring-and-managing-networking#adding-a-counter-to-an-existing-rule_debugging-nftables-rules)).
@@ -386,7 +388,7 @@ systemctl enable --now openvswitch
 | A    | 192.0.2.1/24    | 192.168.42.1/24 | 192.0.2.2 |
 | B    | 192.0.2.2/24    | 192.168.43.1/24 | 192.0.2.1 |
 
-> **NOTE:** 
+> **NOTE:**
 > instead of having two /24 networks, it is also possible to assign addresses from one bigger network (which have the benefit of not needing explicit route assignment).
 
 #### Simple scenario

--- a/docs/Pitfalls.md
+++ b/docs/Pitfalls.md
@@ -1,4 +1,5 @@
 <a id="pitfalls"></a>
+
 # Pitfalls
 
 ## Needle editing
@@ -63,6 +64,7 @@ settings. Alternatively, you may disable optimizing images altogether via the
 setting `OPTIMIZE_IMAGES=0`.
 
 <a id="db-migration"></a>
+
 ## DB migration from SQlite to postgreSQL
 
 As a first step to start using postgreSQL, please, configure postgreSQL database
@@ -90,6 +92,7 @@ In case you need to migrate job groups, test suites, use openqa-dump-templates a
 openqa-load-templates scripts accordingly.
 
 <a id="debugdevelmode"></a>
+
 ## Steps to debug developer mode setup
 
 This is basically a checklist to go through in case the developer mode is broken in your setup

--- a/docs/PrivacyPolicy.md
+++ b/docs/PrivacyPolicy.md
@@ -1,4 +1,5 @@
 <a id="privacypolicy"></a>
+
 # Privacy Policy
 
 ## Introduction

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -1,4 +1,5 @@
 <a id="usersguide"></a>
+
 # Users Guide
 
 ## Introduction
@@ -100,6 +101,7 @@ worker' connected that can fulfill those specifications.
     emulated USB stick.
 
 <a id="medium_types_products"></a>
+
 ### Medium Types (products)
 
 A medium type (product) in openQA is a simple description without any concrete
@@ -123,16 +125,17 @@ Some example variables used by openSUSE are:
 - `RESCUECD` is set to 1 for rescue CD images.
 
 #### Using Wildcards in Medium Versions
+
 You can use the `*` character within a medium version to enable a fallback
 lookup using globbing. This is particularly helpful for the following scenarios:
 
-- *Consolidating generic medium types:* Instead of creating a unique medium
+- _Consolidating generic medium types:_ Instead of creating a unique medium
   type for every single version, you can use `*` as a catch-all version.
-    - Tip: Avoid defining a concrete version (e.g., `16.1`) and a wildcard
-      version (`*`) within one schedule definition unless you have matching job
-      templates for both, as this can trigger a scheduling error
-      (`no templates found for product...`).
-- *Handling isolated tests for individual submissions (e.g. pull-requests):*
+  - Tip: Avoid defining a concrete version (e.g., `16.1`) and a wildcard
+    version (`*`) within one schedule definition unless you have matching job
+    templates for both, as this can trigger a scheduling error
+    (`no templates found for product...`).
+- _Handling isolated tests for individual submissions (e.g. pull-requests):_
   When testing such submissions, schedule the products with e.g.,
   `VERSION=16.1:PR-1234`. This will avoid cluttering the "Next & Previous" table
   and prevent unintended carry-overs. Then specify a partial-match as the medium
@@ -145,6 +148,7 @@ lookup using globbing. This is particularly helpful for the following scenarios:
   [history isolation keys](#history-isolation-keys) mechanism instead.
 
 <a id="history-isolation-keys"></a>
+
 #### Separating the history of independent submissions
 
 Features that operate on the history of a scenario (bug reference
@@ -355,8 +359,6 @@ Test suites can be described using API commands or the admin table for any opera
 <figcaption>Entering a test suite description in the admin table using the web interface:</figcaption>
 </figure>
 
-
-
 If a description is defined, the name of the test suite on the tests overview page shows up as a link. Clicking the link will show the description in a popup. The same syntax as for comments can be used, that is Markdown with custom extensions such as shortened links to ticket systems.
 
 <a id="test_suite_description_shown"></a>
@@ -365,8 +367,6 @@ If a description is defined, the name of the test suite on the tests overview pa
 <img src="images/test_suite_description_shown.png" alt="test suite description popup" />
 <figcaption>popover in test overview with content as configured in the test suites database:</figcaption>
 </figure>
-
-
 
 ### /tests/overview - Customizable test overview page
 
@@ -383,8 +383,6 @@ see [the following example](#overview_multiple_groups).
 <img src="images/tests-overview_multiple_groups.png" alt="test overview page showing multiple groups" />
 <figcaption>The openQA test overview page showing multiple groups at once. The URL query parameters specify the groupid parameter two times to resolve both the "opensuse" and "opensuse test" group.</figcaption>
 </figure>
-
-
 
 Specifying multiple groups with no build will yield the result for the latest
 build of each group. This can be useful to have a static URL for bookmarking.
@@ -439,8 +437,6 @@ carryover.
 <figcaption>Bug icon for job with bug reference on test result overview</figcaption>
 </figure>
 
-
-
 All bug references are stored within the internal database of openQA.
 The status can be updated using the `/bugs` API route with external tools.
 One can set the bug status this way which will then be shown in the web UI,
@@ -452,8 +448,6 @@ see the figure below.
 <img src="images/labels_closed_tickets.png" alt="Example for visualization of closed issues" />
 <figcaption>Example for visualization of closed issues: The upside down icons in red visualize closed issues.</figcaption>
 </figure>
-
-
 
 > **NOTE:**
 > Also GitHub pull requests and issues can be linked. Use the generic format
@@ -474,8 +468,6 @@ will be shown next to it in various places as shown in the figure below.
 <img src="images/label_icon.png" alt="Label icon on test result overview" />
 <figcaption>Label icon for job with a label on test result overview</figcaption>
 </figure>
-
-
 
 > **NOTE:**
 > A label containing a bug reference will still be treated as a label,
@@ -749,6 +741,7 @@ autologin-timeout=0
 ```
 
 <a id="carry-over"></a>
+
 ### Carry over of bug references from previous jobs in same scenario
 
 Many test failures within the same scenario might be due to the same reason.
@@ -820,17 +813,17 @@ In case the developer mode in not working on your instance, try to follow the
 1.  In case a new needles should be created, add the corresponding `assert_screen` calls
     to your test.
 
-2.  Start the test with the `assert_screen` calls which are supposed to fail. 3.  Select "`assert_screen` timeout" under "Pause on screen mismatch" and confirm.
+2.  Start the test with the `assert_screen` calls which are supposed to fail. 3. Select "`assert_screen` timeout" under "Pause on screen mismatch" and confirm.
 
-4.  Wait until the test has paused. There is a button to skip the current timeout to speed
+3.  Wait until the test has paused. There is a button to skip the current timeout to speed
     this up.
 
-5.  A button for accessing the needle editor should occur. It may take a few seconds till
+4.  A button for accessing the needle editor should occur. It may take a few seconds till
     it occurs because the screenshots created so far need to be uploaded from the worker to
     the web UI. Of course it is also possible to go back to the "Details" tab to create a new
     needle from any previous screenshot/match available.
 
-6.  After creating the new needle, click the resume button to test whether it worked.
+5.  After creating the new needle, click the resume button to test whether it worked.
 
 Steps 4. to 6. can be repeated for further needles without restarting the test.
 
@@ -1145,6 +1138,7 @@ If you need the literal string `<<` (for example as a value in the job
 settings), you have to quote it.
 
 <a id="rest_api"></a>
+
 ## Use of the REST API
 
 openQA includes a _client_ script which - depending on the distribution - is
@@ -1187,8 +1181,8 @@ by adding additional query parameters, e.g.:
 - `groupid`/`group`: Return only jobs within the job group with the
   specified ID/name like in the example above. These parameters are mutually
   exclusive, `groupid` has precedence.
-- `latest=1`: De-duplicates, so that for the same `DISTRI`, `VERSION`, `BUILD`,  `TEST`, `FLAVOR`, `ARCH` and `MACHINE` only the latest job is returned.
-- `limit`/`page`: Limit the number of returned jobs and allow pagination, e.g.  `page=2&limit=10` would only show results 11-20.
+- `latest=1`: De-duplicates, so that for the same `DISTRI`, `VERSION`, `BUILD`, `TEST`, `FLAVOR`, `ARCH` and `MACHINE` only the latest job is returned.
+- `limit`/`page`: Limit the number of returned jobs and allow pagination, e.g. `page=2&limit=10` would only show results 11-20.
 - `modules`/`modules_result`: Return only jobs which have a test module with the
   specified name/result.
 
@@ -1206,7 +1200,7 @@ by adding additional query parameters, e.g.:
 - When specifying the same parameter multiple times, only the last occurrence
   is taken into account.
 
-- All values are matched exactly, so e.g. `group=openSUSE+Leap+15` returns only jobs within the group `openSUSE Leap 15` but not jobs from the group  `openSUSE Leap 15 ARM`. This applies to parameters for filtering job settings
+- All values are matched exactly, so e.g. `group=openSUSE+Leap+15` returns only jobs within the group `openSUSE Leap 15` but not jobs from the group `openSUSE Leap 15 ARM`. This applies to parameters for filtering job settings
   as well.
 
 ### Finding tests by querying particular job settings
@@ -1245,6 +1239,7 @@ openqa-cli api jobs result=none job_setting=ISSUES[]={foo,bar} limit=50
 ```
 
 <a id="triggering_tests"></a>
+
 ### Triggering tests
 
 Tests can be triggered over multiple ways, using `openqa-clone-job`,
@@ -1267,6 +1262,7 @@ settings on a job must be supplied in the API request. The "openQA client" has
 examples for this.
 
 <a id="further_examples_for_advanced_dependency_handling"></a>
+
 ##### Further examples for advanced dependency handling
 
 It is possible to spawn a single set of jobs using just one API call, e.g.:
@@ -1289,6 +1285,7 @@ To use colons within a settings key, just add a trailing `:`, e.g.:
     openqa-cli api -X POST jobs TEST=test KEY:WITH:COLONS:=example
 
 <a id="spawning_multiple_jobs_based_on_templates_isos_post"></a>
+
 #### Spawning multiple jobs based on templates - isos post
 
 The most common way of spawning jobs on production instances is using the
@@ -1384,6 +1381,7 @@ This is recommended on big instances but means that the results (and
 possible errors) need to be polled via `openqa-cli api isos/$scheduled_product_id`.
 
 <a id="statistical_investigation"></a>
+
 ##### Statistical investigation
 
 In case issues appear sporadically and are therefore hard to reproduce it can
@@ -1540,13 +1538,7 @@ for use by a child job which needs to inherit those changes.
 You can also use special suffixes to the basic parameter forms to access some special handling for
 assets.
 
-
-
-
-
 The following suffixes exist:
-
-
 
 \_URL
 Before starting these jobs, try to download these assets into the relevant asset directory
@@ -1561,8 +1553,6 @@ Specify a compressed asset to be downloaded that will be uncompressed by openQA.
 For e.g. `ISO_1_DECOMPRESS_URL=http://host/foo2.iso.xz` will download the file `foo2.iso.xz`, uncompress it to `foo2.iso`, store it in `/var/lib/openqa/share/factory/iso` and set
 `ISO_1=foo2.iso`. Again, you can also set `ISO_1` to change the name the file will be downloaded
 and uncompressed as.
-
-
 
 ### Specifying assets created by a job
 
@@ -1746,6 +1736,7 @@ as there is enough headroom on the relevant file systems.
 > specifically are still experimental.
 
 <a id="asset_cleanup"></a>
+
 ### Cleanup strategy for assets
 
 To find out whether an asset should be removed, openQA determines by which
@@ -1865,8 +1856,8 @@ The message topic follows the format `SCOPE.APPLICATION.OBJECT.ACTION`, for exam
 
 Here are the events triggered and published by openQA:
 
-1.  `openqa.job.create` when a job is created 2.  `openqa.job.delete` when a job is deleted 3.  `openqa.job.cancel` when a job is cancelled 4.  `openqa.job.restart` when a job is restarted or duplicated 5.  `openqa.job.update_result` when a job result is updated 6.  `openqa.job.done` when a job finishes Job event bodies include the job settings (e.g. `BUILD`, `TEST`, `ARCH`,
-`MACHINE`, `FLAVOR`, asset fields like `ISO` or `HDD_1`) plus `id`, `group_id`, and `remaining` (number of pending jobs for the same build). Finished jobs additionally include `result`, `reason`, `newbuild`, `failedmodules`, `bugref`, and `bugurl` (only present when a bug reference exists). Example of a `*.openqa.job.done` message body (at the time of writing):
+1.  `openqa.job.create` when a job is created 2. `openqa.job.delete` when a job is deleted 3. `openqa.job.cancel` when a job is cancelled 4. `openqa.job.restart` when a job is restarted or duplicated 5. `openqa.job.update_result` when a job result is updated 6. `openqa.job.done` when a job finishes Job event bodies include the job settings (e.g. `BUILD`, `TEST`, `ARCH`,
+    `MACHINE`, `FLAVOR`, asset fields like `ISO` or `HDD_1`) plus `id`, `group_id`, and `remaining` (number of pending jobs for the same build). Finished jobs additionally include `result`, `reason`, `newbuild`, `failedmodules`, `bugref`, and `bugurl` (only present when a bug reference exists). Example of a `*.openqa.job.done` message body (at the time of writing):
 
 ```json
 {

--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -1,4 +1,5 @@
 <a id="writingtests"></a>
+
 # Writing Tests
 
 ## Introduction
@@ -490,6 +491,7 @@ Variables are accessible via the **get_var** and **check_var** functions.
 ## Advanced test features
 
 <a id="changing_timeouts"></a>
+
 ### Changing timeouts
 
 By default, tests are aborted after two hours by the worker. To change this
@@ -502,6 +504,7 @@ within the worker settings on slow worker hosts. It has no influence on the
 video setting.
 
 ### Enabling UEFI with QEMU
+
 Use `UEFI=1` to enable UEFI with the QEMU backend. If your image does not boot
 due to SecureBoot, you can specify the certificate you image is signed with via
 e.g. `UEFI_PFLASH_CERTS=custom.crt` (and use e.g. `ASSET_1=custom.crt` to track
@@ -580,9 +583,10 @@ the corresponding [asset variables](UsersGuide.md#asset_handling).
 
 In addition to that, the following variables can be found in the file
 `vars.json` when Git is used:
+
 - `TEST_GIT_HASH`: The specific version of the tests that were executed.
 - `NEEDLES_GIT_HASH`: The specific version of the needles that were used during
-the test run.
+  the test run.
 
 This file is upload when a test run has concluded and can be found under the
 "Logs & Assets" tab.
@@ -658,6 +662,7 @@ Sometimes issues are sporadic and therefore hard to reproduce. The section about
 might be helpful in this case.
 
 <a id="assigning_jobs_to_workers"></a>
+
 ### Assigning jobs to workers
 
 By default, any worker can get any job with the matching architecture.
@@ -731,8 +736,9 @@ container by setting `OS_AUTOINST_GIT_REPO` to a Git repository URL.
 openQA will construct a Podman command to clone, build, and execute
 `os-autoinst` from that repository.
 The following optional test variables are supported:
-* `OS_AUTOINST_GIT_BRANCH`: The branch to clone (defaults to `master`).
-* `OS_AUTOINST_CONTAINER_IMAGE`: A custom container image to use (defaults to
+
+- `OS_AUTOINST_GIT_BRANCH`: The branch to clone (defaults to `master`).
+- `OS_AUTOINST_CONTAINER_IMAGE`: A custom container image to use (defaults to
   `registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest`).
   `OS_AUTOINST_CONTAINER_IMAGE` requires `OS_AUTOINST_GIT_REPO` to be set.
   For openSUSE test-distribution testing, you can use
@@ -745,15 +751,16 @@ starts as a clean environment. Consequently, default local worker test
 directories (such as `/var/lib/openqa/share/tests/opensuse`) are not mounted.
 To ensure the container can find and execute your test suite, you must
 configure the following:
-* `CASEDIR`: Set this to the public Git repository of your test distribution
+
+- `CASEDIR`: Set this to the public Git repository of your test distribution
   (e.g. `https://github.com/os-autoinst/os-autoinst-distri-opensuse.git`) so
   the container can clone and locate the test scripts.
-* `NEEDLES_DIR`: Since needles are typically managed in a separate repository,
+- `NEEDLES_DIR`: Since needles are typically managed in a separate repository,
   you must point this to the corresponding needles Git repository (e.g.
   `https://github.com/os-autoinst/os-autoinst-needles-opensuse.git`) so the
   container can clone and initialize the required needles.
 
-*Note*: Running `os-autoinst` in a rootless container requires that the
+_Note_: Running `os-autoinst` in a rootless container requires that the
 `_openqa-worker` user has subuid/subgid ranges assigned in `/etc/subuid`
 and `/etc/subgid`. If they are missing, you can configure them by running:
 `usermod --add-subuids 100000-165535 --add-subgids 100000-165535 _openqa-worker`.
@@ -786,6 +793,7 @@ causing incomplete jobs.
 can be used to apply more elaborate issue detection and retriggering of tests.
 
 <a id="job_dependencies"></a>
+
 ### Job dependencies
 
 There are different dependency **types**, most importantly _chained_ and
@@ -892,6 +900,7 @@ of scheduling as well as in the worker configuration file `workers.ini`.
 > we explore ways to make it more flexible.
 
 <a id="inter_machine_dependencies"></a>
+
 #### Inter-machine dependencies
 
 Those dependencies make it possible to create job dependencies between tests
@@ -2037,6 +2046,7 @@ flag as the behaviour is implied). In the latter mode every test module is also
 considered `fatal`. This means the job is aborted after the first failed test module (unless subsequent modules are marked with `always_run`).
 
 <a id="snapshots-for-each-module"></a>
+
 #### Enable snapshots for each module
 
 - Run the worker with `--no-cleanup` parameter. This will preserve the hard
@@ -2198,6 +2208,7 @@ downloaded once. New versions must be supplied as new, unambiguous download
 target file names.
 
 <a id="triggering_tests_based_on_an_any_remote_git_refspec_or_open_github_pull_request"></a>
+
 ### Triggering tests based on an any remote Git refspec or open GitHub pull request
 
 openQA also supports to trigger tests using test code from a pull request or

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Testing Framework",
   "scripts": {
-    "lint": "eslint \"assets/javascripts/**/*.js\" && stylelint \"assets/stylesheets/**/*.{scss,css}\" \"docs/*.css\"",
-    "fix": "eslint --fix \"assets/javascripts/**/*.js\" && stylelint --fix \"assets/stylesheets/**/*.{scss,css}\" \"docs/*.css\""
+    "lint": "eslint \"assets/javascripts/**/*.js\" && stylelint \"assets/stylesheets/**/*.{scss,css}\" \"docs/*.css\" && prettier --check \"docs/**/*.md\"",
+    "fix": "eslint --fix \"assets/javascripts/**/*.js\" && stylelint --fix \"assets/stylesheets/**/*.{scss,css}\" \"docs/*.css\" && prettier --write \"docs/**/*.md\""
   },
   "license": "GPL-2.0",
   "bugs": {


### PR DESCRIPTION
Motivation:
Enforce consistent markdown formatting across all documentation files and
prevent future whitespace or formatting style drift in CI.

Design Choices:
Added Prettier checks and writes to the npm "lint" and "fix" scripts in
package.json.

Benefits:
Automates documentation style checks, ensuring high repository quality and
preventing noisy formatting diffs on future documentation edits.