### PR TITLE
chore: add python3-typer dependency for Markdown Python checker

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -226,3 +226,4 @@ style_check_requires:
   shfmt:
   python3-gitlint:
   python3-ruff:
+  python3-typer:

--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -95,7 +95,7 @@
 %define qemu qemu
 %endif
 # The following line is generated from dependencies.yaml
-%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) >= 1.156.0 perl(Perl::Critic::Community) perl(Pod::Markdown) perl(Test::Perl::Critic) python3-gitlint python3-ruff python3-yamllint shfmt
+%define style_check_requires ShellCheck perl(Code::TidyAll) perl(Perl::Critic) >= 1.156.0 perl(Perl::Critic::Community) perl(Pod::Markdown) perl(Test::Perl::Critic) python3-gitlint python3-ruff python3-typer python3-yamllint shfmt
 # The following line is generated from dependencies.yaml
 %define cover_requires perl(Devel::Cover) perl(Devel::Cover::Report::Codecovbash)
 # The following line is generated from dependencies.yaml


### PR DESCRIPTION
Related issue: https://progress.opensuse.org/issues/205728