### PR TITLE
feat: allow disabling stale job duplication

### DIFF
--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -90,6 +90,10 @@
 ## and its currently assigned jobs are taken care of by the stale job detection
 #worker_timeout = 1800
 
+## Whether jobs made incomplete because their worker became stale should be
+## automatically duplicated
+#auto_duplicate_stale_jobs = 1
+
 ## Timeout for the git command in "job investigation"
 #job_investigate_git_timeout = 20
 

--- a/lib/OpenQA/Scheduler/Model/Jobs.pm
+++ b/lib/OpenQA/Scheduler/Model/Jobs.pm
@@ -616,7 +616,9 @@ sub incomplete_and_duplicate_stale_jobs ($self) {
                         result => OpenQA::Jobs::Constants::INCOMPLETE,
                         reason => "abandoned: associated $worker_info has not sent any status updates for too long",
                     );
-                    my $res = $job->auto_duplicate;
+                    my $res;
+                    $res = $job->auto_duplicate
+                      if OpenQA::App->singleton->config->{global}->{auto_duplicate_stale_jobs};
                     if (ref $res) {
                         log_warning(sprintf 'Dead job %d aborted and duplicated %d', $job->id, $res->id);
                     }

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -140,6 +140,7 @@ sub default_config () {
             job_investigate_git_log_limit => 200,
             job_investigate_git_timeout => 20,
             worker_timeout => DEFAULT_WORKER_TIMEOUT,
+            auto_duplicate_stale_jobs => 1,
             search_results_limit => 50000,
             auto_clone_regex =>
 '^(cache failure: |terminated prematurely: |api failure: Failed to register .* 503|backend died: .*VNC.*(timeout|timed out|refused)|QEMU terminated: Failed to allocate KVM HPT of order 25.* Cannot allocate memory)',

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -48,7 +48,7 @@ subtest 'worker with job and not updated in last 120s is considered dead' => sub
     qr/Dead job 99961 aborted and duplicated 99982\n.*Dead job 99963 aborted as incomplete/, 'dead jobs logged';
 
     for my $job_id (99961, 99963) {
-        my $job = $jobs->find(99963);
+        my $job = $jobs->find($job_id);
         is $job->state, DONE, "running job $job_id is now done";
         is $job->result, INCOMPLETE, "running job $job_id has been marked as incomplete";
         isnt $job->clone_id, undef, "running job $job_id a clone";

--- a/t/20-stale-job-detection.t
+++ b/t/20-stale-job-detection.t
@@ -32,6 +32,7 @@ $app->setup;
 $app->log(undef);
 
 subtest 'worker with job and not updated in last 120s is considered dead' => sub {
+    is $app->config->{global}->{auto_duplicate_stale_jobs}, 1, 'stale jobs are duplicated by default';
     my $dtf = $schema->storage->datetime_parser;
     my $dt = DateTime->from_epoch(epoch => time(), time_zone => 'UTC');
     my $workers = $schema->resultset('Workers');
@@ -66,6 +67,30 @@ subtest 'worker with job and not updated in last 120s is considered dead' => sub
 
     is $app->minion->jobs({tasks => ['finalize_job_results']})->total,
       2, 'minion job to finalize incomplete jobs enqueued';
+};
+
+subtest 'stale job is not duplicated when automatic duplication is disabled' => sub {
+    local $app->config->{global}->{auto_duplicate_stale_jobs} = 0;
+    $schema->resultset('Workers')->find(1)->update({t_seen => undef});
+    my $job = $jobs->create(
+        {
+            assigned_worker_id => 1,
+            state => RUNNING,
+            result => NONE,
+            TEST => 'stale-without-duplication',
+        });
+    my $job_count = $jobs->count;
+
+    stderr_like { OpenQA::Scheduler::Model::Jobs->singleton->incomplete_and_duplicate_stale_jobs }
+    qr/Dead job @{[$job->id]} aborted as incomplete/, 'dead job logged without duplication';
+
+    $job->discard_changes;
+    is $job->state, DONE, 'running job is now done';
+    is $job->result, INCOMPLETE, 'running job has been marked as incomplete';
+    is $job->clone_id, undef, 'running job has not been cloned';
+    is $jobs->count, $job_count, 'no duplicate job has been created';
+    like $job->reason, qr/associated worker localhost:1 has not sent any status updates for too long/,
+      'job has the usual stale-worker reason';
 };
 
 subtest 'exception during stale job detection handled and logged' => sub {


### PR DESCRIPTION
Stale jobs were always duplicated after they were marked incomplete.
On certain setups, this is counterproductive. For example, KDE Linux and
GnomeOS both use a setup where workers are transiently bootstrapped in
CI runners that submit their own job, rather than maintaining persistent
runners that can have any job assigned to them. In these setups,
automatically restarting an incomplete job leaves it stuck in the
scheduling state forever.

Add a config option `auto_duplicate_stale_jobs` and enable by default
for backwards compatibility. When this is disabled, stale jobs are no
longer duplicated but still marked incomplete.

Also fixes what looks like an error in the test implementation, where the
stale job test iterated over two job IDs but always fetched job 9963, so 
both iterations were testing against the same job. Fix this to instead use 
the loop variable so to actually verify both stale jobs have the expected 
behavior.
