### PR TITLE
fix: Avoid errors due to inconsistent rate limiting configuration

### DIFF
--- a/etc/nginx/vhosts.d/openqa-endpoints.inc
+++ b/etc/nginx/vhosts.d/openqa-endpoints.inc
@@ -76,12 +76,13 @@ location ~ /tests/[0-9]+/(livelog|liveterminal)$ {
     proxy_buffering off;
 }
 
-location ~ ^/tests/[0-9]+/details_ajax$ {
-    # Apply rate limiting to details_ajax
-    limit_req zone=details_ajax_limit burst=10 nodelay;
-    limit_req_status 429;
-    add_header Retry-After 5 always;
-
-    # Backend settings are inherited from the server block
-    proxy_pass "http://webui";
-}
+# Optional rate limiting of certain routes, e.g.:
+#location ~ ^/tests/[0-9]+/details_ajax$ {
+#    # Apply rate limiting to details_ajax (needs zone definition, see `openqa.conf.template`)
+#    limit_req zone=details_ajax_limit burst=10 nodelay;
+#    limit_req_status 429;
+#    add_header Retry-After 5 always;
+#
+#    # Backend settings are inherited from the server block
+#    proxy_pass "http://webui";
+#}

--- a/etc/nginx/vhosts.d/openqa.conf.template
+++ b/etc/nginx/vhosts.d/openqa.conf.template
@@ -1,7 +1,7 @@
 include vhosts.d/openqa-upstreams.inc;
 
 # Define rate limiting zone for details_ajax endpoint (10MB zone allows ~160,000 IPs)
-limit_req_zone $binary_remote_addr zone=details_ajax_limit:10m rate=5r/s;
+#limit_req_zone $binary_remote_addr zone=details_ajax_limit:10m rate=5r/s;
 
 server {
     listen       80 default_server;


### PR DESCRIPTION
The rate limiting config in `openqa-endpoints.inc` relies on the zone definition from `openqa.conf.template`. This is just a template and not automatically present/configured. Hence the rate limiting should also not be configured automatically in `openqa-endpoints.inc`. An admin needs to enable both configurations manually and consistently.

This change prevents the following NGINX error when updating openQA packages but not manually taking over config changes from the template:

```
nginx: [emerg] zero size shared memory zone "details_ajax_limit"
```
Note that the zone definition cannot simply be moved to `openqa-endpoints.inc` because NGINX otherwise fails with:

```
nginx: [emerg] "limit_req_zone" directive is not allowed here in
/etc/nginx/vhosts.d/openqa-endpoints.inc:4
```