### PR TITLE
Improve documentation

### DIFF
--- a/docs/Branding.md
+++ b/docs/Branding.md
@@ -3,7 +3,7 @@
 
 You can alter the appearance of the openQA web UI to some extent through
 the "branding" mechanism. The `branding` configuration setting in the `global`
-section of [the web UI configuration](GettingStarted.md#configuration)
+section of [the web UI configuration](GettingStarted.md#webui-configuration)
 specifies the branding to use. It defaults to 'openSUSE', and openQA also
 includes the "plain" branding, which is - as its name suggests - plain and
 generic.

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -443,13 +443,15 @@ Setting up a PostgreSQL database for openQA takes the following steps:
 
 2.  Start the server: `systemctl start postgresql`
 
-3.  The next two steps need to be done as the user **postgres**: `sudo su - postgres`
+3.  The next two steps need to be done as the user **postgres**:
+    `sudo su - postgres`
 
 4.  Create user: `createuser your_username` where `your_username` must be
     the same as the UNIX user you start your local openQA instance with. For a
     development instance that is normally your regular user.
 
-5.  Create database: `createdb -O your_username openqa-local` where  `openqa-local` is the name you want to use for the database
+5.  Create database: `createdb -O your_username openqa-local` where
+    `openqa-local` is the name you want to use for the database
 
 6.  Configure openQA to use PostgreSQL as described in the section
     [Database](Installing.md#database) of the installation guide.
@@ -459,7 +461,8 @@ Setting up a PostgreSQL database for openQA takes the following steps:
 
 7.  openQA will default-initialize the new database on the next startup.
 
-The script `openqa-setup-db` can be used to conduct step 4 and 5. You must still specify the user and database name and run it as user `postgres`:
+The script `openqa-setup-db` can be used to conduct step 4 and 5. You must still
+specify the user and database name and run it as user `postgres`:
 
 ```sh
 sudo sudo -u postgres openqa-setup-db your_username openqa-local
@@ -497,7 +500,8 @@ e.g. `script/openqa-scheduler daemon`.
 
 You can also have a look at the systemd unit files. Although it likely makes
 not much sense to use them directly you can have a look at them to see how the
-different daemons are started. They are found in the `systemd` directory of the openQA repository. You can substitute `/usr/share/openqa/` with the path
+different daemons are started. They are found in the `systemd` directory of the
+openQA repository. You can substitute `/usr/share/openqa/` with the path
 of your openQA Git checkout.
 
 Of course you can ignore the user specified in these unit files and instead
@@ -509,7 +513,8 @@ is not the case by default so it makes sense to
 You do **not** need to setup an additional web server because the daemons
 already provide one. The port under which a service is available is logged on
 startup (the main web UI port is 9625 by default). Local workers need to be
-configured to connect to the main web UI port (add `HOST = [http://localhost:9526+](http://localhost:9526+) to `workers.ini`).
+configured to connect to the main web UI port (add
+`HOST = [http://localhost:9526+](http://localhost:9526+) to `workers.ini`).
 
 Note that you can also start services using a temporary database using the unit
 test database setup and data directory:

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -414,10 +414,13 @@ assets can need a big amount of disk space.
 ### Customize configuration directory
 
 When running openQA from a Git checkout it will find configuration files from
-that checkout under `etc/openqa` and not use any system provided config files under e.g. `/etc/openqa`.
+that checkout under `etc/openqa` and not use any system provided config files
+under e.g. `/etc/openqa`.
 
 It can be necessary during development to change the configuration.
-For example you have to edit `etc/openqa/database.ini` to use another database. It can also be useful to set the authentication method to `Fake` and increase the log level `etc/openqa/openqa.ini`.
+For example you have to edit `etc/openqa/database.ini` to use another database.
+It can also be useful to set the authentication method to `Fake` and increase
+the log level `etc/openqa/openqa.ini`.
 
 To avoid these changes getting in your Git workflow, copy them to a new
 directory and set the environment variable `OPENQA_CONFIG`:
@@ -428,7 +431,8 @@ export OPENQA_CONFIG=$PWD/etc/mine
 ```
 
 > **NOTE:**
-> `OPENQA_CONFIG` needs to point to the **directory** containing `openqa.ini`, > `database.ini`, `client.conf` and `workers.ini` (and **not** a specific file).
+> `OPENQA_CONFIG` needs to point to the **directory** containing `openqa.ini`,
+> `database.ini`, `client.conf` and `workers.ini` (and **not** a specific file).
 
 ### Setting up the PostgreSQL database
 

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -905,7 +905,7 @@ openQA comes with two authentication modules providing authentication methods:
 OpenID and Fake (see [User authentication](Installing.md#authentication)).
 
 All authentication modules reside in `lib/OpenQA/Auth` directory. During openQA start, the `[auth]/method` section of
-[the web UI configuration](GettingStarted.md#configuration) is read and
+[the web UI configuration](GettingStarted.md#webui-configuration) is read and
 according to its value (or default OpenID) openQA tries to require
 `OpenQA::WebAPI::Auth::$method`. If successful, the module for the given method
 is imported or openQA ends with error.

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -514,7 +514,7 @@ You do **not** need to setup an additional web server because the daemons
 already provide one. The port under which a service is available is logged on
 startup (the main web UI port is 9625 by default). Local workers need to be
 configured to connect to the main web UI port (add
-`HOST = [http://localhost:9526+](http://localhost:9526+) to `workers.ini`).
+`HOST = http://localhost:9526` to `workers.ini`).
 
 Note that you can also start services using a temporary database using the unit
 test database setup and data directory:

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -293,16 +293,17 @@ to use.
 The different components of openQA read their configuration from the following
 files:
 
-- `openqa.ini`, `openqa.ini.d/*.ini`: These files are the "web UI" config.
+- <a id="webui-configuration"></a>`openqa.ini`, `openqa.ini.d/*.ini`: These files are the "web UI" config.
   Services providing the web interface and related services such as the
   scheduler are configured via these files.
 
-- `database.ini`, `database.ini.d/*.ini`: These files are also used by services
+- <a id="database-configuration"></a>`database.ini`, `database.ini.d/*.ini`: These files are also used by services
   providing the web interface and related services such as the scheduler. It is
   used to configure how those services connect to the database.
 
-- `workers.ini`, `workers.ini.d/*.ini`: These files are used to configure the
-  openQA worker including its additional cache service.
+- <a id="worker-configuration"></a>`workers.ini`, `workers.ini.d/*.ini`: These
+  files are used to configure the openQA worker including its additional cache
+  service.
 
 - `client.conf`, `client.conf.d/*.conf`: These files contain API credentials and are used by the openQA worker and other tooling such as `openqa-cli` and  `openqa-clone-job` to authenticate with the web interface. One API key/secret
   can be configured per web UI host.
@@ -429,7 +430,7 @@ check out those repositories automatically and no manual setup is needed.
 
 Otherwise you will need to clone tests and needles manually. For this,
 clone a subdirectory under `/var/lib/openqa/tests` for each test distribution you need, e.g. `/var/lib/openqa/tests/opensuse` for openSUSE tests. The repositories will be kept up-to-date if `git_auto_update` is enabled in
-[the web UI configuration](GettingStarted.md#configuration) (which is the
+[the web UI configuration](GettingStarted.md#webui-configuration) (which is the
 default). The updating is triggered when new tests are scheduled. For a periodic
 update (to avoid getting too far behind) you can enable the systemd unit
 `openqa-enqueue-git-auto-update.timer`.

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -532,7 +532,7 @@ APACHE_SERVER_FLAGS="SSL"
 
 If you don't have a TLS/SSL certificate for your host you must turn HTTPS off.
 You can do that in
-[the web UI configuration](GettingStarted.md#configuration):
+[the web UI configuration](GettingStarted.md#webui-configuration):
 
 ``` ini
 [openid]
@@ -546,7 +546,7 @@ openQA requires PostgreSQL 14 or newer. By default, a database with name
 `openqa` and `geekotest` user as owner is used. An automatic setup of a freshly
 installed PostgreSQL instance can be done using [this script](https://github.com/os-autoinst/openQA/blob/master/script/setup-db).
 The database connection can be configured in
-[the database configuration file](GettingStarted.md#configuration).
+[the database configuration file](GettingStarted.md#database-configuration).
 (normally the `[production]` section is relevant). More info about the `dsn`
 value format can be found in the <https://metacpan.org/pod/DBD>::Pg#DBI-Class-Methods[DBD::Pg documentation].
 
@@ -572,7 +572,7 @@ openQA supports four different authentication methods: OpenID (default),
 OAuth2, Fake (for development) and None (no authentication).
 
 Use the `auth` section in
-[the web UI configuration](GettingStarted.md#configuration) to configure
+[the web UI configuration](GettingStarted.md#webui-configuration) to configure
 the method:
 
 ``` ini
@@ -600,7 +600,7 @@ reported when clocks are too far apart.
 
 By default openQA uses OpenID with opensuse.org as OpenID provider.
 OpenID method has its own `openid` section in
-[the web UI configuration](GettingStarted.md#configuration):
+[the web UI configuration](GettingStarted.md#webui-configuration):
 
 ``` ini
 [auth]
@@ -908,7 +908,7 @@ fetch the tests cases and possibly take a look at [Test Developer Guide](Writing
 The automated cleanup is enabled and configured by default. Cleanup tasks are
 scheduled via systemd timer units and run via `openqa-gru.service`. The configuration
 is done in
-[the web UI configuration file](GettingStarted.md#configuration) and
+[the web UI configuration file](GettingStarted.md#webui-configuration) and
 various places within the web UI. If you want to tweak the cleanup to your
 needs, have a look at the
 [Cleanup of assets, results and other data](UsersGuide.md#cleanup)
@@ -964,7 +964,7 @@ You can do so by setting your configuration in the repository
 ```
 
 To enable automatic pushing of the repo as well, you need to add the following
-to [the web UI configuration](GettingStarted.md#configuration):
+to [the web UI configuration](GettingStarted.md#webui-configuration):
 
 ``` ini
 [scm git]
@@ -1022,7 +1022,7 @@ example bugzilla), this job is automatically labeled as linked and treated as
 important.
 
 List of recognized referrers is space separated list configured in
-[the web UI configuration file](GettingStarted.md#configuration):
+[the web UI configuration file](GettingStarted.md#webui-configuration):
 
 ``` ini
 [global]
@@ -1092,7 +1092,7 @@ The running jobs heading in the web UI reflects the current dynamic limit when i
 
 Default behavior for all workers is to use the QEMU backend and connect to
 http://localhost. If you want to change some of those options, you can do so
-in [the worker configuration](GettingStarted.md#configuration). For
+in [the worker configuration](GettingStarted.md#worker-configuration). For
 example to point the workers to the FQDN of your host (needed if test cases need
 to access files of the host) use the following setting:
 
@@ -1110,8 +1110,8 @@ average over a period of 15 minutes exceeds the specified value, the worker will
 not accept new jobs. This can be controlled via the setting
 `CRITICAL_LOAD_AVG_THRESHOLD`. For this to be more effective,
 also check out the setting `LOCK_NAME`. Both settings can be found in the
-[the worker configuration](GettingStarted.md#configuration) where they are
-explained in greater detail.
+[the worker configuration](GettingStarted.md#worker-configuration) where they
+are explained in greater detail.
 
 ### Further systemd units for the worker
 
@@ -1209,7 +1209,7 @@ detailed instructions how to configure the AMQP server.
 To let openQA send messages to an AMQP message bus,
 first make sure that the `perl-Mojo-RabbitMQ-Client` RPM is installed.
 Then you will need to configure AMQP in
-[the web UI configuration file](GettingStarted.md#configuration):
+[the web UI configuration file](GettingStarted.md#webui-configuration):
 
 ``` ini
 # Enable the AMQP plugin
@@ -1239,7 +1239,7 @@ Requirements:
 
 - Shared storage from all instances must be properly mounted
 
-In [the worker configuration](GettingStarted.md#configuration), enter
+In [the worker configuration](GettingStarted.md#worker-configuration), enter
 space-separated instance hosts and optionally configure where the shared storage
 is mounted. Example:
 
@@ -1279,7 +1279,7 @@ remote instances.
 If your network is slow or you experience long time to load needles you might
 want to consider enabling caching on your remote workers. To enable caching,
 `CACHEDIRECTORY` must be set in
-[the worker configuration](GettingStarted.md#configuration). There are
+[the worker configuration](GettingStarted.md#worker-configuration). There are
 also further settings one can optionally configure. Example:
 
 ``` ini
@@ -1300,7 +1300,7 @@ openQA through the repositories, said directory will be created for you.
 The shown configuration causes workers to download the assets from the web UI
 and use them locally. The `TESTPOOLSERVER` setting causes also tests and needles to be downloaded via `rsync` from the specified location. You can find
 further examples in the comments in
-[the worker configuration](GettingStarted.md#configuration).
+[the worker configuration](GettingStarted.md#worker-configuration).
 
 It is suggested to have the cache and pool directories on the same filesystem
 to ensure assets used by tests are available as long as needed. This is
@@ -1350,7 +1350,7 @@ openqa-worker-cacheservice service) and share it with workers using
 some network filesystem (see [Configuring remote workers](Installing.md#configuring_remote_workers)
 section above).
 Such setups can use `SYNC_ASSETS_HOOK` in
-[the web UI configuration](GettingStarted.md#configuration) to ensure the
+[the web UI configuration](GettingStarted.md#webui-configuration) to ensure the
 cache is up to date before starting the job (or resuming test in developer
 mode). The setting takes a shell command that is executed just before
 evaluating assets. It is up to the system administrator to decide what it
@@ -1492,7 +1492,7 @@ workers are tracked under user whose API keys are workers using.
 Audit log is directly accessible from `Admin menu`.
 
 Auditing, by default enabled, can be disabled by global configuration option in
-[the web UI configuration file](GettingStarted.md#configuration):
+[the web UI configuration file](GettingStarted.md#webui-configuration):
 
 ``` ini
 [global]
@@ -1500,7 +1500,7 @@ audit_enabled = 0
 ```
 
 The `audit` section of
-[the web UI configuration](GettingStarted.md#configuration) allows to
+[the web UI configuration](GettingStarted.md#webui-configuration) allows to
 exclude some events from logging using a space separated blocklist:
 
 ``` ini
@@ -1509,7 +1509,7 @@ blocklist = job_grab job_done
 ```
 
 The `audit/storage_duration` section of
-[the web UI configuration](GettingStarted.md#configuration) allows to set
+[the web UI configuration](GettingStarted.md#webui-configuration) allows to set
 the retention policy for different audit event types:
 
 ``` ini
@@ -2030,7 +2030,7 @@ zypper -n in wireguard-tools
 systemctl enable --now wg-quick@openqa
 ```
 
-Then update [the worker configuration](GettingStarted.md#configuration)
+Then update [the worker configuration](GettingStarted.md#worker-configuration)
 on the workers like this:
 
 ``` ini

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -811,6 +811,11 @@ public cloud. The only requirement is access to the web UI host over
 HTTP/HTTPS. For running tests based on virtual machines KVM support is
 recommended.
 
+If you have a powerful machine you can run many worker services in parallel
+relying on automatic load-based throttling and configurable locking to avoid
+running into stability issues. Check out the [throttling section](#throttling)
+for details.
+
 The openQA worker is distributed as a separate package which be installed on
 multiple machines while still using only one web UI.
 
@@ -822,6 +827,10 @@ zypper in openQA-worker
 # Fedora
 dnf install openqa-worker
 ```
+
+Once you got workers running they should show up in the admin section of openQA
+in the workers section as 'idle'. When you get so far, you have your own
+instance of openQA up and running and all that is left is to set up some tests.
 
 ### Local LLM Server
 
@@ -1092,23 +1101,17 @@ to access files of the host) use the following setting:
 HOST = http://openqa.example.com
 ```
 
-The load of the system can affect test execution and cause failures due to
-delays of command execution and
+### Throttling
+
+The load of the system can affect test stability and causing VM boot problems
+and failures due to delays of command execution and
 [thrashing](https://en.wikipedia.org/wiki/Thrashing_(computer_science)). If the
-average over a period of 15 minutes exceeds the specified value the worker will
-not accept new jobs.
-
-workers.ini
-
-``` ini
-[global]
-# Set to 0 to disable.
-#CRITICAL_LOAD_AVG_THRESHOLD = 40
-```
-
-Once you got workers running they should show up in the admin section of openQA
-in the workers section as 'idle'. When you get so far, you have your own
-instance of openQA up and running and all that is left is to set up some tests.
+average over a period of 15 minutes exceeds the specified value, the worker will
+not accept new jobs. This can be controlled via the setting
+`CRITICAL_LOAD_AVG_THRESHOLD`. For this to be more effective,
+also check out the setting `LOCK_NAME`. Both settings can be found in the
+[the worker configuration](GettingStarted.md#configuration) where they are
+explained in greater detail.
 
 ### Further systemd units for the worker
 

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -1092,15 +1092,13 @@ to access files of the host) use the following setting:
 HOST = http://openqa.example.com
 ```
 
-The load of the system can affect test execution and cause failures due to delays of command execution and [thrashing](https://en.wikipedia.org/wiki/Thrashing_(computer_science)). If the average over a period of 15 minutes exceeds the specified value the worker will not accept new jobs.
-
-
-
-
+The load of the system can affect test execution and cause failures due to
+delays of command execution and
+[thrashing](https://en.wikipedia.org/wiki/Thrashing_(computer_science)). If the
+average over a period of 15 minutes exceeds the specified value the worker will
+not accept new jobs.
 
 workers.ini
-
-
 
 ``` ini
 [global]
@@ -1108,11 +1106,9 @@ workers.ini
 #CRITICAL_LOAD_AVG_THRESHOLD = 40
 ```
 
-
-
-Once you got workers running they should show up in the admin section of openQA in
-the workers section as 'idle'. When you get so far, you have your own instance
-of openQA up and running and all that is left is to set up some tests.
+Once you got workers running they should show up in the admin section of openQA
+in the workers section as 'idle'. When you get so far, you have your own
+instance of openQA up and running and all that is left is to set up some tests.
 
 ### Further systemd units for the worker
 

--- a/docs/Networking.md
+++ b/docs/Networking.md
@@ -180,7 +180,7 @@ Ensure to make gre_tunnel_preup.sh executable.
 ##### Configure openQA workers
 
 Allow worker instances to run multi-machine jobs by modifying
-[the worker configuration](GettingStarted.md#configuration):
+[the worker configuration](GettingStarted.md#webui-configuration):
 
 ```sh
 [global]
@@ -330,7 +330,7 @@ Bridge "br0"
 
 > **NOTE:** 
 > If the balance of the tap devices is wrong in
-> [the worker configuration](GettingStarted.md#configuration), the tag
+> [the worker configuration](GettingStarted.md#worker-configuration), the tag
 > cannot be assigned and the communication will be broken.
 
 To list the rules which are effectively configured in the underlying netfilter

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -769,7 +769,7 @@ Jenkins.
 > The lookup-depth is limited. The search for candidates will also stop
 > early if too many different kinds of failures were seen. Check out the
 > descriptions of the relevant settings in the `carry_over` section of
-> [the web UI configuration](GettingStarted.md#configuration) for details.
+> [the web UI configuration](GettingStarted.md#webui-configuration) for details.
 
 > **NOTE:**
 > For an approach to add bug references based on a search expression found
@@ -1551,7 +1551,7 @@ The following suffixes exist:
 \_URL
 Before starting these jobs, try to download these assets into the relevant asset directory
 of the openQA web-UI from trusted domains specified in
-[the web UI configuration file](GettingStarted.md#configuration).
+[the web UI configuration file](GettingStarted.md#webui-configuration).
 For example `ISO_1_URL=http://trusted.com/foo.iso` would, if `trusted.com` is set as a trusted domain, cause openQA to download the file `foo.iso` to
 `/var/lib/openqa/share/factory/iso` and set `ISO_1=foo.iso`. If you set both
 `ISO_1` and `ISO_1_URL`, the file pointed to by `ISO_1_URL` will be downloaded and renamed to the name set as `ISO_1`.
@@ -1616,7 +1616,7 @@ All cleanup jobs run within the Minion job queue, normally provided by
 `openqa-gru.service`. The dashboard for Minion jobs is accessible via the
 administrator menu in the web UI. Only one cleanup job can run at the same time
 unless `concurrent` is set to `1` in the `[cleanup]` settings of
-[the web UI configuration](GettingStarted.md#configuration). Many other
+[the web UI configuration](GettingStarted.md#webui-configuration). Many other
 cleanup-related settings can be found within the web UI configuration as well,
 e.g. the `[…_limits]` sections contain various tweaks and allow to change certain
 defaults. Check out the sub section
@@ -1670,7 +1670,7 @@ Further remarks:
   how to mark a job as important on job group level. Jobs can also be marked as
   important by adding a "link label" (e.g.
   `label:linked Job mentioned on https://…`) in a job comment. - New groups use the limits configured in the `[default_group_limits]`
-  section of [the web UI configuration](GettingStarted.md#configuration).
+  section of [the web UI configuration](GettingStarted.md#webui-configuration).
   Jobs outside of any group use the limits configured in the `[no_group_limits]`
   section of the web UI configuration.
 

--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -2337,7 +2337,7 @@ GitHub.
     needs at least the scope "repo".
 
 2.  Add the previously created token to the
-    [web UI configuration file](GettingStarted.md#configuration):
+    [web UI configuration file](GettingStarted.md#webui-configuration):
 
 [secrets]
 github_token = \$token

--- a/etc/openqa/workers.ini
+++ b/etc/openqa/workers.ini
@@ -98,6 +98,8 @@
 # scheduled jobs at the same time. More worker instances would only start
 # further jobs after 30 seconds - unless the load exceeds the configured
 # threshold then.)
+# The setting can also help with boot problems due to starting too many VMs at
+# the same time (see https://progress.opensuse.org/issues/203487).
 # Workers that could not acquire a lock will temporarily show as unavailable
 # with an according note. This prevents the scheduler from immediately assigning
 # a job on these slots again (increasing the chances it will spread future


### PR DESCRIPTION
I just wanted to add documentation for `LOCK_NAME` needed to change existing documentation a little bit and then found many issues (still from the Markdown conversion) that I fixed as well. Check out the individual commit messages for details.

Related ticket: https://progress.opensuse.org/issues/203487