### PR TITLE
feat: Add OpenQA::ProhibitEscapedDelimiters PerlCritic policy

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -47,6 +47,9 @@ severity = 5
 [OpenQA::RedundantStrictWarning]
 equivalent_modules = Test::Most
 
+# -- Prohibit escaped delimiters that can be avoided with q{} or qq{}
+[-OpenQA::ProhibitEscapedDelimiters]
+
 [ValuesAndExpressions::RequireNumberSeparators]
 min_value = 1000000
 

--- a/external/os-autoinst-common/.github/workflows/base-commit-message-checker.yml
+++ b/external/os-autoinst-common/.github/workflows/base-commit-message-checker.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
       - name: Install gitlint

--- a/external/os-autoinst-common/.github/workflows/perl-author-tests.yml
+++ b/external/os-autoinst-common/.github/workflows/perl-author-tests.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: |
           git config --system --add safe.directory "$GITHUB_WORKSPACE"
           make test-author

--- a/external/os-autoinst-common/.github/workflows/perl-lint-checks.yml
+++ b/external/os-autoinst-common/.github/workflows/perl-lint-checks.yml
@@ -12,5 +12,5 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: GITHUB_ACTIONS=1 make test-tidy

--- a/external/os-autoinst-common/.github/workflows/test.yaml
+++ b/external/os-autoinst-common/.github/workflows/test.yaml
@@ -11,5 +11,5 @@ jobs:
     container:
       image: registry.opensuse.org/devel/openqa/containers/os-autoinst_dev
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: make test-t

--- a/external/os-autoinst-common/.github/workflows/yamllint.yml
+++ b/external/os-autoinst-common/.github/workflows/yamllint.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     name: "YAML-lint"
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: docker://registry.opensuse.org/home/okurz/container/containers/tumbleweed:yamllint
         with:
           entrypoint: make

--- a/external/os-autoinst-common/.gitrepo
+++ b/external/os-autoinst-common/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = git@github.com:os-autoinst/os-autoinst-common.git
 	branch = master
-	commit = 7e1f983c44858679f93e2046ed1aa82171bd7f4b
-	parent = c33cde59ddc4f20d6bf4b948375303b749073f4a
+	commit = 35e32c71fd6c7616457b84e6def84db489853b71
+	parent = 4deef227bb8985c5bab4e5d9e30c3c262f15d068
 	method = merge
 	cmdver = 0.4.6

--- a/external/os-autoinst-common/.perlcriticrc
+++ b/external/os-autoinst-common/.perlcriticrc
@@ -43,3 +43,7 @@ severity = 5
 # -- Superfluous use strict/warning.
 [OpenQA::RedundantStrictWarning]
 equivalent_modules = Test::Most
+
+# -- Prohibit escaped delimiters that can be avoided with q{} or qq{}
+[OpenQA::ProhibitEscapedDelimiters]
+severity = 3

--- a/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/ProhibitEscapedDelimiters.pm
+++ b/external/os-autoinst-common/lib/perlcritic/Perl/Critic/Policy/OpenQA/ProhibitEscapedDelimiters.pm
@@ -1,0 +1,27 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package Perl::Critic::Policy::OpenQA::ProhibitEscapedDelimiters;
+
+use strict;
+use warnings;
+use experimental 'signatures';
+use base 'Perl::Critic::Policy';
+
+use Perl::Critic::Utils qw( :severities :classification :ppi );
+
+our $VERSION = '0.0.1';
+
+sub default_severity { return $SEVERITY_MEDIUM }
+sub default_themes { return qw(openqa) }
+sub applies_to { return qw(PPI::Token::Quote::Double) }
+
+sub violates ($self, $elem, $document) {
+    my $content = $elem->content;
+    return () unless $content =~ m/\\"/ || $content =~ m/\\\$/ || $content =~ m/\\@/;
+    my $desc = 'Double-quoted string contains unnecessary backslash-escaped characters';
+    my $expl = 'Use the q{} or qq{} operators instead of escaping characters to improve readability';
+    return $self->violation($desc, $expl, $elem);
+}
+
+1;

--- a/external/os-autoinst-common/t/OpenQA/ProhibitEscapedDelimiters.run
+++ b/external/os-autoinst-common/t/OpenQA/ProhibitEscapedDelimiters.run
@@ -1,0 +1,18 @@
+## name Passing
+## failures 0
+## cut
+
+my $s1 = 'hello';
+my $s2 = "hello";
+my $s3 = q{hello "world" $var @arr};
+my $s4 = qq{hello "world" $var @arr};
+my $s5 = "hello world";
+my $s6 = "hello \\ world";
+
+## name Failing
+## failures 3
+## cut
+
+my $f1 = "hello \" world";
+my $f2 = "hello \$world";
+my $f3 = "hello \@array";

--- a/external/os-autoinst-common/tools/update-deps
+++ b/external/os-autoinst-common/tools/update-deps
@@ -1,5 +1,5 @@
 #!/usr/bin/env perl
-# Copyright SUSE LLC
+# Copyright 2020 SUSE LLC
 # SPDX-License-Identifier: MIT
 use strict;
 use warnings;


### PR DESCRIPTION
Motivation:
Ensure there is an automatic style check policy for cases where q{} or qq{} can
be used instead of backslash-escaping characters in double-quoted strings.

Design Choices:
Implemented the custom PerlCritic policy inline within vendor dependency copy.
Disabled it by default in openQA's .perlcriticrc to avoid failing on existing
violations, allowing it to be enabled after future codebase cleanup.

Benefits:
The policy is available to use and ready to be turned on globally in openQA as
soon as existing legacy cases are refactored.

After:
* https://github.com/os-autoinst/os-autoinst-common/pull/100