### PR TITLE
refactor(ui): remove jQuery from main application scripts

### DIFF
--- a/assets/javascripts/comments.js
+++ b/assets/javascripts/comments.js
@@ -48,18 +48,7 @@ function deleteComment(deleteButton) {
     return;
   }
   fetchWithCSRF(deleteButton.dataset.deleteUrl, {method: 'DELETE'})
-    .then(response => {
-      return response
-        .json()
-        .then(json => {
-          // Attach the parsed JSON to the response object for further use
-          return {response, json};
-        })
-        .catch(() => {
-          // If parsing fails, handle it as a non-JSON response
-          throw `Server returned ${response.status}: ${response.statusText}`;
-        });
-    })
+    .then(handleJSONResponseOrThrow)
     .then(({response, json}) => {
       if (!response.ok) throw `Server returned ${response.status}: ${response.statusText}\n${json.error || ''}`;
       if (json.error) throw json.error;
@@ -85,18 +74,7 @@ function updateComment(form) {
   markdownElement.style.display = '';
   markdownElement.innerHTML = '<em>Loading…</em>';
   fetchWithCSRF(url, {method: 'PUT', body: new FormData(form)})
-    .then(response => {
-      return response
-        .json()
-        .then(json => {
-          // Attach the parsed JSON to the response object for further use
-          return {response, json};
-        })
-        .catch(() => {
-          // If parsing fails, handle it as a non-JSON response
-          throw `Server returned ${response.status}: ${response.statusText}`;
-        });
-    })
+    .then(handleJSONResponseOrThrow)
     .then(({response, json}) => {
       if (!response.ok || json.error)
         throw `Server returned ${response.status}: ${response.statusText}\n${json.error || ''}`;
@@ -131,18 +109,7 @@ function addComment(form, insertAtBottom) {
   }
   const url = form.action;
   fetch(url, {method: 'POST', body: new FormData(form)})
-    .then(response => {
-      return response
-        .json()
-        .then(json => {
-          // Attach the parsed JSON to the response object for further use
-          return {response, json};
-        })
-        .catch(() => {
-          // If parsing fails, handle it as a non-JSON response
-          throw `Server returned ${response.status}: ${response.statusText}`;
-        });
-    })
+    .then(handleJSONResponseOrThrow)
     .then(({response, json}) => {
       if (!response.ok || json.error)
         throw `Server returned ${response.status}: ${response.statusText}\n${json.error || ''}`;

--- a/assets/javascripts/filter_form.js
+++ b/assets/javascripts/filter_form.js
@@ -5,7 +5,11 @@ function setupFilterForm(options) {
     cardHeader.addEventListener('click', function () {
       const cardBody = document.querySelector('#filter-panel .card-body');
       if (cardBody) {
-        $(cardBody).toggle(200);
+        if (cardBody.style.display === 'none' || cardBody.style.display === '') {
+          cardBody.style.display = 'block';
+        } else {
+          cardBody.style.display = 'none';
+        }
         if (document.getElementById('filter-panel').classList.contains('filter-panel-bottom')) {
           window.scrollTo({top: document.documentElement.scrollHeight, behavior: 'smooth'});
         }
@@ -66,7 +70,9 @@ function setupFilterForm(options) {
         });
       }
 
-      const newQuery = new URLSearchParams(Array.from(params).filter(([, value]) => value !== '')).toString();
+      const newQuery = new URLSearchParams(Array.from(params).filter(([, value]) => value !== ''))
+        .toString()
+        .replace(/\+/g, '%20');
 
       if (newQuery !== currentQuery) {
         // show progress indication
@@ -97,7 +103,12 @@ function setupFilterForm(options) {
       filterForm.querySelectorAll('input[hidden]').forEach(input => {
         input.remove();
       });
-      $(filterForm).find('select').val([]).trigger('chosen:updated');
+      filterForm.querySelectorAll('select').forEach(select => {
+        Array.from(select.options).forEach(opt => (opt.selected = false));
+        if (typeof jQuery !== 'undefined' && typeof jQuery.fn.chosen === 'function') {
+          $(select).trigger('chosen:updated');
+        }
+      });
       document.querySelector('#filter-panel .card-header span').textContent =
         'no filter present, click to toggle filter form';
     });

--- a/assets/javascripts/index.js
+++ b/assets/javascripts/index.js
@@ -6,50 +6,56 @@ function setupIndexPage() {
   setupFilterForm({preventLoadingIndication: true});
 
   // set default values of filter form
-  const filterForm = $('#filter-form');
-  const filterFullScreenCheckBox = $('#filter-fullscreen');
-  const showTagsCheckBox = $('#filter-show-tags');
-  const onlyTaggedCheckBox = $('#filter-only-tagged');
-  const defaultExpanedCheckBox = $('#filter-default-expanded');
-  filterFullScreenCheckBox.prop('checked', false);
-  showTagsCheckBox.prop('checked', false);
-  onlyTaggedCheckBox.prop('checked', false);
-  onlyTaggedCheckBox.on('change', function () {
-    const checked = onlyTaggedCheckBox.prop('checked');
-    if (checked) {
-      showTagsCheckBox.prop('checked', true);
-    }
-    showTagsCheckBox.prop('disabled', checked);
-  });
-  defaultExpanedCheckBox.prop('checked', false);
+  const filterForm = document.getElementById('filter-form');
+  const filterFullScreenCheckBox = document.getElementById('filter-fullscreen');
+  const showTagsCheckBox = document.getElementById('filter-show-tags');
+  const onlyTaggedCheckBox = document.getElementById('filter-only-tagged');
+  const defaultExpanedCheckBox = document.getElementById('filter-default-expanded');
+  if (filterFullScreenCheckBox) filterFullScreenCheckBox.checked = false;
+  if (showTagsCheckBox) showTagsCheckBox.checked = false;
+  if (onlyTaggedCheckBox) {
+    onlyTaggedCheckBox.checked = false;
+    onlyTaggedCheckBox.addEventListener('change', function () {
+      const checked = onlyTaggedCheckBox.checked;
+      if (checked) {
+        showTagsCheckBox.checked = true;
+      }
+      showTagsCheckBox.disabled = checked;
+    });
+  }
+  if (defaultExpanedCheckBox) defaultExpanedCheckBox.checked = false;
 
   // apply query parameters to filter form
   const handleFilterParams = function (key, val) {
     if (key === 'show_tags') {
-      showTagsCheckBox.prop('checked', val !== '0');
+      showTagsCheckBox.checked = val !== '0';
       return 'show tags';
     } else if (key === 'only_tagged') {
-      onlyTaggedCheckBox.prop('checked', val !== '0');
-      onlyTaggedCheckBox.trigger('change');
+      onlyTaggedCheckBox.checked = val !== '0';
+      onlyTaggedCheckBox.dispatchEvent(new Event('change'));
       return 'only tagged';
     } else if (key === 'group') {
-      $('#filter-group').prop('value', val);
+      const el = document.getElementById('filter-group');
+      if (el) el.value = val;
       return "group '" + val + "'";
     } else if (key === 'limit_builds') {
-      $('#filter-limit-builds').prop('value', val);
+      const el = document.getElementById('filter-limit-builds');
+      if (el) el.value = val;
       return val + ' builds per group';
     } else if (key === 'time_limit_days') {
-      $('#filter-time-limit-days').prop('value', val);
+      const el = document.getElementById('filter-time-limit-days');
+      if (el) el.value = val;
       return val + ' days old or newer';
     } else if (key === 'fullscreen') {
-      filterFullScreenCheckBox.prop('checked', val !== '0');
+      filterFullScreenCheckBox.checked = val !== '0';
       return 'fullscreen';
     } else if (key === 'interval') {
       window.autoreload = val !== 0 ? val : undefined;
-      $('#filter-autorefresh-interval').prop('value', val);
+      const el = document.getElementById('filter-autorefresh-interval');
+      if (el) el.value = val;
       return 'auto refresh';
     } else if (key === 'default_expanded') {
-      defaultExpanedCheckBox.prop('checked', val !== '0');
+      defaultExpanedCheckBox.checked = val !== '0';
       return 'expanded';
     }
   };
@@ -58,46 +64,49 @@ function setupIndexPage() {
   loadBuildResults();
 
   // prevent page reload when submitting filter form (when we load build results via AJAX anyways)
-  filterForm.submit(function (event) {
-    if (!window.updatingBuildResults) {
-      const queryParams = filterForm.serialize();
-      loadBuildResults(queryParams);
-      history.replaceState({}, document.title, window.location.pathname + '?' + queryParams);
-      parseFilterArguments(handleFilterParams);
-    }
-    toggleFullscreenMode($('#filter-fullscreen').is(':checked'));
-    autoRefreshRestart();
-    event.preventDefault();
-  });
+  if (filterForm) {
+    filterForm.addEventListener('submit', function (event) {
+      if (!window.updatingBuildResults) {
+        const queryParams = new URLSearchParams(new FormData(filterForm)).toString().replace(/\+/g, '%20');
+        loadBuildResults(queryParams);
+        history.replaceState({}, document.title, window.location.pathname + '?' + queryParams);
+        parseFilterArguments(handleFilterParams);
+      }
+      toggleFullscreenMode(document.getElementById('filter-fullscreen').checked);
+      autoRefreshRestart();
+      event.preventDefault();
+    });
+  }
 
-  toggleFullscreenMode(filterFullScreenCheckBox.is(':checked'));
+  toggleFullscreenMode(filterFullScreenCheckBox && filterFullScreenCheckBox.checked);
   autoRefreshRestart();
 }
 
 function loadBuildResults(queryParams) {
-  const buildResultsElement = $('#build-results');
-  const loadingElement = $('#build-results-loading');
-  const filterForm = $('#filter-form');
-  const filterFormApplyButton = $('#filter-apply-button');
+  const buildResultsElement = document.getElementById('build-results');
+  const loadingElement = document.getElementById('build-results-loading');
+  const filterForm = document.getElementById('filter-form');
+  const filterFormApplyButton = document.getElementById('filter-apply-button');
 
   if (!window.autoreload) {
-    loadingElement.show();
-    buildResultsElement.html('');
+    if (loadingElement) loadingElement.style.display = 'block';
+    if (buildResultsElement) buildResultsElement.innerHTML = '';
   }
-  filterFormApplyButton.prop('disabled', true);
+  if (filterFormApplyButton) filterFormApplyButton.disabled = true;
   window.updatingBuildResults = true;
 
   const showBuildResults = function (buildResults) {
-    loadingElement.hide();
-    buildResultsElement.html(buildResults);
+    if (loadingElement) loadingElement.style.display = 'none';
+    if (buildResultsElement) buildResultsElement.innerHTML = buildResults;
     updateTimeago();
     alignBuildLabels();
-    filterFormApplyButton.prop('disabled', false);
+    if (filterFormApplyButton) filterFormApplyButton.disabled = false;
     window.updatingBuildResults = false;
   };
 
   // query build results via AJAX using parameters from filter form
-  const url = new URL(buildResultsElement.data('build-results-url'), window.location.href);
+  if (!buildResultsElement) return;
+  const url = new URL(buildResultsElement.dataset.buildResultsUrl, window.location.href);
   url.search = queryParams ? queryParams : window.location.search.substr(1);
   fetch(url)
     .then(response => {

--- a/assets/javascripts/obs_rsync.js
+++ b/assets/javascripts/obs_rsync.js
@@ -36,18 +36,7 @@ function postAndRedrawElement(btn, id, delay = 0, confirmMessage = '') {
     return;
   }
   fetchWithCSRF(btn.dataset.posturl, {method: 'POST'})
-    .then(response => {
-      return response
-        .json()
-        .then(json => {
-          // Attach the parsed JSON to the response object for further use
-          return {response, json};
-        })
-        .catch(() => {
-          // If parsing fails, handle it as a non-JSON response
-          throw `Server returned ${response.status}: ${response.statusText}`;
-        });
-    })
+    .then(handleJSONResponseOrThrow)
     .then(({response, json}) => {
       if (!response.ok || json.error)
         throw `Server returned ${response.status}: ${response.statusText}\n${json.error || ''}`;
@@ -67,18 +56,7 @@ function postAndRedrawElement(btn, id, delay = 0, confirmMessage = '') {
 
 function postAndRedirect(btn, redir = '') {
   fetchWithCSRF(btn.dataset.posturl, {method: 'POST'})
-    .then(response => {
-      return response
-        .json()
-        .then(json => {
-          // Attach the parsed JSON to the response object for further use
-          return {response, json};
-        })
-        .catch(() => {
-          // If parsing fails, handle it as a non-JSON response
-          throw `Server returned ${response.status}: ${response.statusText}`;
-        });
-    })
+    .then(handleJSONResponseOrThrow)
     .then(({response, json}) => {
       if (!response.ok || json.error)
         throw `Server returned ${response.status}: ${response.statusText}\n${json.error || ''}`;

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -36,6 +36,19 @@ function fetchWithCSRF(resource, options) {
   return window.fetch(resource, options);
 }
 
+function handleJSONResponseOrThrow(response) {
+  return response
+    .json()
+    .then(json => {
+      // Attach the parsed JSON to the response object for further use
+      return {response, json};
+    })
+    .catch(() => {
+      // If parsing fails, handle it as a non-JSON response
+      throw `Server returned ${response.status}: ${response.statusText}`;
+    });
+}
+
 function makeFlashElement(text) {
   if (typeof text === 'string') {
     const span = document.createElement('span');

--- a/assets/javascripts/overview.js
+++ b/assets/javascripts/overview.js
@@ -123,15 +123,18 @@ function stackParallelChildren(depElement, dependencyInfo) {
 function setupOverview(options) {
   setupLazyLoadingFailedSteps();
   updateTimeago();
-  $('.cancel').bind('ajax:success', function (event, xhr, status) {
-    $(this).text(''); // hide the icon
-    const icon = $(this).parents('td').find('.status');
-    icon.removeClass('state_scheduled').removeClass('state_running');
-    icon.addClass('state_cancelled');
-    icon.attr('title', 'Cancelled');
-    icon.fadeTo('slow', 0.5).fadeTo('slow', 1.0);
+  $('.cancel').on('ajax:success', function (event, xhr, status) {
+    this.textContent = ''; // hide the icon
+    const icon = this.closest('td').querySelector('.status');
+    if (icon) {
+      icon.classList.remove('state_scheduled', 'state_running');
+      icon.classList.add('state_cancelled');
+      icon.title = 'Cancelled';
+      icon.style.opacity = 0.5;
+      setTimeout(() => (icon.style.opacity = 1.0), 500);
+    }
   });
-  $('.restart').bind('ajax:success', function (event, xhr, status) {
+  $('.restart').on('ajax:success', function (event, xhr, status) {
     if (typeof xhr !== 'object' || !Array.isArray(xhr.result)) {
       addFlash('danger', '<strong>Unable to restart job.</strong>');
       return;
@@ -139,32 +142,38 @@ function setupOverview(options) {
     showJobRestartResults(xhr, undefined, forceJobRestartViaRestartLink.bind(undefined, event.currentTarget));
     const newId = xhr.result[0];
     const oldId = 0;
-    $.each(newId, function (key, value) {
-      if (!$('.restart[data-jobid="' + key + '"]').length) {
-        return true;
+    const newIdMap = xhr.result[0];
+    Object.entries(newIdMap).forEach(([key, value]) => {
+      const restarted = document.querySelector('.restart[data-jobid="' + key + '"]');
+      if (!restarted) {
+        return;
       }
-      const restarted = $('.restart[data-jobid="' + key + '"]');
-      restarted.text(''); // hide the icon
-      const icon = restarted.parents('td').find('.status');
-      icon.removeClass('state_done').removeClass('state_cancelled');
-      icon.addClass('state_scheduled');
-      icon.attr('title', 'Scheduled');
-      // remove the result class
-      restarted.parents('td').find('.result_passed').removeClass('result_passed');
-      restarted.parents('td').find('.result_failed').removeClass('result_failed');
-      restarted.parents('td').find('.result_softfailed').removeClass('result_softfailed');
+      restarted.textContent = ''; // hide the icon
+      const td = restarted.closest('td');
+      const icon = td.querySelector('.status');
+      if (icon) {
+        icon.classList.remove('state_done', 'state_cancelled');
+        icon.classList.add('state_scheduled');
+        icon.title = 'Scheduled';
 
-      // If the API call returns a new id, a new job have been created to replace
-      // the old one. In other case, the old job is being reused
-      if (value) {
-        const link = icon.parents('a');
-        const oldId = restarted.data('jobid');
-        const newUrl = link.attr('href').replace(oldId, value);
-        link.attr('href', newUrl);
-        link.addClass('restarted');
+        // remove the result class
+        td.querySelectorAll('.result_passed, .result_failed, .result_softfailed').forEach(el => {
+          el.classList.remove('result_passed', 'result_failed', 'result_softfailed');
+        });
+
+        // If the API call returns a new id, a new job have been created to replace
+        // the old one. In other case, the old job is being reused
+        if (value) {
+          const link = icon.closest('a');
+          const oldId = restarted.dataset.jobid;
+          const newUrl = link.getAttribute('href').replace(oldId, value);
+          link.setAttribute('href', newUrl);
+          link.classList.add('restarted');
+        }
+
+        icon.style.opacity = 0.5;
+        setTimeout(() => (icon.style.opacity = 1.0), 500);
       }
-
-      icon.fadeTo('slow', 0.5).fadeTo('slow', 1.0);
     });
   });
   const dependencies = document.getElementsByClassName('dependency');
@@ -203,15 +212,15 @@ function setupOverview(options) {
   form.todo = false;
 
   // initialize filter for modules results
-  const modulesResultFilter = $('#modules_result');
-  modulesResultFilter.chosen({width: '100%'});
-  modulesResultFilter.change(function (event) {
-    // update query params
-    const params = parseQueryParams();
-    params.modules_results = modulesResultFilter.val();
-  });
-
-  modulesResultFilter.chosen({width: '100%'});
+  const modulesResultFilter = document.getElementById('modules_result');
+  if (modulesResultFilter && typeof jQuery !== 'undefined' && typeof jQuery.fn.chosen === 'function') {
+    $(modulesResultFilter).chosen({width: '100%'});
+    modulesResultFilter.addEventListener('change', function (event) {
+      // update query params
+      const params = parseQueryParams();
+      params.modules_results = Array.from(modulesResultFilter.selectedOptions).map(opt => opt.value);
+    });
+  }
 
   // find specified results
   const flags = {result: {}, state: {}};
@@ -236,15 +245,27 @@ function setupOverview(options) {
       });
       return 'NOT ' + formatFilter(val);
     } else if (key === 'todo') {
-      form.todo.checked = val !== '0';
+      const todoCheck = document.getElementById('filter-todo');
+      if (todoCheck) todoCheck.checked = val !== '0';
       return 'TODO';
     } else if (key === 'modules_result') {
       modulesResults.push(val);
-      modulesResultFilter.val(modulesResults).trigger('chosen:updated').trigger('change');
+      if (modulesResultFilter) {
+        Array.from(modulesResultFilter.options).forEach(opt => {
+          if (opt.value === val) opt.selected = true;
+        });
+        if (typeof jQuery !== 'undefined' && typeof jQuery.fn.chosen === 'function') {
+          $(modulesResultFilter).trigger('chosen:updated');
+        }
+        modulesResultFilter.dispatchEvent(new Event('change'));
+      }
       return formatFilter(val);
-    } else if (form[key] && form[key].value != null) {
-      form[key].value += form[key].value.length > 0 ? `,${val}` : val;
-      return val;
+    } else {
+      const input = document.getElementById('filter-' + key.replace(/_/g, '-')) || form.elements[key];
+      if (input && input.value !== undefined) {
+        input.value += input.value.length > 0 ? `,${val}` : val;
+        return val;
+      }
     }
   });
 

--- a/assets/javascripts/render.js
+++ b/assets/javascripts/render.js
@@ -126,7 +126,9 @@ function renderModuleRow(module, snippets) {
     style: 'position: relative'
   });
   const showPreviewForLink = function () {
-    setCurrentPreview($(this).parent()); // show the preview when clicking on step links
+    if (typeof jQuery !== 'undefined') {
+      setCurrentPreview($(this.parentElement)); // show the preview when clicking on step links
+    }
     return false;
   };
 


### PR DESCRIPTION
Motivation:
Remove jQuery usage from main application scripts to modernize the codebase and
improve page load performance.

Design Choices:
Migrate various utility scripts to modern fetch/CSRF APIs and define the
handleJSONResponseOrThrow helper globally in openqa.js.

Benefits:
Reduced bundle size, native browser API usage, and robust error handling for UI
test reliability.

Before:
* #6988