### PR TITLE
feat: improve custom worker engine handling for custom certs + docs

### DIFF
--- a/docs/WritingTests.md
+++ b/docs/WritingTests.md
@@ -726,39 +726,54 @@ WORKER_CLASS = planet-earth,continent-antarctica,location-my_station
 By default the openQA workers run the "isotovideo" application from PATH on the
 worker host, that is in most cases
 [isotovideo](https://github.com/os-autoinst/os-autoinst/blob/master/isotovideo).
-A custom worker engine command can be set with the test variable `ISOTOVIDEO`.
-For example to run isotovideo from a custom container image one could use the
-test variable setting
-`ISOTOVIDEO=podman run --pull=always --rm -it registry.example.org/my/container/isotovideo /usr/bin/isotovideo -d`
 
-Alternatively, you can run the worker engine inside a rootless Podman
-container by setting `OS_AUTOINST_GIT_REPO` to a Git repository URL.
-openQA will construct a Podman command to clone, build, and execute
-`os-autoinst` from that repository.
-The following optional test variables are supported:
+You can run the worker engine inside a rootless Podman container by setting
+`OS_AUTOINST_GIT_REPO` to a Git repository URL. openQA will automatically
+construct a Podman command to clone, build, and execute `os-autoinst` from
+that repository.
 
+The preferred and most flexible way to configure this is to explicitly specify
+the Git repositories for your test distribution and needles using `CASEDIR`
+and `NEEDLES_DIR` so that a proper git directory is supplied (especially useful
+for non-legacy tests). Here is a copy-pastable snippet using `openqa-clone-job`:
+
+```sh
+openqa-clone-job --skip-chained-deps --within-instance <target_job_url> \
+  OS_AUTOINST_GIT_REPO=https://github.com/<your_username>/os-autoinst.git \
+  OS_AUTOINST_GIT_BRANCH=<your_test_branch> \
+  OS_AUTOINST_CONTAINER_IMAGE=registry.opensuse.org/devel/openqa/containers/osado-dev-container:latest \
+  CASEDIR=https://github.com/os-autoinst/os-autoinst-distri-opensuse.git \
+  NEEDLES_DIR=https://github.com/os-autoinst/os-autoinst-needles-opensuse.git
+```
+
+The variables used in this snippet configure the following:
+
+- `OS_AUTOINST_GIT_REPO`: The repository containing the custom `os-autoinst` engine.
 - `OS_AUTOINST_GIT_BRANCH`: The branch to clone (defaults to `master`).
 - `OS_AUTOINST_CONTAINER_IMAGE`: A custom container image to use (defaults to
   `registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest`).
   `OS_AUTOINST_CONTAINER_IMAGE` requires `OS_AUTOINST_GIT_REPO` to be set.
-  For openSUSE test-distribution testing, you can use
-  `registry.opensuse.org/devel/openqa/containers/osado-dev-container:latest`
-  which pre-installs necessary test dependencies like
-  `os-autoinst-distri-opensuse-deps`.
+  For openSUSE test-distribution testing, you can use the `osado-dev-container`
+  which pre-installs necessary dependencies like `os-autoinst-distri-opensuse-deps`.
+- `CASEDIR` / `NEEDLES_DIR`: Point these to your public Git repositories so the
+  container can clone and locate the required test scripts and needles.
 
-When running inside a rootless container using these variables, the container
-starts as a clean environment. Consequently, default local worker test
-directories (such as `/var/lib/openqa/share/tests/opensuse`) are not mounted.
-To ensure the container can find and execute your test suite, you must
-configure the following:
+#### Testing with internal repositories
 
-- `CASEDIR`: Set this to the public Git repository of your test distribution
-  (e.g. `https://github.com/os-autoinst/os-autoinst-distri-opensuse.git`) so
-  the container can clone and locate the test scripts.
-- `NEEDLES_DIR`: Since needles are typically managed in a separate repository,
-  you must point this to the corresponding needles Git repository (e.g.
-  `https://github.com/os-autoinst/os-autoinst-needles-opensuse.git`) so the
-  container can clone and initialize the required needles.
+For internal or private Git repositories, cloning directly inside the container
+could fail due to missing SSL certificates. To simplify this, openQA automatically
+detects if standard host system CA certificate directories (such as `/etc/ssl/certs`,
+`/etc/pki`, `/usr/share/pki`, and `/var/lib/ca-certificates`) exist on the host.
+If present, they are automatically volume-mounted read-only into the rootless
+container. This allows the container's git command to securely verify internal git
+servers without requiring any manual certificate or custom `ISOTOVIDEO` commands.
+
+Alternatively, you can rely on the built-in fallback for legacy tests: the host
+openQA worker's standard `share` and `tests` directories, as well as any instance
+test caches (e.g. `/var/lib/openqa/cache/<instance_domain>`), are automatically
+volume-mounted read-only into the rootless container. If you omit `CASEDIR` and
+`NEEDLES_DIR`, the containerized engine will seamlessly find and access the local
+or cached test distributions and needles already present on the worker.
 
 _Note_: Running `os-autoinst` in a rootless container requires that the
 `_openqa-worker` user has subuid/subgid ranges assigned in `/etc/subuid`

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 package OpenQA::Worker::Engines::isotovideo;
+
 use Mojo::Base -signatures;
+
+our $CA_DIRS = [qw(/etc/ssl/certs /etc/pki /usr/share/pki /var/lib/ca-certificates)];
 use OpenQA::Constants qw(WORKER_SR_DONE WORKER_EC_CACHE_FAILURE WORKER_EC_ASSET_FAILURE WORKER_SR_DIED);
 use OpenQA::JobSettings;
 use OpenQA::Log qw(log_error log_info log_debug log_warning get_channel_handle format_settings);
@@ -541,6 +544,11 @@ sub _construct_isotovideo_cmd ($job_settings, $isotovideo) {
         path($podman_dir)->make_path;
         my $podman_tmp_dir = getcwd() . '/podman_tmp';
         path($podman_tmp_dir . '/run')->make_path;
+        my @local_dirs = grep { -d } (prjdir() . '/share', prjdir() . '/tests');
+        @local_dirs = (prjdir() . '/share') unless @local_dirs;
+        my @local_mounts = map { ('-v', "$_:$_:ro") } @local_dirs;
+        my @ca_mounts = map { ('-v', "$_:$_:ro") } grep { -d } @$CA_DIRS;
+
         my @cmd = (
             'env',
             "HOME=$podman_tmp_dir",
@@ -558,6 +566,9 @@ sub _construct_isotovideo_cmd ($job_settings, $isotovideo) {
             '--device', '/dev/kvm',
             '-v', getcwd() . ':/pool',
             '-w', '/pool',
+            @local_mounts,
+            @ca_mounts,
+
             $image,
             'sh', '-c', "git clone --branch=$branch --depth=1 $repo && make -C os-autoinst && os-autoinst/isotovideo -d"
         );

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -542,9 +542,13 @@ sub _construct_isotovideo_cmd ($job_settings, $isotovideo) {
 
         my $podman_dir = prjdir() . '/cache/podman';
         path($podman_dir)->make_path;
+        my $podman_runroot = "$podman_dir/run";
+        path($podman_runroot)->make_path;
         my $podman_tmp_dir = getcwd() . '/podman_tmp';
-        path($podman_tmp_dir . '/run')->make_path;
-        my @local_dirs = grep { -d } (prjdir() . '/share', prjdir() . '/tests');
+        path($podman_tmp_dir)->make_path;
+        my $cache_root = prjdir() . '/cache';
+        my @cache_dirs = grep { basename($_) ne 'podman' } glob "$cache_root/*";
+        my @local_dirs = grep { -d } (prjdir() . '/share', prjdir() . '/tests', @cache_dirs);
         @local_dirs = (prjdir() . '/share') unless @local_dirs;
         my @local_mounts = map { ('-v', "$_:$_:ro") } @local_dirs;
         my @ca_mounts = map { ('-v', "$_:$_:ro") } grep { -d } @$CA_DIRS;
@@ -552,10 +556,10 @@ sub _construct_isotovideo_cmd ($job_settings, $isotovideo) {
         my @cmd = (
             'env',
             "HOME=$podman_tmp_dir",
-            "XDG_RUNTIME_DIR=$podman_tmp_dir/run",
+            "XDG_RUNTIME_DIR=$podman_runroot",
             'podman',
             '--root', "$podman_dir/data/containers/storage",
-            '--runroot', "$podman_tmp_dir/run/containers",
+            '--runroot', "$podman_runroot/containers",
             '--storage-opt', 'ignore_chown_errors=true',
             '--cgroup-manager=cgroupfs',
             '--events-backend=file',

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -586,6 +586,8 @@ subtest 'using cgroupv2' => sub {
 };
 
 subtest '_construct_isotovideo_cmd' => sub {
+    local $OpenQA::Worker::Engines::isotovideo::CA_DIRS = [];
+
     my $isotovideo = '/usr/bin/isotovideo';
 
     subtest 'default command' => sub {
@@ -603,7 +605,7 @@ subtest '_construct_isotovideo_cmd' => sub {
     subtest 'containerized with OS_AUTOINST_GIT_REPO' => sub {
         my $settings = {OS_AUTOINST_GIT_REPO => 'https://github.com/foo/os-autoinst.git'};
         my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
-        is scalar(@cmd), 27, 'returns a list of execution arguments';
+        is scalar(@cmd), 29, 'returns a list of execution arguments';
         my $podman_dir = prjdir() . '/cache/podman';
         my $podman_tmp_dir = getcwd() . '/podman_tmp';
         is $cmd[0], 'env', 'uses env';
@@ -629,10 +631,13 @@ subtest '_construct_isotovideo_cmd' => sub {
         is $cmd[20], getcwd() . ':/pool', 'mounts getcwd() to pool';
         is $cmd[21], '-w', 'sets working dir flag';
         is $cmd[22], '/pool', 'sets working dir';
-        is $cmd[23], 'registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest', 'uses default image';
-        is $cmd[24], 'sh', 'executes sh';
-        is $cmd[25], '-c', 'runs shell command';
-        like $cmd[26], qr/git clone --branch=master --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
+        is $cmd[23], '-v', 'mounts share volume';
+        my $share = prjdir() . '/share';
+        is $cmd[24], "$share:$share:ro", 'mounts share dir ro';
+        is $cmd[25], 'registry.opensuse.org/devel/openqa/containers/os-autoinst_dev:latest', 'uses default image';
+        is $cmd[26], 'sh', 'executes sh';
+        is $cmd[27], '-c', 'runs shell command';
+        like $cmd[28], qr/git clone --branch=master --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
           'clones master branch by default';
     };
 
@@ -643,9 +648,9 @@ subtest '_construct_isotovideo_cmd' => sub {
             OS_AUTOINST_CONTAINER_IMAGE => 'my_custom_image:latest'
         };
         my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
-        is scalar(@cmd), 27, 'returns a list of execution arguments';
-        is $cmd[23], 'my_custom_image:latest', 'uses custom image';
-        like $cmd[26], qr/git clone --branch=my_feature --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
+        is scalar(@cmd), 29, 'returns a list of execution arguments';
+        is $cmd[25], 'my_custom_image:latest', 'uses custom image';
+        like $cmd[28], qr/git clone --branch=my_feature --depth=1 https:\/\/github.com\/foo\/os-autoinst\.git/,
           'clones custom branch';
     };
 
@@ -655,6 +660,20 @@ subtest '_construct_isotovideo_cmd' => sub {
             OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
         }
         qr/OS_AUTOINST_CONTAINER_IMAGE requires OS_AUTOINST_GIT_REPO/, 'dies with helpful error message';
+    };
+
+    subtest 'containerized with mounted CA certificates' => sub {
+        my $settings = {OS_AUTOINST_GIT_REPO => 'https://github.com/foo/os-autoinst.git'};
+        my $tmp_dir = path(Mojo::File->new($ENV{OPENQA_BASEDIR} || '.')->child('tmp', 'ca-certs')->to_string);
+        $tmp_dir->make_path;
+        local $OpenQA::Worker::Engines::isotovideo::CA_DIRS = [$tmp_dir->to_string, '/nonexistent/dir'];
+
+        my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
+
+        my $ca_mount = $tmp_dir->to_string;
+        is scalar(grep { $_ eq "$ca_mount:$ca_mount:ro" } @cmd), 1, 'mounts existing CA directory';
+        is scalar(grep { $_ eq '/nonexistent/dir:/nonexistent/dir:ro' } @cmd), 0, 'ignores non-existent CA directory';
+        is scalar(@cmd), 31, 'adds exactly 2 elements for the single CA mount';
     };
 };
 

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -607,15 +607,16 @@ subtest '_construct_isotovideo_cmd' => sub {
         my @cmd = OpenQA::Worker::Engines::isotovideo::_construct_isotovideo_cmd($settings, $isotovideo);
         is scalar(@cmd), 29, 'returns a list of execution arguments';
         my $podman_dir = prjdir() . '/cache/podman';
+        my $podman_runroot = "$podman_dir/run";
         my $podman_tmp_dir = getcwd() . '/podman_tmp';
         is $cmd[0], 'env', 'uses env';
         is $cmd[1], "HOME=$podman_tmp_dir", 'sets correct home directory under openqa cache';
-        is $cmd[2], "XDG_RUNTIME_DIR=$podman_tmp_dir/run", 'sets XDG_RUNTIME_DIR environment variable';
+        is $cmd[2], "XDG_RUNTIME_DIR=$podman_runroot", 'sets XDG_RUNTIME_DIR environment variable';
         is $cmd[3], 'podman', 'runs podman';
         is $cmd[4], '--root', 'uses --root';
         is $cmd[5], "$podman_dir/data/containers/storage", 'sets correct root directory';
         is $cmd[6], '--runroot', 'uses --runroot';
-        is $cmd[7], "$podman_tmp_dir/run/containers", 'sets correct run root directory';
+        is $cmd[7], "$podman_runroot/containers", 'sets correct run root directory';
         is $cmd[8], '--storage-opt', 'sets storage-opt';
         is $cmd[9], 'ignore_chown_errors=true', 'ignores chown errors';
         is $cmd[10], '--cgroup-manager=cgroupfs', 'uses cgroupfs manager';


### PR DESCRIPTION
See indidivual commits

Verification jobs:
1. Pre-State Failure (Verification of Current Bug)
- Job URL: https://openqa.suse.de/tests/23928955
- Result: incomplete
- Error: isotovideo died: No scripts in CASEDIR 'sle'
- Explanation: This job ran on a production worker using the old/pre-state engine code not referencing any git repo in CASEDIR. Because the containerized engine could not read the host worker's cached test directories under /var/lib/openqa/cache/openqa.suse.de, it failed with a broken symlink error.
2. Legacy Local/Cached Checkout Verification (Post-State Success)
- Job URL: https://openqa.suse.de/tests/23931476
- Result: passed
- Explanation: This job executed on the updated worker engine (worker38). It verified that the new dynamic volume-mounting logic for standard directories (share, tests, and /var/lib/openqa/cache/*) and the shared concurrent runroot fix worked, allowing the legacy/cached test suite files to be read and executed to completion.
3. Remote OSADO PR/Git Refspec Verification (Post-State Success)
- Job URL: https://openqa.suse.de/tests/23932036
- Result: passed
- Explanation: This job verified the non-legacy case by checking out a remote custom PR branch (https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/26324) inside the container worker engine. It completed and passed, confirming full end-to-end integration of both custom os-autoinst (PR #3081) and custom test-distribution PR repositories.