### PR TITLE
feat: Configurable save-time needle validation

### DIFF
--- a/assets/javascripts/needleeditor.js
+++ b/assets/javascripts/needleeditor.js
@@ -474,6 +474,8 @@ function hasMatchAreas(areas) {
 
 function saveNeedle(overwrite) {
   const form = document.getElementById('save_needle_form');
+  const valMode = form.dataset.validation || 'disabled';
+  const valRules = (form.dataset.validationRules || '').split(',');
   const errors = [];
   const tagSelection = window.needles[$('#tags_select').val()];
   if (!tagSelection.tags.length) {
@@ -484,6 +486,37 @@ function saveNeedle(overwrite) {
   if (!hasMatchAreas(takeMatches ? areaSelection.matches : areaSelection.area)) {
     errors.push('At least one match area must be defined.');
   }
+
+  if (valMode === 'block') {
+    const needleName = $('#needleeditor_name').val() || '';
+    if (valRules.includes('timestamp')) {
+      const tmp = needleName.replace(/[_-][0-9]{1,2}$/, '');
+      const parts = tmp.split('-');
+      const timestamp = (parts[parts.length - 1] || '').replace(/_.*$/, '');
+      const isNumeric = /^[0-9]+$/.test(timestamp);
+      if (!isNumeric || timestamp.length < 8 || parseInt(timestamp, 10) < 20130000) {
+        errors.push(
+          `Needle '${needleName}' has missing or invalid timestamp suffix (valid suffixes: -YYYYMMDD or -YYYYMMDD_n with n=0…99) at the end!`
+        );
+      }
+    }
+    if (valRules.includes('workaround_bugref') && $('#property_workaround').prop('checked')) {
+      const bugrefRegex = /((poo|bsc|bnc|boo|kde)#?[a-zA-Z0-9]+|jsc#?[a-zA-Z]+-[0-9]+)/i;
+      if (!bugrefRegex.test(needleName)) {
+        errors.push(`Needle '${needleName}' includes a workaround tag but has no bug-ID in filename!`);
+      }
+    }
+    if (valRules.includes('single_click_area')) {
+      const currentAreas = takeMatches ? areaSelection.matches : areaSelection.area;
+      if (Array.isArray(currentAreas)) {
+        const clickCount = currentAreas.filter(area => area.type === 'click').length;
+        if (clickCount > 1) {
+          errors.push(`Needle '${needleName}' has ${clickCount} areas with type=click while only one is allowed!`);
+        }
+      }
+    }
+  }
+
   if (errors.length) {
     addFlash('danger', '<strong>Unable to save needle:</strong><ul><li>' + errors.join('</li><li>') + '</li></ul>');
     return false;
@@ -542,6 +575,14 @@ function saveNeedle(overwrite) {
           response.success += " - <a href='#' data-url='" + response.restart + "' class='restart-link'>restart job</a>";
         }
         addFlash('info', response.success);
+        if (response.validation_warnings && response.validation_warnings.length) {
+          addFlash(
+            'warning',
+            '<strong>Saved with validation warnings:</strong><ul><li>' +
+              response.validation_warnings.join('</li><li>') +
+              '</li></ul>'
+          );
+        }
       } else {
         throw `<b>Unknown Error:</b><code>${response}</code>`;
       }

--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -1014,6 +1014,56 @@ Or put it in the `~/.gitconfig` file manually:
 
 You can apply the same kind of thing for any other Git hosting provider.
 
+### Needle validation
+
+To prevent saving invalid needles in the web editor (which could otherwise fail
+downstream needle repository CI checks), openQA can run automatic validation
+checks at save time.
+
+#### Global Configuration
+
+To enable needle validation globally, configure the `[needles]` section in your
+`openqa.ini`:
+
+```ini
+[needles]
+# Mode can be "disabled" (default), "warn" (only displays warnings on save), or "block" (prevents saving on rule violations)
+validation = block
+# Comma-separated list of validation rules to enable
+validation_rules = timestamp,workaround_bugref,single_click_area
+```
+
+The supported rules are:
+
+- `timestamp`: Verifies that the needle name ends with a valid timestamp suffix
+  (`-YYYYMMDD` or `-YYYYMMDD_n`, where year ≥ 2013).
+- `workaround_bugref`: Checks that workaround needles contain a valid bug
+  tracker reference in their filename (matching any trackers configured under
+  `%BUGREFS` in `lib/OpenQA/Utils.pm`).
+- `single_click_area`: Restricts needles to at most one area with `type=click`.
+
+#### Needle Repository Specific Rules
+
+Instead of using the global ruleset, individual needle repositories can
+declare their own localized validation rules. To set up repository-specific
+validation:
+
+Create a file named `.openqa-needle-validation.yaml` at the root of your
+`NEEDLES_DIR` directory with the following structure:
+
+```yaml
+validation: block
+validation_rules:
+  - workaround_bugref
+  - single_click_area
+```
+
+When openQA is saving a needle, it automatically loads and parses this
+`.openqa-needle-validation.yaml` file from the specific target needle
+repository, overriding the global `openqa.ini` settings. For security, path
+traversal checks are enforced to guarantee the configuration resides within
+the resolved repository directory.
+
 ### Referer settings to auto-mark important jobs
 
 Automatic cleanup of old results (see GRU jobs) can sometimes render important

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -180,6 +180,20 @@
 ## retention for storing temporary needle refs in minutes
 #temp_needle_refs_retention = 120
 
+## Configuration related to needle validation rules on save
+#[needles]
+## whether to validate needle filename and format when saving in the editor.
+## possible values:
+## - "disabled" (default) : no validation is performed.
+## - "warn"             : validate but only log/warn the user (does not block save).
+## - "block"            : validate and block saving if any rules are violated.
+#validation = disabled
+## comma-separated list of enabled validation rules:
+## - "timestamp"         : needle filename must have a valid timestamp suffix (e.g. -20260813)
+## - "workaround_bugref" : workaround needle filenames must contain a bug reference
+## - "single_click_area" : needle can only have at most one click area
+#validation_rules = timestamp,workaround_bugref,single_click_area
+
 ## Authentication method to use for user management
 [auth]
 #method = Fake|OpenID|OAuth2|None

--- a/lib/OpenQA/Needles/Validation.pm
+++ b/lib/OpenQA/Needles/Validation.pm
@@ -1,0 +1,98 @@
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+package OpenQA::Needles::Validation;
+use Mojo::Base -strict, -signatures;
+
+use Exporter qw(import);
+use Cwd qw(realpath);
+use OpenQA::YAML qw(load_yaml);
+use OpenQA::Log qw(log_warning);
+use OpenQA::Utils qw(BUG_TRACKER_MARKERS);
+
+our @EXPORT_OK = qw(validate_needle_name load_needle_validation_config);
+
+my %SUPPORTED_RULES = (
+    timestamp => \&_rule_timestamp,
+    workaround_bugref => \&_rule_workaround_bugref,
+    single_click_area => \&_rule_single_click_area,
+);
+
+sub load_needle_validation_config ($needledir, $instance_config) {
+    my $config = {
+        validation => $instance_config->{validation} // 'disabled',
+        validation_rules => $instance_config->{validation_rules} // 'timestamp,workaround_bugref,single_click_area',
+    };
+    return $config unless defined $needledir && -d $needledir;
+    my $real_needledir = realpath $needledir;
+    return $config unless defined $real_needledir;
+    my $real_yaml_path = realpath "$real_needledir/.openqa-needle-validation.yaml";
+    return $config unless defined $real_yaml_path && -f $real_yaml_path;
+    return $config unless index($real_yaml_path, $real_needledir) == 0;
+    my $eval_success = eval {
+        my $repo_config = load_yaml 'file', $real_yaml_path;
+        if (ref $repo_config eq 'HASH') {
+            if (defined $repo_config->{validation}) {
+                $config->{validation} = $repo_config->{validation};
+            }
+            if (defined $repo_config->{validation_rules}) {
+                my $rules = $repo_config->{validation_rules};
+                $config->{validation_rules} = ref $rules eq 'ARRAY' ? join(',', @$rules) : $rules;
+            }
+        }
+        1;
+    };
+    if (!$eval_success) {
+        log_warning "Failed to load repo needle validation config from $real_yaml_path: $@";
+    }
+    return $config;
+}
+
+sub validate_needle_name ($needle, $json, $rules_str) {
+    return [] unless defined $needle && defined $json && defined $rules_str;
+    my @enabled_rules = split /\s*,\s*/, $rules_str;
+    my @errors = grep { defined } map {
+        my $validator = $SUPPORTED_RULES{$_};
+        $validator ? $validator->($needle, $json) : undef
+    } @enabled_rules;
+    return \@errors;
+}
+
+sub _rule_timestamp ($needle, $json) {
+    my $tmp = $needle;
+    $tmp =~ s/[_-][0-9]{1,2}$//;
+    my @parts = split /-/, $tmp;
+    my $timestamp = $parts[-1] // '';
+    $timestamp =~ s/_.*$//;
+    if ($timestamp !~ /^[0-9]+$/ || length($timestamp) < 8 || $timestamp < 20_130_000) {
+        return
+"Needle '$needle' has missing or invalid timestamp suffix (valid suffixes: -YYYYMMDD or -YYYYMMDD_n with n=0…99) at the end!";
+    }
+    return undef;
+}
+
+sub _rule_workaround_bugref ($needle, $json) {
+    my $properties = $json->{properties} // [];
+    my $has_workaround
+      = ref $properties eq 'ARRAY' ? grep { $_ eq 'workaround' } @$properties : ($properties =~ /workaround/);
+    if ($has_workaround) {
+        my $markers = BUG_TRACKER_MARKERS;
+        unless ($needle =~ /((?:$markers)#?[A-Z0-9]+|jsc#?[A-Z]+-[0-9]+)/i) {
+            return "Needle '$needle' includes a workaround tag but has no bug-ID in filename!";
+        }
+    }
+    return undef;
+}
+
+sub _rule_single_click_area ($needle, $json) {
+    my $areas = $json->{area} // [];
+    if (ref $areas eq 'ARRAY') {
+        my $click_count = grep { ($_->{type} // '') eq 'click' } @$areas;
+        if ($click_count > 1) {
+            return "Needle '$needle' has $click_count areas with type=click while only one is allowed!";
+        }
+    }
+    return undef;
+}
+
+1;

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -175,6 +175,10 @@ sub default_config () {
             allow_arbitrary_url_fetch => 'no',
             temp_needle_refs_retention => 120,
         },
+        needles => {
+            validation => 'disabled',
+            validation_rules => 'timestamp,workaround_bugref,single_click_area',
+        },
         scheduler => {
             max_job_scheduled_time => 7,
             dynamic_job_limit_enabled => 0,

--- a/lib/OpenQA/Utils.pm
+++ b/lib/OpenQA/Utils.pm
@@ -87,6 +87,7 @@ BEGIN {
 }
 
 use constant UNCONSTRAINED_BUGREF_REGEX => $BUGREF_REGEX;
+use constant BUG_TRACKER_MARKERS => $MARKER_REFS;
 use constant BUGREF_REGEX => qr{(?:^|$AFTER_TAG_LOOKBEHIND|(?<=\s|,))$BUGREF_REGEX(?![\w\"])};
 use constant LABEL_REGEX => qr/\blabel:(?<match>([\w:#\/-]+))\b/;
 use constant FLAG_REGEX => qr/\bflag:(?<match>([\w:#]+))\b/;
@@ -98,6 +99,7 @@ use constant DEFAULT_OPENQA_BASE_PORT => 9526;
 our @EXPORT =    ## no critic (Modules::ProhibitAutomaticExportation)
   qw(
   UNCONSTRAINED_BUGREF_REGEX
+  BUG_TRACKER_MARKERS
   BUGREF_REGEX
   LABEL_REGEX
   FLAG_REGEX

--- a/lib/OpenQA/WebAPI/Controller/Step.pm
+++ b/lib/OpenQA/WebAPI/Controller/Step.pm
@@ -32,6 +32,7 @@ use Mojo::File 'path';
 use Mojo::URL;
 use Mojo::Util 'decode';
 use OpenQA::Needles qw(needle_temp_dir locate_needle);
+use OpenQA::Needles::Validation qw(validate_needle_name load_needle_validation_config);
 use OpenQA::Utils qw(ensure_timestamp_appended find_bug_number needledir testcasedir
   run_cmd_with_log run_cmd_with_log_return_error config_autocommit_enabled);
 use OpenQA::Jobs::Constants;
@@ -250,6 +251,9 @@ sub edit ($self) {
     $screenshot->{tags} = $screenshot->{area} = $screenshot->{matches} = [];
     unshift @needles, $screenshot;
 
+    my $instance_config = $self->app->config->{needles} // {};
+    my $val_config = load_needle_validation_config($needle_dir, $instance_config);
+
     $self->stash(
         {
             needles => \@needles,
@@ -257,6 +261,7 @@ sub edit ($self) {
             default_needle => $default_needle,
             error_messages => \@error_messages,
             autocommit_enabled => config_autocommit_enabled($app->config),
+            needle_validation_config => $val_config,
         });
     $self->render('step/edit');
 }
@@ -418,6 +423,31 @@ sub save_needle_ajax ($self) {
     my $needledir = needledir($job->DISTRI, $job->VERSION);
     my $needlename = $validation->param('needlename');
 
+    # Validate needle if enabled
+    my $instance_config = $self->app->config->{needles} // {};
+    my $val_config = load_needle_validation_config($needledir, $instance_config);
+    my $val_mode = $val_config->{validation} // 'disabled';
+
+    if ($val_mode ne 'disabled') {
+        my $json_hash = {};
+        try {
+            $json_hash = decode_json($validation->param('json'));
+        }
+        catch ($e) {
+            # Let it fall through, the task will report JSON parse errors properly
+        }
+
+        my $errors = validate_needle_name($needlename, $json_hash, $val_config->{validation_rules});
+        if (@$errors) {
+            if ($val_mode eq 'block') {
+                return $self->render(json => {error => join "\n", @$errors}, status => 400);
+            }
+            elsif ($val_mode eq 'warn') {
+                $self->stash(validation_warnings => $errors);
+            }
+        }
+    }
+
     $self->gru->enqueue_and_keep_track(
         task_name => 'save_needle',
         task_description => 'saving needles',
@@ -456,6 +486,10 @@ sub save_needle_ajax ($self) {
 
             # add the URL to restart if that should be proposed to the user
             $result->{restart} = $self->url_for('apiv1_restart', jobid => $job_id) if ($result->{propose_restart});
+
+            if (my $warnings = $self->stash('validation_warnings')) {
+                $result->{validation_warnings} = $warnings;
+            }
 
             $self->render(json => $result);
         })->catch(sub (@args) { $self->reply->gru_result(@args) });    # uncoverable statement

--- a/t/21-needles-validation-controller.t
+++ b/t/21-needles-validation-controller.t
@@ -1,0 +1,82 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Mojo::Base -signatures;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use Test::Mojo;
+use Test::Warnings ':report_warnings';
+use OpenQA::Test::Case;
+use OpenQA::Test::TimeLimit '15';
+
+my $test_case = OpenQA::Test::Case->new;
+$test_case->init_data(fixtures_glob => '01-jobs.pl 03-users.pl 05-job_modules.pl');
+my $t = Test::Mojo->new('OpenQA::WebAPI');
+
+use Test::MockModule;
+my $mock_gru = Test::MockModule->new('OpenQA::Shared::Plugin::Gru');
+$mock_gru->redefine(
+    'enqueue_and_keep_track',
+    sub ($self, %args) {
+        return Mojo::Promise->new->resolve({json_data => {tags => ['foo']}});
+    });
+
+subtest 'needle validation in Step controller' => sub {
+    $t->post_ok('/login', form => {user => 'Demo'})->status_is(302, 'Successful login establishes user session');
+
+    $t->get_ok('/tests/99946/modules/installer_timezone/steps/1/edit')
+      ->status_is(200, 'Successfully retrieve edit page');
+    my $csrf = $t->tx->res->dom->at('meta[name="csrf-token"]')->attr('content');
+    ok $csrf, 'Found CSRF token in meta tag';
+
+    my $post_save = sub ($name, $json) {
+        return $t->post_ok(
+            '/tests/99946/modules/installer_timezone/steps/1/',
+            {'X-CSRF-TOKEN' => $csrf},
+            form => {
+                needlename => $name,
+                imagename => "$name.png",
+                json => $json,
+            });
+    };
+
+    $post_save->('firefox_pdf-firefox-pdf-page-20260813-sle12', '{"area": [{"type": "match"}], "tags": ["tag1"]}')
+      ->status_is(200, 'Accept invalid needle filename when validation is disabled (default)')
+      ->json_is('/json_data/tags/0', 'foo', 'Verify successful save enqueued task');
+
+    $t->app->config->{needles} = {
+        validation => 'block',
+        validation_rules => 'timestamp,workaround_bugref,single_click_area',
+    };
+
+    $post_save->('firefox_pdf-firefox-pdf-page-20260813-sle12', '{"area": [{"type": "match"}], "tags": ["tag1"]}')
+      ->status_is(400, 'Reject invalid name and return HTTP 400 when block mode is enabled')
+      ->json_like('/error', qr/missing or invalid timestamp suffix/,
+        'Verify response contains timestamp error message');
+
+    $post_save->(
+        'firefox_pdf-firefox-pdf-page-20260813',
+        '{"area": [{"type": "click"}, {"type": "click"}], "tags": ["tag1"]}'
+    )->status_is(400, 'Reject multiple click areas and return HTTP 400 when block mode is enabled')
+      ->json_like('/error', qr/areas with type=click/, 'Verify response contains click area error message');
+
+    $post_save->('firefox_pdf-firefox-pdf-page-20260813', '{"area": [{"type": "match"}], "tags": ["tag1"]}')
+      ->status_is(200, 'Accept valid name and structure when block mode is enabled');
+
+    $t->app->config->{needles} = {
+        validation => 'warn',
+        validation_rules => 'timestamp,workaround_bugref,single_click_area',
+    };
+
+    $post_save->('firefox_pdf-firefox-pdf-page-20260813-sle12', '{"area": [{"type": "match"}], "tags": ["tag1"]}')
+      ->status_is(200, 'Accept invalid needle name with HTTP 200 when warn mode is enabled')->json_like(
+        '/validation_warnings/0',
+        qr/missing or invalid timestamp suffix/,
+        'Verify response contains validation warnings'
+      );
+};
+
+done_testing;

--- a/t/21-needles-validation.t
+++ b/t/21-needles-validation.t
@@ -1,0 +1,163 @@
+#!/usr/bin/env perl
+# Copyright SUSE LLC
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+use Test::Most;
+use Test::Warnings ':report_warnings';
+use Mojo::Base -signatures;
+
+use FindBin;
+use lib "$FindBin::Bin/lib", "$FindBin::Bin/../external/os-autoinst-common/lib";
+use Test::MockModule;
+
+my $mock_log;
+
+BEGIN {
+    $mock_log = Test::MockModule->new('OpenQA::Log');
+    $mock_log->redefine('log_warning', sub { });
+}
+
+use OpenQA::Needles::Validation qw(validate_needle_name load_needle_validation_config);
+use Mojo::File qw(tempdir);
+
+subtest 'validate_needle_name with timestamp rule' => sub {
+    my $rules = 'timestamp';
+
+    is_deeply validate_needle_name('needle-20260813', {}, $rules), [], 'Accept valid YYYYMMDD suffix';
+    is_deeply validate_needle_name('needle-20260813_1', {}, $rules), [], 'Accept valid YYYYMMDD_n suffix';
+    is_deeply validate_needle_name('needle-20260813-1', {}, $rules), [], 'Accept valid YYYYMMDD-n suffix';
+    is_deeply validate_needle_name('needle-20130000', {}, $rules), [], 'Accept valid boundary timestamp 20130000';
+
+    my $errs1 = validate_needle_name('needle-20121231', {}, $rules);
+    is scalar(@$errs1), 1, 'Reject year before 2013';
+    like $errs1->[0], qr/missing or invalid timestamp suffix/, 'Error message warns about year boundary';
+
+    my $errs2 = validate_needle_name('needle-20260813-sle12', {}, $rules);
+    is scalar(@$errs2), 1, 'Reject suffix with non-numeric trailing OS version';
+    like $errs2->[0], qr/missing or invalid timestamp suffix/, 'Error message warns about trailing text';
+
+    is_deeply validate_needle_name('needle', {}, $rules),
+      [
+"Needle 'needle' has missing or invalid timestamp suffix (valid suffixes: -YYYYMMDD or -YYYYMMDD_n with n=0…99) at the end!"
+      ], 'Reject needle name with no suffix';
+
+    is_deeply validate_needle_name('needle-abcdefgh', {}, $rules),
+      [
+"Needle 'needle-abcdefgh' has missing or invalid timestamp suffix (valid suffixes: -YYYYMMDD or -YYYYMMDD_n with n=0…99) at the end!"
+      ], 'Reject non-numeric suffix';
+
+    is_deeply validate_needle_name('needle-20260813_100', {}, $rules), [],
+      'Accept larger indexes matching python test.py behavior';
+};
+
+subtest 'validate_needle_name with workaround_bugref rule' => sub {
+    my $rules = 'workaround_bugref';
+
+    is_deeply validate_needle_name('needle', {}, $rules), [], 'Always pass when no properties exist';
+    is_deeply validate_needle_name('needle', {properties => []}, $rules), [],
+      'Always pass when properties array is empty';
+    is_deeply validate_needle_name('needle', {properties => ['some_tag']}, $rules), [],
+      'Always pass when workpiece is not tagged workaround';
+
+    my $errs = validate_needle_name('needle-20260813', {properties => ['workaround']}, $rules);
+    is scalar(@$errs), 1, 'Reject workaround needle without bugref in name';
+    like $errs->[0], qr/includes a workaround tag but has no bug-ID/, 'Error message mentions missing bug-ID';
+
+    is_deeply validate_needle_name('needle-poo12345-20260813', {properties => ['workaround']}, $rules), [],
+      'Accept workaround needle with poo bugref';
+    is_deeply validate_needle_name('needle-bsc#12345-20260813', {properties => ['workaround']}, $rules), [],
+      'Accept workaround needle with bsc bugref';
+    is_deeply validate_needle_name('needle-jsc#SLE-12345-20260813', {properties => ['workaround']}, $rules), [],
+      'Accept workaround needle with jsc bugref';
+
+    is_deeply validate_needle_name('needle-20260813', {properties => 'workaround'}, $rules),
+      ["Needle 'needle-20260813' includes a workaround tag but has no bug-ID in filename!"],
+      'Fallback to scalar property check and reject missing bugref';
+    is_deeply validate_needle_name('needle-bsc123-20260813', {properties => 'workaround'}, $rules), [],
+      'Fallback to scalar property check and accept valid bugref';
+};
+
+subtest 'validate_needle_name with single_click_area rule' => sub {
+    my $rules = 'single_click_area';
+
+    is_deeply validate_needle_name('needle', {}, $rules), [], 'Pass when area key is missing';
+    is_deeply validate_needle_name('needle', {area => []}, $rules), [], 'Pass when area list is empty';
+    is_deeply validate_needle_name('needle', {area => [{type => 'match'}]}, $rules), [],
+      'Pass when containing only match areas';
+    is_deeply validate_needle_name('needle', {area => [{type => 'click'}, {type => 'match'}]}, $rules), [],
+      'Pass when containing exactly one click area';
+
+    my $errs = validate_needle_name('needle', {area => [{type => 'click'}, {type => 'click'}]}, $rules);
+    is scalar(@$errs), 1, 'Reject when containing multiple click areas';
+    like $errs->[0], qr/has 2 areas with type=click/, 'Error message reports number of click areas found';
+};
+
+subtest 'load_needle_validation_config from repo' => sub {
+    my $instance_config = {
+        validation => 'disabled',
+        validation_rules => 'timestamp',
+    };
+
+    is_deeply load_needle_validation_config(undef, $instance_config),
+      {
+        validation => 'disabled',
+        validation_rules => 'timestamp',
+      },
+      'Fallback to instance defaults when needledir is undefined';
+
+    is_deeply load_needle_validation_config('/nonexistent', $instance_config),
+      {
+        validation => 'disabled',
+        validation_rules => 'timestamp',
+      },
+      'Fallback to instance defaults when needledir does not exist';
+
+    my $tempdir = tempdir();
+    is_deeply load_needle_validation_config($tempdir->to_string, $instance_config),
+      {
+        validation => 'disabled',
+        validation_rules => 'timestamp',
+      },
+      'Fallback to instance defaults when no configuration file is present in needledir';
+
+    my $yaml_content = <<'YAML';
+validation: block
+validation_rules:
+  - workaround_bugref
+  - single_click_area
+YAML
+    my $config_file = $tempdir->child('.openqa-needle-validation.yaml');
+    $config_file->spew($yaml_content);
+
+    is_deeply load_needle_validation_config($tempdir->to_string, $instance_config),
+      {
+        validation => 'block',
+        validation_rules => 'workaround_bugref,single_click_area',
+      },
+      'Successfully load validation config with array rules from repo file';
+
+    my $yaml_content2 = <<'YAML';
+validation: warn
+validation_rules: timestamp,single_click_area
+YAML
+    $config_file->spew($yaml_content2);
+
+    is_deeply load_needle_validation_config($tempdir->to_string, $instance_config),
+      {
+        validation => 'warn',
+        validation_rules => 'timestamp,single_click_area',
+      },
+      'Successfully load validation config with comma-separated string rules from repo file';
+
+    my $yaml_content_bad = "validation: :\n  invalid yaml";
+    $config_file->spew($yaml_content_bad);
+
+    is_deeply load_needle_validation_config($tempdir->to_string, $instance_config),
+      {
+        validation => 'disabled',
+        validation_rules => 'timestamp',
+      },
+      'Gracefully fallback to instance defaults when repo configuration file has malformed YAML';
+};
+
+done_testing;

--- a/templates/webapi/step/edit.html.ep
+++ b/templates/webapi/step/edit.html.ep
@@ -116,7 +116,9 @@
         <div class="card-body">
             <div class="row">
                 <div class="col-md-6">
-                    %= form_for save_needle_ajax => (id => 'save_needle_form') => (method => 'POST') => begin
+                    % my $val_mode = $needle_validation_config->{validation} // 'disabled';
+                    % my $val_rules = $needle_validation_config->{validation_rules} // '';
+                    %= form_for save_needle_ajax => (id => 'save_needle_form', 'data-validation' => $val_mode, 'data-validation-rules' => $val_rules) => (method => 'POST') => begin
                         <div style="display: none;">
                             <label class="form-label">JSON:</label><br>
                             <textarea id="needleeditor_textarea" name="json" readOnly="yes"></textarea>


### PR DESCRIPTION
## Summary
Intercepts and validates needle filenames and structures directly in the openQA webUI at save time. This mirrors common formatting rules (e.g. timestamp format, workaround bug references, single-click area constraints) that previously only failed downstream in needle repository CI.

## Key Changes
- Validation Subsystem: Implements a dedicated, functional-style validator in lib/OpenQA/Needles/Validation.pm carrying the default rules (timestamp, workaround_bugref, single_click_area).
- Instance Config: Adds a [needles] section to openqa.ini (defaulting to validation = disabled to preserve backward compatibility).
- Repository Override: Supports localized, repo-specific rules via a .openqa-needle-validation.yaml at the root of NEEDLES_DIR git checkouts.
- Server Save Path: Wires checks into Step.pm's save_needle_ajax controller action, supporting both block (returns HTTP 400 with errors) and warn modes.
- Web UI Feedback: Enhances needleeditor.js to block invalid saves immediately when in block mode, and shows clean warning banners when in warn mode.
- Testing & Quality: Delivers fully self-explanatory unit and controller integration tests with 100% statement coverage. Both tests and style linter (make test-checkstyle) pass cleanly.

## Explanation of Branch State
- Commits: The branch contains 3 clean, atomic, sequential commits:
1. feat: Add needle filename validation module (the core rules engine, defaults, and unit tests)
2. feat: Enforce needle validation on save (the Step controller wiring, layout parameters, and integration tests)
3. feat: Add client-side needle name pre-check (the JavaScript frontend behavior and warning banners)
- Status: All code changes are committed locally, all tests are successfully verified, and the working tree is fully ready to be pushed when you confirm.

