### PR TITLE
feat(container/ci/Dockerfile): include perl-IO-Interactive

### DIFF
--- a/container/ci/Dockerfile
+++ b/container/ci/Dockerfile
@@ -10,7 +10,7 @@ FROM opensuse/tumbleweed
 # hadolint ignore=DL3037
 RUN zypper ar -p 95 -f 'https://download.opensuse.org/repositories/devel:openQA/openSUSE_Tumbleweed' devel_openQA && \
     zypper --gpg-auto-import-keys ref && \
-    zypper in -y os-autoinst-devel openQA-devel nodejs-default perl-TAP-Harness-JUnit && \
+    zypper in -y os-autoinst-devel openQA-devel nodejs-default perl-TAP-Harness-JUnit perl-IO-Interactive && \
     zypper clean -a
 
 ENV OPENQA_DIR=/opt/openqa


### PR DESCRIPTION
This package installation should fix the failure states of perlcritics policies enforcing:

- Perl::Critic::Policy::InputOutput::ProhibitExplicitStdin
- Perl::Critic::Policy::InputOutput::ProhibitInteractiveTest

Related: https://progress.opensuse.org/issues/201318

Look #7441