### PR TITLE
feat: support native scheduled product monitoring

### DIFF
--- a/lib/OpenQA/CLI/monitor.pm
+++ b/lib/OpenQA/CLI/monitor.pm
@@ -7,9 +7,41 @@ use Mojo::Base 'OpenQA::Command', -signatures;
 use OpenQA::Jobs::Constants;
 use List::Util qw(all);
 use Mojo::Util qw(encode);
+use Term::ANSIColor qw(colored);
 
 has description => 'Monitors a set of jobs';
 has usage => sub { OpenQA::CLI->_help('monitor') };
+
+sub _error_from_json ($self, $json) {
+    return $json->{error} // join "\n", map { $_->{error_message} } @{$json->{failed}};
+}
+
+sub _populate_job_ids ($self, $results, $job_ids) {
+    return 'No results present' unless ref $results eq 'HASH';
+    my $ids = $results->{successful_job_ids};
+    return 'No successful job IDs present' unless ref $ids eq 'ARRAY';
+    push @$job_ids, @$ids;
+    return 0;
+}
+
+sub _wait_for_jobs ($self, $client, $poll_interval, $scheduled_product_id, $job_ids) {
+    return undef unless $scheduled_product_id;
+    my %pending_statuses = (added => 1, scheduling => 1);
+    my $status = 'added';
+    while (exists $pending_statuses{$status}) {
+        my $tx = $client->build_tx(GET => $self->url_for("isos/$scheduled_product_id"));
+        my $res = $self->retry_tx($client, $tx);
+        return $res if $res != 0;
+        my $json = $tx->res->json;
+        $status = $json->{status} // '?';
+        my $results = $json->{results};
+        my $error = $self->_error_from_json($results // $json);
+        return $error if $error;
+        return $self->_populate_job_ids($results, $job_ids) if $status eq 'scheduled';
+        sleep $poll_interval;
+    }
+    return "Scheduled product $scheduled_product_id ended up $status";
+}
 
 sub _monitor_jobs ($self, $client, $follow, $poll_interval, $job_ids, $job_results) {
     my $start = time;
@@ -48,8 +80,20 @@ sub command ($self, @args) {
     die $self->usage unless OpenQA::CLI::get_opt(monitor => \@args, [], \my %options);
 
     @args = $self->decode_args(@args);
-    $self->_monitor_and_return($self->client($self->url_for('tests')),
-        $options{follow}, $options{'poll-interval'}, \@args);
+    my $client = $self->client($self->url_for('tests'));
+    my $poll_interval = $options{'poll-interval'} // 10;
+    my @job_ids = @args;
+
+    if (my $sp_id = $options{'scheduled-product-id'}) {
+        my $error = $self->_wait_for_jobs($client, $poll_interval, $sp_id, \@job_ids);
+        if ($error) {
+            print STDERR colored(['red'], $error, "\n");
+            return 1;
+        }
+    }
+
+    die $self->usage unless @job_ids;
+    $self->_monitor_and_return($client, $options{follow}, $poll_interval, \@job_ids);
 }
 
 1;

--- a/lib/OpenQA/CLI/schedule.pm
+++ b/lib/OpenQA/CLI/schedule.pm
@@ -9,37 +9,6 @@ has description => 'Schedules a set of jobs (via "isos post" creating a schedule
 has usage => sub { OpenQA::CLI->_help('schedule') };
 has post_url => sub { shift->url_for('isos') };
 
-sub _error_from_json ($json) {
-    return $json->{error} // join "\n", map { $_->{error_message} } @{$json->{failed}};
-}
-
-sub _populate_job_ids ($self, $results, $job_ids) {
-    return 'No results present' unless ref $results eq 'HASH';
-    my $ids = $results->{successful_job_ids};
-    return 'No successful job IDs present' unless ref $ids eq 'ARRAY';
-    push @$job_ids, @$ids;
-    return 0;
-}
-
-sub _wait_for_jobs ($self, $client, $poll_interval, $scheduled_product_id, $job_ids) {
-    return undef unless $scheduled_product_id;
-    my %pending_statuses = (added => 1, scheduling => 1);
-    my $status = 'added';
-    while (exists $pending_statuses{$status}) {
-        my $tx = $client->build_tx(GET => $self->url_for("isos/$scheduled_product_id"));
-        my $res = $self->retry_tx($client, $tx);
-        return $res if $res != 0;
-        my $json = $tx->res->json;
-        $status = $json->{status} // '?';
-        my $results = $json->{results};
-        my $error = _error_from_json($results // $json);
-        return $error if $error;
-        return $self->_populate_job_ids($results, $job_ids) if $status eq 'scheduled';
-        sleep $poll_interval;
-    }
-    return "Scheduled product $scheduled_product_id ended up $status";
-}
-
 sub _create_jobs ($self, $client, $args, $options, $job_ids) {
     my $params = $self->parse_params($args, $options->{'param-file'});
     my $tx = $client->build_tx(POST => $self->post_url, {}, form => $params);
@@ -54,7 +23,7 @@ sub _create_jobs ($self, $client, $args, $options, $job_ids) {
         say $job_count == 1 ? '1 job has been created:' : "$job_count jobs have been created:";
         say ' - ' . $host_url->clone->path("tests/$_") for @$job_ids;
     }
-    my $error = _error_from_json($json);
+    my $error = $self->_error_from_json($json);
     $error = $self->_wait_for_jobs($client, $options->{'poll-interval'}, $scheduled_product_id, $job_ids)
       if !$error && !@$job_ids && $options->{monitor};
     return 0 unless $error;

--- a/public/openqa-cli.yaml
+++ b/public/openqa-cli.yaml
@@ -192,3 +192,4 @@ subcommands:
     options:
       - *poll_intervall
       - *follow
+      - scheduled-product-id|S=i --Monitor jobs scheduled under this scheduled product ID

--- a/t/43-cli-schedule.t
+++ b/t/43-cli-schedule.t
@@ -139,6 +139,56 @@ subtest 'monitor jobs as a separate command' => sub {
     is $res, 0, 'zero return-code if clone of followed jobs ok';
 };
 
+subtest 'monitor scheduled product as a separate command' => sub {
+    my $res;
+    my $monitor = OpenQA::CLI::monitor->new;
+    my $jobs = $schema->resultset('Jobs');
+    $jobs->create({id => $_, TEST => "test-$_"}) for (200 .. 201);
+    my $sp = $schema->resultset('ScheduledProducts')->create(
+        {
+            id => 50,
+            distri => 'opensuse',
+            version => '13.1',
+            flavor => 'DVD',
+            arch => 'i586',
+            status => 'scheduled',
+            settings => {},
+            results => {
+                successful_job_ids => [200, 201]}});
+    $job_controller_mock->mock(
+        get_status => sub ($self) {
+            $job_controller_mock->original('get_status')->($self);
+            my $job = $self->schema->resultset('Jobs')->find(int($self->stash('jobid')));
+            $job->done(result => (shift(@job_mock_results) // PASSED), reason => 'mocked')
+              if $job && $job->result eq NONE;
+        });
+    @job_mock_results = (PASSED, SOFTFAILED);
+    combined_like { $res = $monitor->run(@basic_options, '--scheduled-product-id', 50) } qr/200.*201/s,
+      'status logged for scheduled product';
+    is $res, 0, 'zero return-code if all jobs of scheduled product ok';
+    $job_controller_mock->unmock('get_status');
+};
+
+subtest 'monitor scheduled product error case' => sub {
+    my $res;
+    my $monitor = OpenQA::CLI::monitor->new;
+    my $sp = $schema->resultset('ScheduledProducts')->create(
+        {
+            id => 51,
+            distri => 'opensuse',
+            version => '13.1',
+            flavor => 'DVD',
+            arch => 'i586',
+            status => 'fatal_error',
+            settings => {},
+            results => {
+                error => 'scheduling failed'
+            }});
+    combined_like { $res = $monitor->run(@basic_options, '--scheduled-product-id', 51) } qr/scheduling failed/s,
+      'error logged for scheduled product failure';
+    is $res, 1, 'non-zero return-code if scheduled product failed';
+};
+
 subtest 'api command preserves lowercase keys for routes expecting them' => sub {
     my $res;
     my $api = OpenQA::CLI::api->new;


### PR DESCRIPTION
Motivation:
Avoid custom polling downstream scripts (such as monitor-openqa_job) when
triggering and monitoring are decoupled.

Design Choices:
Refactor OpenQA::CLI::schedule to move _wait_for_jobs and helper
subroutines into OpenQA::CLI::monitor. Add scheduled-product-id to the
monitor subcommand natively.

Benefits:
Reduces code duplication across repositories, improves maintainability,
and provides clean integration CLI commands for separate CI pipeline jobs.