### PR TITLE
feat: use storage-centric names for cleanup

### DIFF
--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -1702,13 +1702,22 @@ This means a job is "in the archive" if:
 The cleanup of logs/results uses time-based retentions and hence is independent
 of actually available space on any assigned storage volumes. To ensure enough
 free space on the file systems storing results one can use the configuration
-settings `…_min_free_disk_space_percentage` to control automatic cleanup
+settings `…_cleanup_min_free_percentage` to control automatic cleanup
 behavior. These percentages extend the cleanup of logs/results so that they are
 deleted until the specified percentage of file system space is free. This
 extended deletion happens independently of configured time-based retention
 thresholds.
 
-The deletion happens in the following order:
+To help distinguish between the different storage-aware thresholds in openQA,
+three distinct configuration families exist:
+
+| Threshold Family           | Section         | Description & Purpose                                                                                              | Example Configuration Keys                                                                                                               |
+| -------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Scheduler Suspension**   | `[scheduler]`   | Suspends job scheduling and assignments when free storage space drops too low to prevent full storage depletion.   | `results_min_free_storage_space_percentage`<br>`archive_min_free_storage_space_percentage`<br>`assets_min_free_storage_space_percentage` |
+| **Cleanup Lower Bound**    | `[misc_limits]` | Deletes older logs and results (independently of time retentions) until the specified free percentage is restored. | `result_cleanup_min_free_percentage`<br>`archive_cleanup_min_free_percentage`                                                            |
+| **Cleanup Skip Threshold** | `[misc_limits]` | Skips or aborts the cleanup job early if there is already sufficient free headroom, saving system I/O resources.   | `result_cleanup_max_free_percentage`<br>`asset_cleanup_max_free_percentage`                                                              |
+
+The deletion during the space-aware cleanup lower bound happens in the following order:
 
 1.  Videos of unimportant jobs
 
@@ -1732,7 +1741,7 @@ as there is enough headroom on the relevant file systems.
 > **NOTE:**
 > The space-aware cleanup relies on `df` reporting a valid file system space
 > usage. The algorithms also assume that screenshots and test results are stored
-> on the same file system. The `…_min_free_disk_space_percentage` settings
+> on the same file system. The `…_cleanup_min_free_percentage` settings
 > specifically are still experimental.
 
 <a id="asset_cleanup"></a>

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -311,18 +311,18 @@ concurrent = 0
 ## interrupted, increase to reduce the number of Minion jobs)
 #screenshot_cleanup_batches_per_minion_job = 450
 ## Extend the job result cleanup via experimental
-## `…_min_free_disk_space_percentage` settings to ensure storage does not become
+## `…_cleanup_min_free_percentage` settings to ensure storage does not become
 ## too full (see documentation section "Space-aware cleanup" for details)
 ## Specifies the threshold for the file system where job results are regularly
 ## stored on, zero keeps regularly stored results as long as configured per
 ## retentions
-#results_min_free_disk_space_percentage = 0
+#result_cleanup_min_free_percentage = 0
 ## Specifies the threshold for the file system where job results are archived,
 ## zero keeps archived results as long as configured per retentions
-#archive_min_free_disk_space_percentage = 0
+#archive_cleanup_min_free_percentage = 0
 ## Allows running the extended job result cleanup via
-## `…_min_free_disk_space_percentage` settings in dry-run mode
-#dry_min_free_disk_space_cleanup = 0
+## `…_cleanup_min_free_percentage` settings in dry-run mode
+#cleanup_min_free_dry_run = 0
 ## Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800
 ## Default number of records to include in not otherwise specifically limited

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -285,6 +285,9 @@ sub default_config () {
             asset_cleanup_max_free_percentage => 100,
             screenshot_cleanup_batch_size => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
+            result_cleanup_min_free_percentage => undef,
+            archive_cleanup_min_free_percentage => undef,
+            cleanup_min_free_dry_run => undef,
             results_min_free_disk_space_percentage => undef,
             archive_min_free_disk_space_percentage => undef,
             dry_min_free_disk_space_cleanup => undef,
@@ -384,6 +387,25 @@ sub read_config ($app) {
     if ($config->{audit}->{blacklist}) {
         $app->log->warn("Deprecated use of config key '[audit]: blacklist'. Use '[audit]: blocklist' instead");
         $config->{audit}->{blocklist} = delete $config->{audit}->{blacklist};
+    }
+    my $misc_limits = $config->{misc_limits};
+    for my $item (
+        [qw(results_min_free_disk_space_percentage result_cleanup_min_free_percentage)],
+        [qw(archive_min_free_disk_space_percentage archive_cleanup_min_free_percentage)],
+        [qw(dry_min_free_disk_space_cleanup cleanup_min_free_dry_run)])
+    {
+        my ($old_key, $new_key) = @$item;
+        if (defined $misc_limits->{$old_key}) {
+            if (defined $misc_limits->{$new_key}) {
+                $app->log->warn("Conflict: both '$old_key' (deprecated) and '$new_key' are set. Using '$new_key'.");
+            }
+            else {
+                $app->log->warn(
+                    "Deprecated use of config key '[misc_limits]: $old_key'. Use '[misc_limits]: $new_key' instead");
+                $misc_limits->{$new_key} = $misc_limits->{$old_key};
+            }
+            delete $misc_limits->{$old_key};
+        }
     }
     my $minion_task_triggers = $config->{minion_task_triggers};
     $minion_task_triggers->{$_} = [split /\s+/, $minion_task_triggers->{$_}] for keys %{$minion_task_triggers};

--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -6,7 +6,7 @@ use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use OpenQA::Log qw(log_info log_debug);
 use OpenQA::Utils qw(:DEFAULT assetdir);
-use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage);
+use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry finish_job_if_storage_usage_below_percentage);
 use OpenQA::Task::SignalGuard;
 
 use Mojo::URL;
@@ -50,7 +50,7 @@ sub _limit ($app, $job) {
     return undef unless my $limit_guard = acquire_limit_lock_or_retry($job);
 
     return undef
-      if finish_job_if_disk_usage_below_percentage(
+      if finish_job_if_storage_usage_below_percentage(
         job => $job,
         setting => 'asset_cleanup_max_free_percentage',
         dir => assetdir,

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -9,7 +9,7 @@ use OpenQA::Log qw(log_debug log_info log_warning);
 use OpenQA::ScreenshotDeletion;
 use OpenQA::Utils qw(:DEFAULT prjdir resultdir archivedir check_df);
 use OpenQA::Task::Utils
-  qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage is_disk_usage_below_percentage);
+  qw(acquire_limit_lock_or_retry finish_job_if_storage_usage_below_percentage is_storage_usage_below_percentage);
 use OpenQA::Task::SignalGuard;
 use Scalar::Util 'looks_like_number';
 use List::Util 'min';
@@ -44,7 +44,7 @@ sub _limit ($job, $args = undef) {
     return undef unless my $limit_guard = acquire_limit_lock_or_retry($job);
 
     return undef
-      if finish_job_if_disk_usage_below_percentage(
+      if finish_job_if_storage_usage_below_percentage(
         job => $job,
         setting => 'result_cleanup_max_free_percentage',
         dir => resultdir,
@@ -86,7 +86,7 @@ sub _limit ($job, $args = undef) {
     my $last_processed_id;
     for my $group (@all_groups) {
         if (
-            my $msg = is_disk_usage_below_percentage(
+            my $msg = is_storage_usage_below_percentage(
                 job => $job,
                 setting => 'result_cleanup_max_free_percentage',
                 dir => resultdir
@@ -150,7 +150,7 @@ sub _limit ($job, $args = undef) {
     }
     $job->note(screenshot_cleanup => \@screenshot_cleanup_info);
     $gru->enqueue(ensure_results_below_threshold => {}, {parents => \@parent_minion_job_ids})
-      if $config->{results_min_free_disk_space_percentage} or $config->{archive_min_free_disk_space_percentage};
+      if $config->{result_cleanup_min_free_percentage} or $config->{archive_cleanup_min_free_percentage};
 }
 
 sub _limit_screenshots ($job, $args) {
@@ -192,7 +192,7 @@ sub _limit_screenshots ($job, $args) {
     }
 }
 
-sub _check_remaining_disk_usage ($job, $resultdir, $min_free_percentage) {
+sub _check_remaining_storage_usage ($job, $resultdir, $min_free_percentage) {
     return 0 unless defined $min_free_percentage;
     my ($available_bytes, $total_bytes) = check_df($resultdir);
     my $free_percentage = $available_bytes / $total_bytes * 100;
@@ -268,13 +268,13 @@ sub _ensure_results_below_threshold ($job, @) {
 
     # load configured free percentage
     my $limits = $job->app->config->{misc_limits};
-    my $min_free_percentage = $limits->{results_min_free_disk_space_percentage} // 'none';
-    my $min_free_percentage_ar = $limits->{archive_min_free_disk_space_percentage};
-    my $dry = $limits->{dry_min_free_disk_space_cleanup};
-    return $job->finish('No minimum free disk space percentage configured') if $min_free_percentage eq 'none';
-    return $job->fail(_format_percentage_error(results_min_free_disk_space_percentage => $min_free_percentage))
+    my $min_free_percentage = $limits->{result_cleanup_min_free_percentage} // 'none';
+    my $min_free_percentage_ar = $limits->{archive_cleanup_min_free_percentage};
+    my $dry = $limits->{cleanup_min_free_dry_run};
+    return $job->finish('No minimum free storage space percentage configured') if $min_free_percentage eq 'none';
+    return $job->fail(_format_percentage_error(result_cleanup_min_free_percentage => $min_free_percentage))
       unless _is_valid_percentage($min_free_percentage);
-    return $job->fail(_format_percentage_error(archive_min_free_disk_space_percentage => $min_free_percentage_ar))
+    return $job->fail(_format_percentage_error(archive_cleanup_min_free_percentage => $min_free_percentage_ar))
       if defined $min_free_percentage_ar && !_is_valid_percentage($min_free_percentage_ar);
 
     # check free percentage
@@ -283,8 +283,8 @@ sub _ensure_results_below_threshold ($job, @) {
     #         instead.
     my $resultdir = resultdir;
     my $archivedir = archivedir;
-    my $margin_bytes = _check_remaining_disk_usage($job, $resultdir, $min_free_percentage);
-    my $margin_bytes_ar = _check_remaining_disk_usage($job, $archivedir, $min_free_percentage_ar);
+    my $margin_bytes = _check_remaining_storage_usage($job, $resultdir, $min_free_percentage);
+    my $margin_bytes_ar = _check_remaining_storage_usage($job, $archivedir, $min_free_percentage_ar);
     $job->note(resultdir => $resultdir);
     $job->note(archivedir => $archivedir);
     return $job->finish('Done, nothing to do') if $margin_bytes >= 0 && $margin_bytes_ar >= 0;

--- a/lib/OpenQA/Task/Utils.pm
+++ b/lib/OpenQA/Task/Utils.pm
@@ -12,7 +12,7 @@ use Time::Seconds;
 use Feature::Compat::Try;
 
 our @EXPORT_OK
-  = (qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage is_disk_usage_below_percentage));
+  = (qw(acquire_limit_lock_or_retry finish_job_if_storage_usage_below_percentage is_storage_usage_below_percentage));
 
 # acquire lock to prevent multiple limit_* tasks to run in parallel unless
 # concurrency is configured to be allowed
@@ -25,7 +25,7 @@ sub acquire_limit_lock_or_retry ($job) {
     return 0;
 }
 
-sub is_disk_usage_below_percentage (%args) {
+sub is_storage_usage_below_percentage (%args) {
     my $job = $args{job};
     my $percentage = $job->app->config->{misc_limits}->{$args{setting}};
 
@@ -46,11 +46,11 @@ sub is_disk_usage_below_percentage (%args) {
     my $free_percentage = $available_bytes / $total_bytes * 100;
     return undef if $free_percentage <= $percentage;
     return
-"Skipping, free disk space on '$dir' exceeds configured percentage $percentage % (free percentage: $free_percentage %)";
+"Skipping, free storage space on '$dir' exceeds configured percentage $percentage % (free percentage: $free_percentage %)";
 }
 
-sub finish_job_if_disk_usage_below_percentage (%args) {
-    if (my $msg = is_disk_usage_below_percentage(%args)) {
+sub finish_job_if_storage_usage_below_percentage (%args) {
+    if (my $msg = is_storage_usage_below_percentage(%args)) {
         log_info $msg;
         $args{job}->finish($msg);
         return 1;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -334,7 +334,7 @@ subtest 'job grab (failed to send job to worker)' => sub {
     is_deeply $allocated, [], 'no workers/jobs allocated';
 };
 
-subtest 'skip jobs because of results_min_free_disk_space_percentage limits)' => sub {
+subtest 'skip jobs because of results_min_free_storage_space_percentage limits)' => sub {
     $job->update({state => DONE});
     $job2->update({state => DONE});
     undef $ws_send_error;

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -11,7 +11,7 @@ use OpenQA::Log qw(log_error);
 use OpenQA::Test::TimeLimit '10';
 require OpenQA::Test::Database;
 use OpenQA::Task::Job::Limit;
-use OpenQA::Task::Utils qw(finish_job_if_disk_usage_below_percentage);
+use OpenQA::Task::Utils qw(finish_job_if_storage_usage_below_percentage);
 use OpenQA::Test::Utils qw(perform_minion_jobs run_gru_job);
 use OpenQA::Utils qw(prjdir assetdir resultdir archivedir);
 use Mojo::JSON qw(decode_json encode_json);
@@ -37,17 +37,17 @@ sub job_log_like ($regex, $test_name) {
     return $job;
 }
 
-subtest 'no minimum free disk space percentage for results configured' => sub {
+subtest 'no minimum free storage space percentage for results configured' => sub {
     my $job = run_gru_job($app, ensure_results_below_threshold => []);
     is $job->{state}, 'finished', 'job considered successful';
-    is $job->{result}, 'No minimum free disk space percentage configured', 'noop if no minimum configured';
+    is $job->{result}, 'No minimum free storage space percentage configured', 'noop if no minimum configured';
 };
 
 subtest 'abort early in case of misconfiguration' => sub {
-    $app->config->{misc_limits}->{results_min_free_disk_space_percentage} = 'foo';
-    my $job = job_log_like qr|results_.*_percentage.*foo.*not.*number|, 'error logged';
+    $app->config->{misc_limits}->{result_cleanup_min_free_percentage} = 'foo';
+    my $job = job_log_like qr|result_cleanup_.*_percentage.*foo.*not.*number|, 'error logged';
     is $job->{state}, 'failed', 'result cleanup still considered successful';
-    like $job->{result}, qr|.*results_min_free_disk_space_percentage.*foo.*not.*|, 'result cleanup skipped early';
+    like $job->{result}, qr|.*result_cleanup_min_free_percentage.*foo.*not.*|, 'result cleanup skipped early';
 };
 
 # provide fake data for df
@@ -65,7 +65,7 @@ subtest 'abort early if there is enough free disk space' => sub {
     $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 10;
     my $job;
     combined_like { $job = run_gru_job($app, limit_results_and_logs => []) }
-    qr/Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 11 %\)/,
+    qr/Skipping, free storage space on '.*' exceeds configured percentage 10 % \(free percentage: 11 %\)/,
       'result cleanup early abort logged';
     is $job->{state}, 'finished', 'result cleanup still considered successful';
     like $job->{result},
@@ -74,7 +74,7 @@ subtest 'abort early if there is enough free disk space' => sub {
 
     $app->config->{misc_limits}->{asset_cleanup_max_free_percentage} = 9;
     combined_like { $job = run_gru_job($app, limit_assets => []) }
-    qr/Skipping, free disk space on '.*' exceeds configured percentage 9 % \(free percentage: 11 %\)/,
+    qr/Skipping, free storage space on '.*' exceeds configured percentage 9 % \(free percentage: 11 %\)/,
       'asset cleanup early abort logged';
     is $job->{state}, 'finished', 'asset cleanup still considered successful';
     like $job->{result},
@@ -83,16 +83,17 @@ subtest 'abort early if there is enough free disk space' => sub {
 
     my @check_args = (job => $app->minion->job($job->{id}), setting => 'result_cleanup_max_free_percentage', dir => '');
     $job->{state} = undef;
-    combined_like { ok !finish_job_if_disk_usage_below_percentage(@check_args, setting => 'foo'),
+    combined_like { ok !finish_job_if_storage_usage_below_percentage(@check_args, setting => 'foo'),
         'invalid setting ignored' } qr/Specified value.*will be ignored/, 'warning about invalid setting logged';
 
     $df_mock->redefine(df => sub { die 'df failed' });
-    combined_like { ok !finish_job_if_disk_usage_below_percentage(@check_args), 'invalid df ignored' }
+    combined_like { ok !finish_job_if_storage_usage_below_percentage(@check_args), 'invalid df ignored' }
       qr/df failed.*Proceeding with cleanup/s, 'warning about invalid df logged';
 
     %df_main_storage = (bavail => 10, blocks => 100);
     $mock_df->();
-    ok !finish_job_if_disk_usage_below_percentage(@check_args), 'cleanup done if not enough free disk space available';
+    ok !finish_job_if_storage_usage_below_percentage(@check_args),
+      'cleanup done if not enough free disk space available';
     is $job->{state}, undef, 'job not finished when proceeding with cleanup';
 };
 
@@ -106,7 +107,7 @@ subtest 'abort early during the loop' => sub {
     my $group_bar = $app->schema->resultset('JobGroups')->create({name => 'bar'});
     my $loop_job;
     combined_like { $loop_job = run_gru_job($app, limit_results_and_logs => []) }
-qr/Early abort during job groups loop \(halted before processing group 'bar'\): Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 20 %\)/,
+qr/Early abort during job groups loop \(halted before processing group 'bar'\): Skipping, free storage space on '.*' exceeds configured percentage 10 % \(free percentage: 20 %\)/,
       'early abort during loop logged';
     is $loop_job->{state}, 'finished', 'result cleanup still considered successful';
     like $loop_job->{notes}->{early_abort_results},
@@ -119,7 +120,7 @@ qr/Early abort during job groups loop \(halted before processing group 'bar'\): 
 
 $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 100;
 $app->config->{misc_limits}->{asset_cleanup_max_free_percentage} = 100;
-$app->config->{misc_limits}->{dry_min_free_disk_space_cleanup} = 1;
+$app->config->{misc_limits}->{cleanup_min_free_dry_run} = 1;
 
 # mock the actual deletion of videos and results; it it tested elsewhere
 my $job_mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
@@ -150,7 +151,7 @@ $job_mock->redefine(
 # note: Not adjusting $available_bytes_mock in these functions because the code does not rely on df except for the initial check.
 
 # turn on the cleanup
-$app->config->{misc_limits}->{results_min_free_disk_space_percentage} = 20;
+$app->config->{misc_limits}->{result_cleanup_min_free_percentage} = 20;
 
 subtest 'df returns bad data' => sub {
     %df_main_storage = (bavail => 10, blocks => 5);
@@ -314,9 +315,9 @@ subtest 'jobs in archive not considered by default' => sub {
       'not finished as job that could gain disk space is in the archive';
 };
 
-subtest 'jobs in archive considered via archive_min_free_disk_space_percentage' => sub {
+subtest 'jobs in archive considered via archive_cleanup_min_free_percentage' => sub {
     # setup: as in the previous subtest but this time the job is supposed to be deleted from the archive
-    $app->config->{misc_limits}->{archive_min_free_disk_space_percentage} = 31;
+    $app->config->{misc_limits}->{archive_cleanup_min_free_percentage} = 31;
 
     my @expected_messages = (
         'Unable to cleanup enough results from results dir',
@@ -337,7 +338,7 @@ subtest 'jobs in archive considered via archive_min_free_disk_space_percentage' 
 
 subtest 'archive cleanup skipped if archive not full; result dir cleanup still attempted' => sub {
     # setup: as in the previous subtest but this time the archive is not full
-    $app->config->{misc_limits}->{archive_min_free_disk_space_percentage} = 30;
+    $app->config->{misc_limits}->{archive_cleanup_min_free_percentage} = 30;
 
     my @expected_messages = ('Unable to cleanup enough results from results dir', 'Nothing to do for archive');
     my $job = job_log_like qr/
@@ -352,8 +353,8 @@ subtest 'archive cleanup skipped if archive not full; result dir cleanup still a
 
 subtest 'deleted screenshots always accounted to main storage' => sub {
     # setup: assume that only the deletion of screenshots has freed the disk space when deleting archived job
-    $app->config->{misc_limits}->{dry_min_free_disk_space_cleanup} = 0;
-    $app->config->{misc_limits}->{archive_min_free_disk_space_percentage} = 31;
+    $app->config->{misc_limits}->{cleanup_min_free_dry_run} = 0;
+    $app->config->{misc_limits}->{archive_cleanup_min_free_percentage} = 31;
     %gained_disk_space_by_deleting_results_of_job = ();
     %gained_disk_space_by_deleting_screenshots_of_job = ($important_job_id => 1);
     $dry_run_expected = 0;

--- a/t/config.t
+++ b/t/config.t
@@ -158,6 +158,45 @@ subtest 'Test configuration override from file' => sub {
       'default job_storage_duration extended to result_storage_duration (no group)';
 };
 
+subtest 'Test deprecated cleanup config keys' => sub {
+    my $t_dir = tempdir;
+    local $ENV{OPENQA_CONFIG} = $t_dir;
+    OpenQA::App->set_singleton(my $app = Mojolicious->new(log => $quiet_log));
+
+    my @data = (
+        "[misc_limits]\n",
+        "results_min_free_disk_space_percentage = 15\n",
+        "archive_min_free_disk_space_percentage = 25\n",
+        "dry_min_free_disk_space_cleanup = 1\n",
+    );
+    $t_dir->child('openqa.ini')->spew(join '', @data);
+
+    combined_like sub { OpenQA::Setup::read_config($app) },
+qr/Deprecated use of config key '\[misc_limits\]: results_min_free_disk_space_percentage'.*Deprecated use of config key '\[misc_limits\]: archive_min_free_disk_space_percentage'.*Deprecated use of config key '\[misc_limits\]: dry_min_free_disk_space_cleanup'/s,
+      'warns for deprecated keys';
+
+    is $app->config->{misc_limits}->{result_cleanup_min_free_percentage}, 15,
+      'results_min_free_disk_space_percentage mapped correctly';
+    is $app->config->{misc_limits}->{archive_cleanup_min_free_percentage}, 25,
+      'archive_min_free_disk_space_percentage mapped correctly';
+    is $app->config->{misc_limits}->{cleanup_min_free_dry_run}, 1, 'dry_min_free_disk_space_cleanup mapped correctly';
+
+    # Conflict test
+    my $t_dir2 = tempdir;
+    local $ENV{OPENQA_CONFIG} = $t_dir2;
+    my $app2 = Mojolicious->new(log => $quiet_log);
+    my @data2 = (
+        "[misc_limits]\n",
+        "results_min_free_disk_space_percentage = 15\n",
+        "result_cleanup_min_free_percentage = 33\n",
+    );
+    $t_dir2->child('openqa.ini')->spew(join '', @data2);
+    combined_like sub { OpenQA::Setup::read_config($app2) },
+qr/Conflict: both 'results_min_free_disk_space_percentage' \(deprecated\) and 'result_cleanup_min_free_percentage' are set/,
+      'warns on conflict';
+    is $app2->config->{misc_limits}->{result_cleanup_min_free_percentage}, 33, 'preferred the new key value';
+};
+
 subtest 'openqa.ini documentation check' => sub {
     my $defaults = OpenQA::Setup::default_config();
     my $ini_path = path($FindBin::Bin)->child('..', 'etc', 'openqa', 'openqa.ini');
@@ -186,7 +225,10 @@ subtest 'openqa.ini documentation check' => sub {
               =~ /^(scm|parallel_children_collapsable_results_sel|file_domain|prio_throttling_data|access_control_allow_origin_header|changelog_file|file_subdomain|search_results_limit)$/;
             next if $section eq 'hypnotoad';
             next if $section eq 'job_settings_ui' && $key eq 'default_data_dir';
-            next if $section eq 'misc_limits' && $key =~ /^(prio_throttling_data|prio_group_data|mcp_max_result_size)$/;
+            next
+              if $section eq 'misc_limits'
+              && $key
+              =~ /^(prio_throttling_data|prio_group_data|mcp_max_result_size|results_min_free_disk_space_percentage|archive_min_free_disk_space_percentage|dry_min_free_disk_space_cleanup)$/;
             next if $section eq 'rate_limits' && $key eq 'search';
             next if $section eq 'secrets';
             next if $section eq 'audit' && $key eq 'blacklist';

--- a/templates/webapi/admin/group/group_property_editor.html.ep
+++ b/templates/webapi/admin/group/group_property_editor.html.ep
@@ -267,9 +267,9 @@
                     <span id="editor-info">
                         <div>All time-related properties (measured in days) can be set to <em>0</em> to denote infinity.</div>
                         % my $limits = app->config->{misc_limits};
-                        % if ($limits->{results_min_free_disk_space_percentage} || $limits->{archive_min_free_disk_space_percentage}) {
+                        % if ($limits->{result_cleanup_min_free_percentage} || $limits->{archive_cleanup_min_free_percentage}) {
                         <div>
-                            Results and logs might be deleted earlier than configured to prevent running out of disk space. In this case only videos are deleted at
+                            Results and logs might be deleted earlier than configured to prevent running out of storage space. In this case only videos are deleted at
                             first and only if that is not sufficient the results are deleted. Important jobs are only considered if deleting other jobs was not sufficient.
                             The affected jobs will stay visible on the web UI in any case; only the videos and possibly logs and screenshots will be gone.
                         </div>


### PR DESCRIPTION
Motivation:
The "disk" terminology in cleanup settings and helpers was inconsistent with
the "storage" naming family used by the scheduler thresholds, posing an operator
trap and misrepresenting non-disk (network/volume) file systems.

Design Choices:
Rename `results_min_free_disk_space_percentage` to
`result_cleanup_min_free_percentage`, `archive_min_free_disk_space_percentage`
to `archive_cleanup_min_free_percentage`, and
`dry_min_free_disk_space_cleanup` to `cleanup_min_free_dry_run`. Rename internal
helpers (`is_disk_usage_below_percentage` etc.) to use `storage` instead of
`disk`. Implement backwards-compatible deprecation and conflict mappings in
`read_config`. Document the distinct threshold families in `UsersGuide.md`.

Benefits:
Eliminates terminology and settings confusion, makes logs more accurate, and
retains full backwards compatibility for older configs.

Related issue: https://progress.opensuse.org/issues/195560