### PR TITLE
feat: Make filter/sorting/pagination/status of workers table persistent

### DIFF
--- a/assets/javascripts/admin_worker.js
+++ b/assets/javascripts/admin_worker.js
@@ -21,7 +21,7 @@ function setupWorkerNeedles() {
 }
 
 function loadWorkerTable() {
-  $('#workers').DataTable({
+  const table = $('#workers').DataTable({
     initComplete: function () {
       this.api()
         .columns()
@@ -56,6 +56,12 @@ function loadWorkerTable() {
   // prevent sorting when worker status selection clicked
   $('#workers_online').on('click', function (event) {
     event.stopPropagation();
+  });
+
+  setupTablePersistence(table, {
+    customFilters: {
+      status: {column: 4, element: '#workers_online', defaultValue: 'Idle'}
+    }
   });
 }
 

--- a/assets/javascripts/openqa.js
+++ b/assets/javascripts/openqa.js
@@ -126,6 +126,107 @@ function updateQueryParams(params) {
   history.replaceState({}, document.title, `?${search.join('&')}${hash}`);
 }
 
+function setupTablePersistence(table, options = {}) {
+  // define function to determine sort order
+  const initialSortOrder = {};
+  const applySortOrder = params => {
+    const order = table.order();
+    if (order && order.length > 0) {
+      const sortCol = String(order[0][0]);
+      const sortDir = order[0][1];
+      if (sortCol !== initialSortOrder.sort?.[0] || sortDir !== initialSortOrder.order?.[0]) {
+        params.sort = [sortCol];
+        params.order = [sortDir];
+      }
+    }
+  };
+
+  // apply initial parameters
+  const queryParams = parseQueryParams();
+  const initialPageLen = table.page.len();
+  if (queryParams.q) {
+    table.search(queryParams.q[0]);
+  }
+  applySortOrder(initialSortOrder);
+  if (queryParams.sort) {
+    const sortCol = parseInt(queryParams.sort[0], 10);
+    const sortDir = (queryParams.order && queryParams.order[0]) || 'asc';
+    if (!isNaN(sortCol)) {
+      table.order([[sortCol, sortDir]]);
+    }
+  }
+  if (queryParams.limit) {
+    const limitVal = parseInt(queryParams.limit[0], 10);
+    if (!isNaN(limitVal)) {
+      table.page.len(limitVal);
+    }
+  }
+  if (queryParams.start) {
+    const startVal = parseInt(queryParams.start[0], 10);
+    if (!isNaN(startVal)) {
+      table.page(Math.floor(startVal / table.page.len()));
+    }
+  }
+  if (options.customFilters) {
+    Object.entries(options.customFilters).forEach(([paramKey, config]) => {
+      const element = document.querySelector(config.element);
+      if (!element) {
+        return;
+      }
+      const value = queryParams[paramKey]?.[0] ?? config.defaultValue;
+      if (value === undefined) {
+        return;
+      }
+      element.value = value;
+      if (config.column !== undefined) {
+        table.column(config.column).search(value);
+      }
+    });
+  }
+
+  // perform the initial draw to apply all loaded settings
+  table.draw(false);
+
+  // set up event listener for subsequent changes (updates URL query parameters on draw)
+  table.on('draw.dt', () => {
+    const currentParams = parseQueryParams();
+
+    // clear managed parameters to re-populate them with current table state
+    const managedKeys = ['q', 'sort', 'order', 'limit', 'start'];
+    if (options.customFilters) {
+      managedKeys.push(...Object.keys(options.customFilters));
+    }
+    managedKeys.forEach(key => delete currentParams[key]);
+
+    // add params for each table property that deviates from the default
+    const params = {...currentParams};
+    const searchVal = table.search();
+    if (searchVal) {
+      params.q = [searchVal];
+    }
+    applySortOrder(params);
+    const pageInfo = table.page.info();
+    if (pageInfo) {
+      if (pageInfo.length !== initialPageLen) {
+        params.limit = [String(pageInfo.length)];
+      }
+      if (pageInfo.start > 0) {
+        params.start = [String(pageInfo.start)];
+      }
+    }
+    if (options.customFilters) {
+      Object.entries(options.customFilters).forEach(([paramKey, config]) => {
+        const value = document.querySelector(config.element)?.value;
+        if (value !== undefined && value !== null && value !== config.defaultValue) {
+          params[paramKey] = [value];
+        }
+      });
+    }
+
+    updateQueryParams(params);
+  });
+}
+
 function renderDataSize(sizeInByte) {
   let unitFactor = 1073741824; // one GiB
   let sizeWithUnit = 0;

--- a/t/lib/OpenQA/SeleniumTest.pm
+++ b/t/lib/OpenQA/SeleniumTest.pm
@@ -13,6 +13,7 @@ our @EXPORT =    ## no critic (Modules::ProhibitAutomaticExportation)
   open_new_tab mock_js_functions element_visible element_hidden
   element_not_present javascript_console_has_no_warnings_or_errors
   wait_until wait_until_element_gone wait_for_element wait_for_data_table
+  wait_for_url
   element_prop element_prop_by_selector map_elements);
 
 use Carp;
@@ -368,6 +369,12 @@ sub wait_for_data_table ($table, $expected_row_count) {
     "$expected_row_count rows present", {timeout => OpenQA::Test::TimeLimit::scale_timeout(10)};
     is scalar @entries, $expected_row_count, 'DataTable shows expected number of rows';
     return \@entries;
+}
+
+sub wait_for_url ($regex, $desc = undef) {
+    $desc //= "URL updated with $regex";
+    wait_for { $_DRIVER->get_current_url =~ $regex } $desc;
+    like $_DRIVER->get_current_url, $regex, $desc;
 }
 
 sub kill_driver () {

--- a/t/ui/15-admin-workers.t
+++ b/t/ui/15-admin-workers.t
@@ -11,7 +11,7 @@ use Test::Warnings ':report_warnings';
 use OpenQA::Constants 'DEFAULT_WORKER_TIMEOUT';
 use OpenQA::Test::TimeLimit '18';
 use OpenQA::Test::Case;
-use OpenQA::Test::Utils qw(assume_all_assets_exist embed_server_for_testing);
+use OpenQA::Test::Utils qw(assume_all_assets_exist embed_server_for_testing wait_for);
 use Date::Format 'time2str';
 use OpenQA::WebSockets::Client;
 use OpenQA::SeleniumTest;
@@ -191,6 +191,35 @@ is_deeply
     '0', '1 hour ago',
   ],
   'the first job has been restarted';
+
+subtest 'table persistence' => sub {
+    subtest 'load worker page with a specific status filter' => sub {
+        $driver->get('/admin/workers?status=Working');
+        wait_for { $driver->find_element('#workers_online')->get_value eq 'Working' } 'status selection updated';
+        is $driver->find_element('#workers_online')->get_value, 'Working', 'working status selected from URL';
+    };
+    subtest 'change select filter and check URL updates' => sub {
+        $driver->find_element_by_xpath("//select[\@id='workers_online']/option[\@value='Idle']")->click;
+        wait_for { $driver->get_current_url !~ qr/status=/ } 'URL updated with status removed for default';
+        unlike $driver->get_current_url, qr/status=/, 'URL updated with status removed for default';
+        $driver->find_element_by_xpath("//select[\@id='workers_online']/option[\@value='Offline']")->click;
+        wait_for_url qr/status=Offline/;
+    };
+    subtest 'enter search query and check URL updates' => sub {
+        $driver->find_element('.dt-search input')->send_keys('foo');
+        wait_for_url qr/q=foo/;
+    };
+    subtest 'sort by host (second column) and check URL updates' => sub {
+        $driver->find_element('#workers thead th:nth-child(2)')->click;
+        wait_for_url qr/sort=1/;
+    };
+    subtest 'reload page with further query parameters to verify persistence restores correctly' => sub {
+        $driver->get('/admin/workers?sort=1&order=desc&q=foo');
+        wait_for { $driver->find_element('.dt-search input')->get_value eq 'foo' } 'table updated';
+        is $driver->find_element('.dt-search input')->get_value, 'foo', 'search value "foo" restored';
+        is $driver->find_element('.dt-ordering-desc')->get_text, 'Host', 'sorting in descending order by host';
+    };
+};
 
 kill_driver();
 done_testing();


### PR DESCRIPTION
* Add table state that deviates from defaults as query parameters so it persists when reloading or C&P-ing the URL into another browser tab
* Add a generic function to enable persistence for any DataTable with support for custom filters (like the status on the workers table)
    * The function needs to be applied to tables individually, though (and that is only done for the workers table so far).
    * The function only works for one table per page. Support for more tables per page could be added as needed.