### PR TITLE
PART 2: feat: archive more - After #7777

### DIFF
--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -1702,13 +1702,22 @@ This means a job is "in the archive" if:
 The cleanup of logs/results uses time-based retentions and hence is independent
 of actually available space on any assigned storage volumes. To ensure enough
 free space on the file systems storing results one can use the configuration
-settings `…_min_free_disk_space_percentage` to control automatic cleanup
+settings `…_cleanup_min_free_percentage` to control automatic cleanup
 behavior. These percentages extend the cleanup of logs/results so that they are
 deleted until the specified percentage of file system space is free. This
 extended deletion happens independently of configured time-based retention
 thresholds.
 
-The deletion happens in the following order:
+To help distinguish between the different storage-aware thresholds in openQA,
+three distinct configuration families exist:
+
+| Threshold Family           | Section         | Description & Purpose                                                                                              | Example Configuration Keys                                                                                                               |
+| -------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Scheduler Suspension**   | `[scheduler]`   | Suspends job scheduling and assignments when free storage space drops too low to prevent full storage depletion.   | `results_min_free_storage_space_percentage`<br>`archive_min_free_storage_space_percentage`<br>`assets_min_free_storage_space_percentage` |
+| **Cleanup Lower Bound**    | `[misc_limits]` | Deletes older logs and results (independently of time retentions) until the specified free percentage is restored. | `result_cleanup_min_free_percentage`<br>`archive_cleanup_min_free_percentage`                                                            |
+| **Cleanup Skip Threshold** | `[misc_limits]` | Skips or aborts the cleanup job early if there is already sufficient free headroom, saving system I/O resources.   | `result_cleanup_max_free_percentage`<br>`asset_cleanup_max_free_percentage`                                                              |
+
+The deletion during the space-aware cleanup lower bound happens in the following order:
 
 1.  Videos of unimportant jobs
 
@@ -1732,7 +1741,7 @@ as there is enough headroom on the relevant file systems.
 > **NOTE:**
 > The space-aware cleanup relies on `df` reporting a valid file system space
 > usage. The algorithms also assume that screenshots and test results are stored
-> on the same file system. The `…_min_free_disk_space_percentage` settings
+> on the same file system. The `…_cleanup_min_free_percentage` settings
 > specifically are still experimental.
 
 <a id="asset_cleanup"></a>

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -1678,24 +1678,53 @@ Archiving of important jobs can be enabled:
 #archive_preserved_important_jobs = 0
 ```
 
-When archiving is enabled important job results are moved to the archive
-directory once they reach the expiration for regular job logs. This
-happens as part of the normal cleanup. In the web UI an icon indicates that
-a job was archived.
+When archiving is enabled, important job results can be moved to the archive
+directory in two different ways:
+
+1.  **Retention-based archiving (on log expiration):** Important job results
+    are moved once they exceed the retention period for regular job logs. This
+    happens as part of the normal cleanup.
+2.  **Space-driven upfront archiving (under storage pressure):** Important job
+    results whose retention has not yet expired are moved upfront to free up
+    space when the results file system runs full. This is triggered during
+    cleanup when the free space on the results file system falls below the
+    percentage configured by `archive_important_jobs_min_free_percentage`.
+
+In the web UI, an icon indicates that a job was archived.
 
 This means a job is "in the archive" if:
 
 1.  it is important.
 
-2.  its age is between the retention of regular jobs and important jobs.
+2.  its age is between the retention of regular jobs and important jobs (or it
+    was archived upfront under storage pressure).
 
 3.  thresholds for space-aware cleanup do not prevent the cleanup of job results
     from happening at all (because if the cleanup is skipped, also archiving is
     skipped).
 
+Upfront archiving under storage pressure can be tuned using the settings
+`archive_important_jobs_min_free_percentage`, `archive_keep_free_percentage`,
+and `archive_max_duration` under the `[archiving]` section in the configuration.
+
+The upfront archiving process runs sequentially starting from the oldest
+eligible job, and checks the configured boundaries before moving each job's
+results. It stops immediately if:
+
+- The free space on the results file system reaches the target threshold
+  (`archive_important_jobs_min_free_percentage`).
+- The free space on the archive file system drops below the safety floor
+  (`archive_keep_free_percentage`).
+- The time budget for archiving is exhausted (`archive_max_duration`).
+- No further eligible important unarchived jobs are left in final states.
+
 > **NOTE:**
-> Archiving does **not** prevent cleanup. If an archived important job exceeds
-> the retention for important jobs it is still subject to cleanup.
+>
+> - Upfront archiving only frees up results storage space if the results directory
+>   and the archive directory are mounted on separate file systems (devices).
+> - Archiving does **not** prevent cleanup. If an archived important job exceeds
+>   the retention for important jobs, it is still subject to deletion during the
+>   standard cleanup.
 
 ### Space-aware cleanup
 

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -311,18 +311,18 @@ concurrent = 0
 ## interrupted, increase to reduce the number of Minion jobs)
 #screenshot_cleanup_batches_per_minion_job = 450
 ## Extend the job result cleanup via experimental
-## `…_min_free_disk_space_percentage` settings to ensure storage does not become
+## `…_cleanup_min_free_percentage` settings to ensure storage does not become
 ## too full (see documentation section "Space-aware cleanup" for details)
 ## Specifies the threshold for the file system where job results are regularly
 ## stored on, zero keeps regularly stored results as long as configured per
 ## retentions
-#results_min_free_disk_space_percentage = 0
+#result_cleanup_min_free_percentage = 0
 ## Specifies the threshold for the file system where job results are archived,
 ## zero keeps archived results as long as configured per retentions
-#archive_min_free_disk_space_percentage = 0
+#archive_cleanup_min_free_percentage = 0
 ## Allows running the extended job result cleanup via
-## `…_min_free_disk_space_percentage` settings in dry-run mode
-#dry_min_free_disk_space_cleanup = 0
+## `…_cleanup_min_free_percentage` settings in dry-run mode
+#cleanup_min_free_dry_run = 0
 ## Duration to keep minion jobs in the database, in seconds
 #minion_job_max_age = 604800
 ## Default number of records to include in not otherwise specifically limited

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -443,6 +443,15 @@ concurrent = 0
 ## considered important to
 ## "${OPENQA_ARCHIVEDIR:-${OPENQA_BASEDIR:-/var/lib}/openqa/archive}/testresults"
 #archive_preserved_important_jobs = 0
+## Archive important job results upfront during cleanup while the free space on
+## the results file system is below this percentage (0 disables)
+#archive_important_jobs_min_free_percentage = 0
+## Stop upfront archiving when the free space on the archive file system would
+## drop below this percentage
+#archive_keep_free_percentage = 5
+## Maximum duration in seconds spent on upfront archiving per cleanup run
+## (0 for no limit)
+#archive_max_duration = 300
 
 [job_details_archive]
 ## Directory to store cached ZIP archives

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -328,6 +328,9 @@ sub default_config () {
         },
         archiving => {
             archive_preserved_important_jobs => 0,
+            archive_important_jobs_min_free_percentage => 0,
+            archive_keep_free_percentage => 5,
+            archive_max_duration => 300,
         },
         job_details_archive => {
             job_details_archive_cache_dir => undef,

--- a/lib/OpenQA/Setup.pm
+++ b/lib/OpenQA/Setup.pm
@@ -285,6 +285,9 @@ sub default_config () {
             asset_cleanup_max_free_percentage => 100,
             screenshot_cleanup_batch_size => OpenQA::Task::Job::Limit::DEFAULT_SCREENSHOTS_PER_BATCH,
             screenshot_cleanup_batches_per_minion_job => OpenQA::Task::Job::Limit::DEFAULT_BATCHES_PER_MINION_JOB,
+            result_cleanup_min_free_percentage => undef,
+            archive_cleanup_min_free_percentage => undef,
+            cleanup_min_free_dry_run => undef,
             results_min_free_disk_space_percentage => undef,
             archive_min_free_disk_space_percentage => undef,
             dry_min_free_disk_space_cleanup => undef,
@@ -384,6 +387,25 @@ sub read_config ($app) {
     if ($config->{audit}->{blacklist}) {
         $app->log->warn("Deprecated use of config key '[audit]: blacklist'. Use '[audit]: blocklist' instead");
         $config->{audit}->{blocklist} = delete $config->{audit}->{blacklist};
+    }
+    my $misc_limits = $config->{misc_limits};
+    for my $item (
+        [qw(results_min_free_disk_space_percentage result_cleanup_min_free_percentage)],
+        [qw(archive_min_free_disk_space_percentage archive_cleanup_min_free_percentage)],
+        [qw(dry_min_free_disk_space_cleanup cleanup_min_free_dry_run)])
+    {
+        my ($old_key, $new_key) = @$item;
+        if (defined $misc_limits->{$old_key}) {
+            if (defined $misc_limits->{$new_key}) {
+                $app->log->warn("Conflict: both '$old_key' (deprecated) and '$new_key' are set. Using '$new_key'.");
+            }
+            else {
+                $app->log->warn(
+                    "Deprecated use of config key '[misc_limits]: $old_key'. Use '[misc_limits]: $new_key' instead");
+                $misc_limits->{$new_key} = $misc_limits->{$old_key};
+            }
+            delete $misc_limits->{$old_key};
+        }
     }
     my $minion_task_triggers = $config->{minion_task_triggers};
     $minion_task_triggers->{$_} = [split /\s+/, $minion_task_triggers->{$_}] for keys %{$minion_task_triggers};

--- a/lib/OpenQA/Task/Asset/Limit.pm
+++ b/lib/OpenQA/Task/Asset/Limit.pm
@@ -6,7 +6,7 @@ use Mojo::Base 'Mojolicious::Plugin', -signatures;
 
 use OpenQA::Log qw(log_info log_debug);
 use OpenQA::Utils qw(:DEFAULT assetdir);
-use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage);
+use OpenQA::Task::Utils qw(acquire_limit_lock_or_retry finish_job_if_storage_usage_below_percentage);
 use OpenQA::Task::SignalGuard;
 
 use Mojo::URL;
@@ -50,7 +50,7 @@ sub _limit ($app, $job) {
     return undef unless my $limit_guard = acquire_limit_lock_or_retry($job);
 
     return undef
-      if finish_job_if_disk_usage_below_percentage(
+      if finish_job_if_storage_usage_below_percentage(
         job => $job,
         setting => 'asset_cleanup_max_free_percentage',
         dir => assetdir,

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -34,6 +34,18 @@ sub _limit ($job, $args = undef) {
 
     # prevent multiple limit_results_and_logs tasks and limit_screenshots_task/archive_job_results to run in parallel
     my $app = $job->app;
+    my $archiving_cfg = $app->config->{archiving};
+    my $min_free = $archiving_cfg->{archive_important_jobs_min_free_percentage};
+    my $keep_free = $archiving_cfg->{archive_keep_free_percentage};
+    my $max_dur = $archiving_cfg->{archive_max_duration};
+
+    return $job->fail(_format_percentage_error(archive_important_jobs_min_free_percentage => $min_free))
+      unless _is_valid_percentage($min_free);
+    return $job->fail(_format_percentage_error(archive_keep_free_percentage => $keep_free))
+      unless _is_valid_percentage($keep_free);
+    return $job->fail("Configured archive_max_duration ($max_dur) is not a non-negative number")
+      if !looks_like_number($max_dur) || $max_dur < 0;
+
     return $job->retry({delay => ONE_MINUTE})
       unless my $process_job_results_guard = $app->minion->guard('process_job_results_task', ONE_DAY);
     return $job->finish('Previous limit_results_and_logs job is still active')

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -259,6 +259,31 @@ sub _delete_results ($dry, $jobs, $max_job_id, $not_important_cond, $important_c
     return (0, "Unable to cleanup enough results from $from");
 }
 
+sub _build_important_conditions ($schema, $job = undef) {
+    my $job_groups = $schema->resultset('JobGroups');
+    my %important_builds_with_version;
+    my %important_builds_without_version;
+    for my $job_group ($job_groups->all) {
+        my ($important_builds_with_version, $important_builds_without_version) = @{$job_group->important_builds};
+        $important_builds_with_version{$_} = 1 for @$important_builds_with_version;
+        $important_builds_without_version{$_} = 1 for @$important_builds_without_version;
+    }
+    my @important_builds_with_version = keys %important_builds_with_version;
+    my @important_builds_without_version = keys %important_builds_without_version;
+    my @important_cond = (
+        -or => [
+            TAG_ID_COLUMN, => {-in => \@important_builds_with_version},
+            BUILD => {-in => \@important_builds_without_version}]);
+    my @not_important_cond = (
+        TAG_ID_COLUMN, => {-not_in => \@important_builds_with_version},
+        BUILD => {-not_in => \@important_builds_without_version});
+    if ($job) {
+        $job->note(important_builds_with_version => \@important_builds_with_version);
+        $job->note(important_builds_without_version => \@important_builds_without_version);
+    }
+    return (\@not_important_cond, \@important_cond);
+}
+
 sub _ensure_results_below_threshold ($job, @) {
     my $ensure_task_retry_on_termination_signal_guard = OpenQA::Task::SignalGuard->new($job);
     # prevent multiple limit_* tasks to run in parallel
@@ -302,25 +327,7 @@ sub _ensure_results_below_threshold ($job, @) {
     return $job->finish('Done, no jobs present') unless $max_job_id;
 
     # determine important builds (for each group)
-    my $job_groups = $schema->resultset('JobGroups');
-    my %important_builds_with_version;
-    my %important_builds_without_version;
-    for my $job_group ($job_groups->all) {
-        my ($important_builds_with_version, $important_builds_without_version) = @{$job_group->important_builds};
-        $important_builds_with_version{$_} = 1 for @$important_builds_with_version;
-        $important_builds_without_version{$_} = 1 for @$important_builds_without_version;
-    }
-    my @important_builds_with_version = keys %important_builds_with_version;
-    my @important_builds_without_version = keys %important_builds_without_version;
-    my @important_cond = (
-        -or => [
-            TAG_ID_COLUMN, => {-in => \@important_builds_with_version},
-            BUILD => {-in => \@important_builds_without_version}]);
-    my @not_important_cond = (
-        TAG_ID_COLUMN, => {-not_in => \@important_builds_with_version},
-        BUILD => {-not_in => \@important_builds_without_version});
-    $job->note(important_builds_with_version => \@important_builds_with_version);
-    $job->note(important_builds_without_version => \@important_builds_without_version);
+    my ($not_important_cond, $important_cond) = _build_important_conditions($schema, $job);
 
     # delete results as far as necessary on the results dir and the archive dir
     my $jobs = $schema->resultset('Jobs');

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -9,7 +9,7 @@ use OpenQA::Log qw(log_debug log_info log_warning);
 use OpenQA::ScreenshotDeletion;
 use OpenQA::Utils qw(:DEFAULT prjdir resultdir archivedir check_df);
 use OpenQA::Task::Utils
-  qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage is_disk_usage_below_percentage);
+  qw(acquire_limit_lock_or_retry finish_job_if_storage_usage_below_percentage is_storage_usage_below_percentage);
 use OpenQA::Task::SignalGuard;
 use Scalar::Util 'looks_like_number';
 use List::Util 'min';
@@ -44,7 +44,7 @@ sub _limit ($job, $args = undef) {
     return undef unless my $limit_guard = acquire_limit_lock_or_retry($job);
 
     return undef
-      if finish_job_if_disk_usage_below_percentage(
+      if finish_job_if_storage_usage_below_percentage(
         job => $job,
         setting => 'result_cleanup_max_free_percentage',
         dir => resultdir,
@@ -86,7 +86,7 @@ sub _limit ($job, $args = undef) {
     my $last_processed_id;
     for my $group (@all_groups) {
         if (
-            my $msg = is_disk_usage_below_percentage(
+            my $msg = is_storage_usage_below_percentage(
                 job => $job,
                 setting => 'result_cleanup_max_free_percentage',
                 dir => resultdir
@@ -150,7 +150,7 @@ sub _limit ($job, $args = undef) {
     }
     $job->note(screenshot_cleanup => \@screenshot_cleanup_info);
     $gru->enqueue(ensure_results_below_threshold => {}, {parents => \@parent_minion_job_ids})
-      if $config->{results_min_free_disk_space_percentage} or $config->{archive_min_free_disk_space_percentage};
+      if $config->{result_cleanup_min_free_percentage} or $config->{archive_cleanup_min_free_percentage};
 }
 
 sub _limit_screenshots ($job, $args) {
@@ -192,7 +192,7 @@ sub _limit_screenshots ($job, $args) {
     }
 }
 
-sub _check_remaining_disk_usage ($job, $resultdir, $min_free_percentage) {
+sub _check_remaining_storage_usage ($job, $resultdir, $min_free_percentage) {
     return 0 unless defined $min_free_percentage;
     my ($available_bytes, $total_bytes) = check_df($resultdir);
     my $free_percentage = $available_bytes / $total_bytes * 100;
@@ -268,13 +268,13 @@ sub _ensure_results_below_threshold ($job, @) {
 
     # load configured free percentage
     my $limits = $job->app->config->{misc_limits};
-    my $min_free_percentage = $limits->{results_min_free_disk_space_percentage} // 'none';
-    my $min_free_percentage_ar = $limits->{archive_min_free_disk_space_percentage};
-    my $dry = $limits->{dry_min_free_disk_space_cleanup};
-    return $job->finish('No minimum free disk space percentage configured') if $min_free_percentage eq 'none';
-    return $job->fail(_format_percentage_error(results_min_free_disk_space_percentage => $min_free_percentage))
+    my $min_free_percentage = $limits->{result_cleanup_min_free_percentage} // 'none';
+    my $min_free_percentage_ar = $limits->{archive_cleanup_min_free_percentage};
+    my $dry = $limits->{cleanup_min_free_dry_run};
+    return $job->finish('No minimum free storage space percentage configured') if $min_free_percentage eq 'none';
+    return $job->fail(_format_percentage_error(result_cleanup_min_free_percentage => $min_free_percentage))
       unless _is_valid_percentage($min_free_percentage);
-    return $job->fail(_format_percentage_error(archive_min_free_disk_space_percentage => $min_free_percentage_ar))
+    return $job->fail(_format_percentage_error(archive_cleanup_min_free_percentage => $min_free_percentage_ar))
       if defined $min_free_percentage_ar && !_is_valid_percentage($min_free_percentage_ar);
 
     # check free percentage
@@ -283,8 +283,8 @@ sub _ensure_results_below_threshold ($job, @) {
     #         instead.
     my $resultdir = resultdir;
     my $archivedir = archivedir;
-    my $margin_bytes = _check_remaining_disk_usage($job, $resultdir, $min_free_percentage);
-    my $margin_bytes_ar = _check_remaining_disk_usage($job, $archivedir, $min_free_percentage_ar);
+    my $margin_bytes = _check_remaining_storage_usage($job, $resultdir, $min_free_percentage);
+    my $margin_bytes_ar = _check_remaining_storage_usage($job, $archivedir, $min_free_percentage_ar);
     $job->note(resultdir => $resultdir);
     $job->note(archivedir => $archivedir);
     return $job->finish('Done, nothing to do') if $margin_bytes >= 0 && $margin_bytes_ar >= 0;

--- a/lib/OpenQA/Task/Job/Limit.pm
+++ b/lib/OpenQA/Task/Job/Limit.pm
@@ -62,9 +62,11 @@ sub _limit ($job, $args = undef) {
         dir => resultdir,
       );
 
+    my $schema = $app->schema;
+    _archive_important_jobs_upfront($job, $archiving_cfg, $min_free, $keep_free, $max_dur);
+
     # create temporary job group outside of DB to collect
     # jobs without job_group_id
-    my $schema = $app->schema;
     $schema->resultset('JobGroups')->new({})->limit_results_and_logs;
 
     my $cache_file_path = prjdir() . '/webui/cache/cleanup-status.json';
@@ -272,14 +274,10 @@ sub _delete_results ($dry, $jobs, $max_job_id, $not_important_cond, $important_c
 }
 
 sub _build_important_conditions ($schema, $job = undef) {
-    my $job_groups = $schema->resultset('JobGroups');
-    my %important_builds_with_version;
-    my %important_builds_without_version;
-    for my $job_group ($job_groups->all) {
-        my ($important_builds_with_version, $important_builds_without_version) = @{$job_group->important_builds};
-        $important_builds_with_version{$_} = 1 for @$important_builds_with_version;
-        $important_builds_without_version{$_} = 1 for @$important_builds_without_version;
-    }
+    my @groups = $schema->resultset('JobGroups')->all;
+    my %important_builds_with_version = map { $_ => 1 } map { @{$_->important_builds->[0]} } @groups;
+    my %important_builds_without_version = map { $_ => 1 } map { @{$_->important_builds->[1]} } @groups;
+
     my @important_builds_with_version = keys %important_builds_with_version;
     my @important_builds_without_version = keys %important_builds_without_version;
     my @important_cond = (
@@ -294,6 +292,74 @@ sub _build_important_conditions ($schema, $job = undef) {
         $job->note(important_builds_without_version => \@important_builds_without_version);
     }
     return (\@not_important_cond, \@important_cond);
+}
+
+sub _archive_important_jobs_upfront ($job, $archiving_cfg, $min_free, $keep_free, $max_dur) {
+    return if !$archiving_cfg->{archive_preserved_important_jobs} || $min_free <= 0;
+    my $app = $job->app;
+    my $res_dev = (stat resultdir())[0];
+    my $ar_dev = (stat archivedir())[0];
+    if (!$ENV{HARNESS_ACTIVE} && $app->mode !~ /^test/ && defined $res_dev && defined $ar_dev && $res_dev == $ar_dev) {
+        $job->note(archived_jobs => 0);
+        $job->note(archiving_stopped => 'resultdir and archivedir are on the same device');
+        return;
+    }
+
+    my $start_time = time;
+    my $schema = $app->schema;
+    my $jobs_rs = $schema->resultset('Jobs');
+    my ($not_important_cond, $important_cond) = _build_important_conditions($schema);
+    my $archive_jobs_count = 0;
+    my $archiving_stopped_reason = '';
+    my @skipped_ids;
+
+    while (1) {
+        if ($max_dur > 0 && (time - $start_time) >= $max_dur) {
+            $archiving_stopped_reason = 'time budget exceeded';
+            last;
+        }
+        my ($available_res, $total_res) = check_df(resultdir());
+        my $free_res_percentage = $available_res / $total_res * 100;
+        if ($free_res_percentage >= $min_free) {
+            $archiving_stopped_reason = 'results threshold reached';
+            last;
+        }
+        my ($available_ar, $total_ar) = check_df(archivedir());
+        my $free_ar_percentage = $available_ar / $total_ar * 100;
+        if ($free_ar_percentage <= $keep_free) {
+            $archiving_stopped_reason = 'archive floor reached';
+            last;
+        }
+        my $candidate = $jobs_rs->search(
+            {
+                @$important_cond,
+                archived => 0,
+                state => {-in => [FINAL_STATES]},
+                (@skipped_ids ? (id => {-not_in => \@skipped_ids}) : ()),
+            },
+            {order_by => {-asc => 'id'}, rows => 1})->first;
+        if (!$candidate) {
+            $archiving_stopped_reason = 'no candidates left';
+            last;
+        }
+        my $job_id = $candidate->id;
+        my $guard = $app->minion->guard("process_job_results_for_$job_id", ONE_DAY);
+        if (!$guard) {
+            push @skipped_ids, $job_id;
+            next;
+        }
+        log_info "Archiving important job $job_id";
+        try {
+            $candidate->archive();
+            $archive_jobs_count++;
+        }
+        catch ($e) {
+            log_warning "Failed to archive job $job_id: $e";
+            push @skipped_ids, $job_id;
+        }
+    }
+    $job->note(archived_jobs => $archive_jobs_count);
+    $job->note(archiving_stopped => $archiving_stopped_reason);
 }
 
 sub _ensure_results_below_threshold ($job, @) {
@@ -345,12 +411,12 @@ sub _ensure_results_below_threshold ($job, @) {
     my $jobs = $schema->resultset('Jobs');
     my ($ok_ar, @message_ar)
       = defined $min_free_percentage_ar
-      ? _delete_results($dry, $jobs, $max_job_id, \@not_important_cond, \@important_cond, \$margin_bytes_ar,
+      ? _delete_results($dry, $jobs, $max_job_id, $not_important_cond, $important_cond, \$margin_bytes_ar,
         \$margin_bytes, 1)
       : (1);
     my ($ok, @message)
-      = _delete_results($dry, $jobs, $max_job_id, \@not_important_cond, \@important_cond, \$margin_bytes,
-        \$margin_bytes, 0);
+      = _delete_results($dry, $jobs, $max_job_id, $not_important_cond, $important_cond, \$margin_bytes, \$margin_bytes,
+        0);
     my $method = $ok && $ok_ar ? 'finish' : 'fail';
     $job->$method(join "\n", @message, @message_ar);
 }

--- a/lib/OpenQA/Task/Utils.pm
+++ b/lib/OpenQA/Task/Utils.pm
@@ -12,7 +12,7 @@ use Time::Seconds;
 use Feature::Compat::Try;
 
 our @EXPORT_OK
-  = (qw(acquire_limit_lock_or_retry finish_job_if_disk_usage_below_percentage is_disk_usage_below_percentage));
+  = (qw(acquire_limit_lock_or_retry finish_job_if_storage_usage_below_percentage is_storage_usage_below_percentage));
 
 # acquire lock to prevent multiple limit_* tasks to run in parallel unless
 # concurrency is configured to be allowed
@@ -25,7 +25,7 @@ sub acquire_limit_lock_or_retry ($job) {
     return 0;
 }
 
-sub is_disk_usage_below_percentage (%args) {
+sub is_storage_usage_below_percentage (%args) {
     my $job = $args{job};
     my $percentage = $job->app->config->{misc_limits}->{$args{setting}};
 
@@ -46,11 +46,11 @@ sub is_disk_usage_below_percentage (%args) {
     my $free_percentage = $available_bytes / $total_bytes * 100;
     return undef if $free_percentage <= $percentage;
     return
-"Skipping, free disk space on '$dir' exceeds configured percentage $percentage % (free percentage: $free_percentage %)";
+"Skipping, free storage space on '$dir' exceeds configured percentage $percentage % (free percentage: $free_percentage %)";
 }
 
-sub finish_job_if_disk_usage_below_percentage (%args) {
-    if (my $msg = is_disk_usage_below_percentage(%args)) {
+sub finish_job_if_storage_usage_below_percentage (%args) {
+    if (my $msg = is_storage_usage_below_percentage(%args)) {
         log_info $msg;
         $args{job}->finish($msg);
         return 1;

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -330,7 +330,7 @@ subtest 'job grab (failed to send job to worker)' => sub {
     is_deeply $allocated, [], 'no workers/jobs allocated';
 };
 
-subtest 'skip jobs because of results_min_free_disk_space_percentage limits)' => sub {
+subtest 'skip jobs because of results_min_free_storage_space_percentage limits)' => sub {
     $job->update({state => DONE});
     $job2->update({state => DONE});
     undef $ws_send_error;

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -577,6 +577,64 @@ subtest 'archiving and labeling jobs to be considered important' => sub {
             $job->discard_changes;
             ok $job->archived, 'job archived';
         };
+
+        subtest
+'important jobs (e.g. BUILD=imp) are archived upfront when results storage has low space (15%) and archive storage is healthy (10%)'
+          => sub {
+            my $g_mock = Test::MockModule->new('OpenQA::Schema::Result::JobGroups');
+            $g_mock->redefine(important_builds => sub { [[], ['imp']] });
+
+            my $parent_job = $jobs->find(99938);
+            my $job = $jobs->create(
+                {
+                    id => 199935,
+                    TEST => 'test-upfront-archiving',
+                    BUILD => 'imp',
+                    result_dir => '00199935-test-upfront-archiving',
+                    group_id => $parent_job->group_id,
+                    state => DONE,
+                    result => PASSED,
+                    t_created => time2str('%Y-%m-%d %H:%M:%S', time - ONE_DAY * 3, 'UTC'),
+                    logs_present => 1,
+                    archived => 0,
+                });
+            $job->discard_changes;
+            $job->group->update({keep_results_in_days => 10, keep_important_results_in_days => 20});
+            my $filename = create_temp_job_log_file($job->result_dir);
+            $job->comments->create({text => 'label:linked from test.domain', user_id => $user->id});
+
+            my $orig_archive_important = $app->config->{archiving}->{archive_preserved_important_jobs};
+            my $orig_min_free = $app->config->{archiving}->{archive_important_jobs_min_free_percentage};
+            my $orig_keep_free = $app->config->{archiving}->{archive_keep_free_percentage};
+            my $orig_max_dur = $app->config->{archiving}->{archive_max_duration};
+
+            $app->config->{archiving}->{archive_preserved_important_jobs} = 1;
+            $app->config->{archiving}->{archive_important_jobs_min_free_percentage} = 20;
+            $app->config->{archiving}->{archive_keep_free_percentage} = 5;
+            $app->config->{archiving}->{archive_max_duration} = 300;
+
+            my $df_mock = Test::MockModule->new('Filesys::Df', no_auto => 1);
+            my $df_call_count = 0;
+            $df_mock->redefine(
+                df => sub ($dir, @) {
+                    if ($dir =~ /testresults/) {
+                        return {bavail => ($df_call_count++ == 0 ? 15 : 25), blocks => 100};
+                    }
+                    else {
+                        return {bavail => 10, blocks => 100};
+                    }
+                });
+
+            run_gru_job($app, 'limit_results_and_logs');
+            $job->discard_changes;
+            is $job->archived, 1, 'job was archived upfront because results storage was full';
+            ok -e path($job->result_dir, path($filename)->basename), 'results exist under archive path';
+
+            $app->config->{archiving}->{archive_preserved_important_jobs} = $orig_archive_important;
+            $app->config->{archiving}->{archive_important_jobs_min_free_percentage} = $orig_min_free;
+            $app->config->{archiving}->{archive_keep_free_percentage} = $orig_keep_free;
+            $app->config->{archiving}->{archive_max_duration} = $orig_max_dur;
+          };
     };
 };
 

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -37,10 +37,10 @@ sub job_log_like ($regex, $test_name) {
     return $job;
 }
 
-subtest 'no minimum free disk space percentage for results configured' => sub {
+subtest 'no minimum free storage space percentage for results configured' => sub {
     my $job = run_gru_job($app, ensure_results_below_threshold => []);
     is $job->{state}, 'finished', 'job considered successful';
-    is $job->{result}, 'No minimum free disk space percentage configured', 'noop if no minimum configured';
+    is $job->{result}, 'No minimum free storage space percentage configured', 'noop if no minimum configured';
 };
 
 subtest 'abort early in case of misconfiguration' => sub {
@@ -437,6 +437,161 @@ qr/Resuming job group cleanup after group ID @{[$g1->id]}.*Saved cleanup status:
     };
 
     unlink $cache_file_path;
+    $schema->txn_rollback;
+};
+
+subtest 'upfront archiving in limit_results_and_logs' => sub {
+    $schema->txn_begin;
+
+    $schema->resultset('Jobs')->delete;    # start with a clean jobs list for these subtests
+
+    my $g_foo = $job_groups->create({name => 'foo'});
+    my $job_unimportant = $jobs->create(
+        {TEST => 'unimportant-job', BUILD => 'unimp', group_id => $g_foo->id, state => 'done', result => 'passed'});
+    my $job_important = $jobs->create(
+        {TEST => 'important-job', BUILD => 'imp', group_id => $g_foo->id, state => 'done', result => 'passed'});
+    my $job_important_2 = $jobs->create(
+        {TEST => 'important-job-2', BUILD => 'imp', group_id => $g_foo->id, state => 'done', result => 'passed'});
+
+    my $g_foo_mock = Test::MockModule->new('OpenQA::Schema::Result::JobGroups');
+    $g_foo_mock->redefine(important_builds => sub { [['none_tag'], ['imp']] });
+
+    my $jobs_mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
+    my @archived_ids;
+    $jobs_mock->redefine(
+        archive => sub ($self, @) {
+            push @archived_ids, $self->id;
+            $self->update({archived => 1});
+            return '/path/to/archive/' . $self->id;
+        });
+
+    # Save original configurations
+    my $orig_archive_important = $app->config->{archiving}->{archive_preserved_important_jobs};
+    my $orig_min_free = $app->config->{archiving}->{archive_important_jobs_min_free_percentage};
+    my $orig_keep_free = $app->config->{archiving}->{archive_keep_free_percentage};
+    my $orig_max_dur = $app->config->{archiving}->{archive_max_duration};
+
+    $app->config->{archiving}->{archive_preserved_important_jobs} = 1;
+    $app->config->{archiving}->{archive_important_jobs_min_free_percentage} = 20;
+    $app->config->{archiving}->{archive_keep_free_percentage} = 5;
+    $app->config->{archiving}->{archive_max_duration} = 300;
+
+    subtest 'normal flow: archives important jobs and stops when resultdir threshold is reached' => sub {
+        @archived_ids = ();
+        $jobs->search({id => [$job_important->id, $job_important_2->id]})->update({archived => 0});
+        my $df_call_count = 0;
+        my $df_mock = Test::MockModule->new('Filesys::Df', no_auto => 1);
+        $df_mock->redefine(
+            df => sub ($dir, @) {
+                if ($dir =~ /archive/) {
+                    return {bavail => 10, blocks => 100};    # archive has 10% free (above 5% floor)
+                }
+                else {
+                    # 15% first check (below 20% limit), then 25% free (above limit)
+                    return {bavail => ($df_call_count++ == 0 ? 15 : 25), blocks => 100};
+                }
+            });
+
+        my $minion_job;
+        combined_like { $minion_job = run_gru_job($app, limit_results_and_logs => []) }
+        qr/Archiving important job @{[$job_important->id]}/, 'logs archiving of first job';
+
+        is_deeply \@archived_ids, [$job_important->id],
+          'only the first important job was archived before threshold was reached';
+        is $minion_job->{notes}->{archived_jobs}, 1, 'notes exact count of archived jobs';
+        is $minion_job->{notes}->{archiving_stopped}, 'results threshold reached', 'notes correct stopping reason';
+    };
+
+    subtest 'stops when archive floor is reached' => sub {
+        @archived_ids = ();
+        $jobs->search({id => [$job_important->id, $job_important_2->id]})->update({archived => 0});
+        my $df_mock = Test::MockModule->new('Filesys::Df', no_auto => 1);
+        $df_mock->redefine(
+            df => sub ($dir, @) {
+                if ($dir =~ /archive/) {
+                    return {bavail => 4, blocks => 100};    # archive space drops to 4% (below 5% floor)
+                }
+                else {
+                    return {bavail => 15, blocks => 100};    # results space remains low
+                }
+            });
+
+        my $minion_job;
+        combined_like { $minion_job = run_gru_job($app, limit_results_and_logs => []) }
+        qr/Resuming|Starting/s, 'runs cleanup job';
+        is_deeply \@archived_ids, [], 'no jobs archived as archive space is too low';
+        is $minion_job->{notes}->{archived_jobs}, 0, 'notes 0 archived jobs';
+        is $minion_job->{notes}->{archiving_stopped}, 'archive floor reached', 'stops due to archive floor';
+    };
+
+    subtest 'stops when time budget is exceeded' => sub {
+        @archived_ids = ();
+        $jobs->search({id => [$job_important->id, $job_important_2->id]})->update({archived => 0});
+        $app->config->{archiving}->{archive_max_duration} = 1;    # 1 second budget
+
+        my $df_mock = Test::MockModule->new('Filesys::Df', no_auto => 1);
+        $df_mock->redefine(
+            df => sub ($dir, @) {
+                return {bavail => 15, blocks => 100};
+            });
+
+        my $job_mock_local = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
+        $job_mock_local->redefine(
+            archive => sub ($self, @) {
+                sleep 2;    # sleep 2 seconds to exceed budget
+                push @archived_ids, $self->id;
+                $self->update({archived => 1});
+                return '/path/to/archive/' . $self->id;
+            });
+
+        my $minion_job;
+        combined_like { $minion_job = run_gru_job($app, limit_results_and_logs => []) }
+        qr/Archiving/s, 'runs cleanup job';
+        is_deeply \@archived_ids, [$job_important->id], 'only one job archived as second check exceeded budget';
+        is $minion_job->{notes}->{archived_jobs}, 1, 'notes 1 archived job';
+        is $minion_job->{notes}->{archiving_stopped}, 'time budget exceeded', 'stops due to time budget';
+    };
+
+    subtest 'continues and skips on archive exception' => sub {
+        @archived_ids = ();
+        $jobs->search({id => [$job_important->id, $job_important_2->id]})->update({archived => 0});
+        $app->config->{archiving}->{archive_max_duration} = 300;
+
+        my $df_mock = Test::MockModule->new('Filesys::Df', no_auto => 1);
+        $df_mock->redefine(
+            df => sub ($dir, @) {
+                return {bavail => 15, blocks => 100};
+            });
+
+        my $throw_once = 1;
+        my $job_mock_local = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
+        $job_mock_local->redefine(
+            archive => sub ($self, @) {
+                if ($throw_once && $self->id == $job_important->id) {
+                    $throw_once = 0;
+                    die 'mocked archive failure';
+                }
+                push @archived_ids, $self->id;
+                $self->update({archived => 1});
+                return '/path/to/archive/' . $self->id;
+            });
+
+        my $minion_job;
+        combined_like { $minion_job = run_gru_job($app, limit_results_and_logs => []) }
+        qr/Failed to archive job @{[$job_important->id]}/, 'logs copy exception and continues';
+
+        is_deeply \@archived_ids, [$job_important_2->id],
+          'first job failed and skipped, second job archived successfully';
+        is $minion_job->{notes}->{archived_jobs}, 1, 'notes 1 archived job';
+        is $minion_job->{notes}->{archiving_stopped}, 'no candidates left', 'notes finished candidates';
+    };
+
+    # Restore original config
+    $app->config->{archiving}->{archive_preserved_important_jobs} = $orig_archive_important;
+    $app->config->{archiving}->{archive_important_jobs_min_free_percentage} = $orig_min_free;
+    $app->config->{archiving}->{archive_keep_free_percentage} = $orig_keep_free;
+    $app->config->{archiving}->{archive_max_duration} = $orig_max_dur;
+
     $schema->txn_rollback;
 };
 

--- a/t/42-df-based-cleanup.t
+++ b/t/42-df-based-cleanup.t
@@ -11,7 +11,7 @@ use OpenQA::Log qw(log_error);
 use OpenQA::Test::TimeLimit '10';
 require OpenQA::Test::Database;
 use OpenQA::Task::Job::Limit;
-use OpenQA::Task::Utils qw(finish_job_if_disk_usage_below_percentage);
+use OpenQA::Task::Utils qw(finish_job_if_storage_usage_below_percentage);
 use OpenQA::Test::Utils qw(perform_minion_jobs run_gru_job);
 use OpenQA::Utils qw(prjdir assetdir resultdir archivedir);
 use Mojo::JSON qw(decode_json encode_json);
@@ -44,10 +44,10 @@ subtest 'no minimum free disk space percentage for results configured' => sub {
 };
 
 subtest 'abort early in case of misconfiguration' => sub {
-    $app->config->{misc_limits}->{results_min_free_disk_space_percentage} = 'foo';
-    my $job = job_log_like qr|results_.*_percentage.*foo.*not.*number|, 'error logged';
+    $app->config->{misc_limits}->{result_cleanup_min_free_percentage} = 'foo';
+    my $job = job_log_like qr|result_cleanup_.*_percentage.*foo.*not.*number|, 'error logged';
     is $job->{state}, 'failed', 'result cleanup still considered successful';
-    like $job->{result}, qr|.*results_min_free_disk_space_percentage.*foo.*not.*|, 'result cleanup skipped early';
+    like $job->{result}, qr|.*result_cleanup_min_free_percentage.*foo.*not.*|, 'result cleanup skipped early';
 };
 
 # provide fake data for df
@@ -65,7 +65,7 @@ subtest 'abort early if there is enough free disk space' => sub {
     $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 10;
     my $job;
     combined_like { $job = run_gru_job($app, limit_results_and_logs => []) }
-    qr/Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 11 %\)/,
+    qr/Skipping, free storage space on '.*' exceeds configured percentage 10 % \(free percentage: 11 %\)/,
       'result cleanup early abort logged';
     is $job->{state}, 'finished', 'result cleanup still considered successful';
     like $job->{result},
@@ -74,7 +74,7 @@ subtest 'abort early if there is enough free disk space' => sub {
 
     $app->config->{misc_limits}->{asset_cleanup_max_free_percentage} = 9;
     combined_like { $job = run_gru_job($app, limit_assets => []) }
-    qr/Skipping, free disk space on '.*' exceeds configured percentage 9 % \(free percentage: 11 %\)/,
+    qr/Skipping, free storage space on '.*' exceeds configured percentage 9 % \(free percentage: 11 %\)/,
       'asset cleanup early abort logged';
     is $job->{state}, 'finished', 'asset cleanup still considered successful';
     like $job->{result},
@@ -83,16 +83,17 @@ subtest 'abort early if there is enough free disk space' => sub {
 
     my @check_args = (job => $app->minion->job($job->{id}), setting => 'result_cleanup_max_free_percentage', dir => '');
     $job->{state} = undef;
-    combined_like { ok !finish_job_if_disk_usage_below_percentage(@check_args, setting => 'foo'),
+    combined_like { ok !finish_job_if_storage_usage_below_percentage(@check_args, setting => 'foo'),
         'invalid setting ignored' } qr/Specified value.*will be ignored/, 'warning about invalid setting logged';
 
     $df_mock->redefine(df => sub { die 'df failed' });
-    combined_like { ok !finish_job_if_disk_usage_below_percentage(@check_args), 'invalid df ignored' }
+    combined_like { ok !finish_job_if_storage_usage_below_percentage(@check_args), 'invalid df ignored' }
       qr/df failed.*Proceeding with cleanup/s, 'warning about invalid df logged';
 
     %df_main_storage = (bavail => 10, blocks => 100);
     $mock_df->();
-    ok !finish_job_if_disk_usage_below_percentage(@check_args), 'cleanup done if not enough free disk space available';
+    ok !finish_job_if_storage_usage_below_percentage(@check_args),
+      'cleanup done if not enough free disk space available';
     is $job->{state}, undef, 'job not finished when proceeding with cleanup';
 };
 
@@ -106,7 +107,7 @@ subtest 'abort early during the loop' => sub {
     my $group_bar = $app->schema->resultset('JobGroups')->create({name => 'bar'});
     my $loop_job;
     combined_like { $loop_job = run_gru_job($app, limit_results_and_logs => []) }
-qr/Early abort during job groups loop \(halted before processing group 'bar'\): Skipping, free disk space on '.*' exceeds configured percentage 10 % \(free percentage: 20 %\)/,
+qr/Early abort during job groups loop \(halted before processing group 'bar'\): Skipping, free storage space on '.*' exceeds configured percentage 10 % \(free percentage: 20 %\)/,
       'early abort during loop logged';
     is $loop_job->{state}, 'finished', 'result cleanup still considered successful';
     like $loop_job->{notes}->{early_abort_results},
@@ -119,7 +120,7 @@ qr/Early abort during job groups loop \(halted before processing group 'bar'\): 
 
 $app->config->{misc_limits}->{result_cleanup_max_free_percentage} = 100;
 $app->config->{misc_limits}->{asset_cleanup_max_free_percentage} = 100;
-$app->config->{misc_limits}->{dry_min_free_disk_space_cleanup} = 1;
+$app->config->{misc_limits}->{cleanup_min_free_dry_run} = 1;
 
 # mock the actual deletion of videos and results; it it tested elsewhere
 my $job_mock = Test::MockModule->new('OpenQA::Schema::Result::Jobs');
@@ -150,7 +151,7 @@ $job_mock->redefine(
 # note: Not adjusting $available_bytes_mock in these functions because the code does not rely on df except for the initial check.
 
 # turn on the cleanup
-$app->config->{misc_limits}->{results_min_free_disk_space_percentage} = 20;
+$app->config->{misc_limits}->{result_cleanup_min_free_percentage} = 20;
 
 subtest 'df returns bad data' => sub {
     %df_main_storage = (bavail => 10, blocks => 5);
@@ -314,9 +315,9 @@ subtest 'jobs in archive not considered by default' => sub {
       'not finished as job that could gain disk space is in the archive';
 };
 
-subtest 'jobs in archive considered via archive_min_free_disk_space_percentage' => sub {
+subtest 'jobs in archive considered via archive_cleanup_min_free_percentage' => sub {
     # setup: as in the previous subtest but this time the job is supposed to be deleted from the archive
-    $app->config->{misc_limits}->{archive_min_free_disk_space_percentage} = 31;
+    $app->config->{misc_limits}->{archive_cleanup_min_free_percentage} = 31;
 
     my @expected_messages = (
         'Unable to cleanup enough results from results dir',
@@ -337,7 +338,7 @@ subtest 'jobs in archive considered via archive_min_free_disk_space_percentage' 
 
 subtest 'archive cleanup skipped if archive not full; result dir cleanup still attempted' => sub {
     # setup: as in the previous subtest but this time the archive is not full
-    $app->config->{misc_limits}->{archive_min_free_disk_space_percentage} = 30;
+    $app->config->{misc_limits}->{archive_cleanup_min_free_percentage} = 30;
 
     my @expected_messages = ('Unable to cleanup enough results from results dir', 'Nothing to do for archive');
     my $job = job_log_like qr/
@@ -352,8 +353,8 @@ subtest 'archive cleanup skipped if archive not full; result dir cleanup still a
 
 subtest 'deleted screenshots always accounted to main storage' => sub {
     # setup: assume that only the deletion of screenshots has freed the disk space when deleting archived job
-    $app->config->{misc_limits}->{dry_min_free_disk_space_cleanup} = 0;
-    $app->config->{misc_limits}->{archive_min_free_disk_space_percentage} = 31;
+    $app->config->{misc_limits}->{cleanup_min_free_dry_run} = 0;
+    $app->config->{misc_limits}->{archive_cleanup_min_free_percentage} = 31;
     %gained_disk_space_by_deleting_results_of_job = ();
     %gained_disk_space_by_deleting_screenshots_of_job = ($important_job_id => 1);
     $dry_run_expected = 0;

--- a/t/config.t
+++ b/t/config.t
@@ -155,6 +155,45 @@ subtest 'Test configuration override from file' => sub {
       'default job_storage_duration extended to result_storage_duration (no group)';
 };
 
+subtest 'Test deprecated cleanup config keys' => sub {
+    my $t_dir = tempdir;
+    local $ENV{OPENQA_CONFIG} = $t_dir;
+    OpenQA::App->set_singleton(my $app = Mojolicious->new(log => $quiet_log));
+
+    my @data = (
+        "[misc_limits]\n",
+        "results_min_free_disk_space_percentage = 15\n",
+        "archive_min_free_disk_space_percentage = 25\n",
+        "dry_min_free_disk_space_cleanup = 1\n",
+    );
+    $t_dir->child('openqa.ini')->spew(join '', @data);
+
+    combined_like sub { OpenQA::Setup::read_config($app) },
+qr/Deprecated use of config key '\[misc_limits\]: results_min_free_disk_space_percentage'.*Deprecated use of config key '\[misc_limits\]: archive_min_free_disk_space_percentage'.*Deprecated use of config key '\[misc_limits\]: dry_min_free_disk_space_cleanup'/s,
+      'warns for deprecated keys';
+
+    is $app->config->{misc_limits}->{result_cleanup_min_free_percentage}, 15,
+      'results_min_free_disk_space_percentage mapped correctly';
+    is $app->config->{misc_limits}->{archive_cleanup_min_free_percentage}, 25,
+      'archive_min_free_disk_space_percentage mapped correctly';
+    is $app->config->{misc_limits}->{cleanup_min_free_dry_run}, 1, 'dry_min_free_disk_space_cleanup mapped correctly';
+
+    # Conflict test
+    my $t_dir2 = tempdir;
+    local $ENV{OPENQA_CONFIG} = $t_dir2;
+    my $app2 = Mojolicious->new(log => $quiet_log);
+    my @data2 = (
+        "[misc_limits]\n",
+        "results_min_free_disk_space_percentage = 15\n",
+        "result_cleanup_min_free_percentage = 33\n",
+    );
+    $t_dir2->child('openqa.ini')->spew(join '', @data2);
+    combined_like sub { OpenQA::Setup::read_config($app2) },
+qr/Conflict: both 'results_min_free_disk_space_percentage' \(deprecated\) and 'result_cleanup_min_free_percentage' are set/,
+      'warns on conflict';
+    is $app2->config->{misc_limits}->{result_cleanup_min_free_percentage}, 33, 'preferred the new key value';
+};
+
 subtest 'openqa.ini documentation check' => sub {
     my $defaults = OpenQA::Setup::default_config();
     my $ini_path = path($FindBin::Bin)->child('..', 'etc', 'openqa', 'openqa.ini');
@@ -183,7 +222,10 @@ subtest 'openqa.ini documentation check' => sub {
               =~ /^(scm|parallel_children_collapsable_results_sel|file_domain|prio_throttling_data|access_control_allow_origin_header|changelog_file|file_subdomain|search_results_limit)$/;
             next if $section eq 'hypnotoad';
             next if $section eq 'job_settings_ui' && $key eq 'default_data_dir';
-            next if $section eq 'misc_limits' && $key =~ /^(prio_throttling_data|prio_group_data|mcp_max_result_size)$/;
+            next
+              if $section eq 'misc_limits'
+              && $key
+              =~ /^(prio_throttling_data|prio_group_data|mcp_max_result_size|results_min_free_disk_space_percentage|archive_min_free_disk_space_percentage|dry_min_free_disk_space_cleanup)$/;
             next if $section eq 'rate_limits' && $key eq 'search';
             next if $section eq 'secrets';
             next if $section eq 'audit' && $key eq 'blacklist';

--- a/templates/webapi/admin/group/group_property_editor.html.ep
+++ b/templates/webapi/admin/group/group_property_editor.html.ep
@@ -267,9 +267,9 @@
                     <span id="editor-info">
                         <div>All time-related properties (measured in days) can be set to <em>0</em> to denote infinity.</div>
                         % my $limits = app->config->{misc_limits};
-                        % if ($limits->{results_min_free_disk_space_percentage} || $limits->{archive_min_free_disk_space_percentage}) {
+                        % if ($limits->{result_cleanup_min_free_percentage} || $limits->{archive_cleanup_min_free_percentage}) {
                         <div>
-                            Results and logs might be deleted earlier than configured to prevent running out of disk space. In this case only videos are deleted at
+                            Results and logs might be deleted earlier than configured to prevent running out of storage space. In this case only videos are deleted at
                             first and only if that is not sufficient the results are deleted. Important jobs are only considered if deleting other jobs was not sufficient.
                             The affected jobs will stay visible on the web UI in any case; only the videos and possibly logs and screenshots will be gone.
                         </div>


### PR DESCRIPTION
### Motivation
During result cleanup, important job results are deleted if results storage is full although they could be moved to the archive instead. This PR introduces upfront archiving under storage pressure before deletions occur. It also renames cleanup settings and helpers to be storage-centric, resolving a naming trap for operators.

### Design Choices
- **Storage-centric rename (feat/refactor):** Renamed `results_min_free_disk_space_percentage` and siblings to `_cleanup_min_free_percentage` and `_storage_` in code identifiers, aligning with other scheduler thresholds. Backwards compatibility is preserved via mapping with deprecation/conflict warnings.
- **Upfront archiving (feat):** Added a sequential upfront archiving phase for important jobs in `_limit` (before any deletion starts). Stops if the results threshold is reached, the archive floor is reached, the time budget is exceeded, or no candidates remain.

### Benefits
- Safely preserves important test results under storage pressure before deletion is triggered.
- Eliminates settings/terminology confusion for operators while keeping existing configurations backwards-compatible.

Related issue: https://progress.opensuse.org/issues/195560

After:
* #7777