### PR TITLE
feat: Allow querying the number of restarts via the jobs API

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -443,6 +443,11 @@ children and parents, job id, group id, name, parent group id and name, priority
 settings, state and times of startup and finish of the job.
 Pass follow=1 as query param to follow job clones and report most recent result for given id.
 
+Pass ancestors=1 as query parameter to include how many restarts have happened until the
+current job.
+Pass descendants=1 as query parameter to include how many restarts have happened as of the
+current job.
+
 =back
 
 =cut

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -455,7 +455,7 @@ sub show ($self) {
     my $unredacted = $self->param('unredacted') && $self->is_operator;
     return unless my $job = $self->find_job_or_render_not_found($job_id, $follow ? {prefetch => 'settings'} : {});
     $job = $job->latest_job if $follow;
-    $job = $job->to_hash(
+    my $job_data = $job->to_hash(
         assets => 1,
         check_assets => $check_assets,
         deps => 1,
@@ -463,8 +463,11 @@ sub show ($self) {
         parent_group => 1,
         unredacted => $unredacted,
     );
-    $job->{followed_id} = $job_id if ($job_id != $job->{id});
-    $self->render(json => {job => $job});
+    $job_data->{followed_id} = $job_id if $job_id != $job_data->{id};
+    for my $param (qw(ancestors descendants)) {
+        $job_data->{$param} = $job->$param if $self->param($param);
+    }
+    $self->render(json => {job => $job_data});
 }
 
 =over 4

--- a/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Job.pm
@@ -441,7 +441,9 @@ sub create ($self) {
 Shows details for a specific job, such as the assets associated, assigned worker id,
 children and parents, job id, group id, name, parent group id and name, priority, result,
 settings, state and times of startup and finish of the job.
-Pass follow=1 as query param to follow job clones and report most recent result for given id.
+
+Pass follow=1 as query parameter to follow job restarts and report most the recent result
+for the specified job id.
 
 Pass ancestors=1 as query parameter to include how many restarts have happened until the
 current job.
@@ -605,14 +607,16 @@ sub update_status ($self) {
 Retrieve status of a job. Returns id, state, result, blocked_by_id.
 Preferable over /job/<id> for performance and payload size, if you are only
 interested in the status.
-Pass follow=1 as query param to follow job clones and report most recent result for given id.
+
+Pass follow=1 as query parameter to follow job restarts and report most the recent result
+for the specified job id.
 
 =back
 
 =cut
 
 sub get_status ($self) {
-    my $follow = $self->param('follow');    # follow job clones and report most recent result for given id
+    my $follow = $self->param('follow');    # follow job restarts and report most recent result for given id
     my @fields = qw(id state result blocked_by_id);
     my $jobid = $self->stash('jobid');
     return unless my $job = $self->find_job_or_render_not_found($jobid);

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -349,6 +349,15 @@ subtest 'jobs for job settings' => sub {
       ->json_is({jobs => [99926]});
 };
 
+subtest 'query number of restarts' => sub {
+    $t->get_ok('/api/v1/jobs/99944?ancestors=1&descendants=1')->status_is(200);
+    $t->json_is('/job/ancestors', 0)->json_is('/job/descendants', 2);
+    $t->get_ok('/api/v1/jobs/99945?ancestors=1&descendants=1')->status_is(200);
+    $t->json_is('/job/ancestors', 1)->json_is('/job/descendants', 1);
+    $t->get_ok('/api/v1/jobs/99946?ancestors=1&descendants=1')->status_is(200);
+    $t->json_is('/job/ancestors', 2)->json_is('/job/descendants', 0);
+};
+
 $schema->txn_begin;
 
 subtest 'restart jobs, error handling' => sub {


### PR DESCRIPTION
This helps external scripts that retry openQA jobs (such as `openqa-label-known-issues`) as such scripts no longer need to go though the possibly long chain of jobs manually to figure out whether the job has already been restarted often enough.

The use would look like this: https://github.com/os-autoinst/os-autoinst-scripts/pull/670