### PR TITLE
feat: Retry jobs that exceed the max setup time automatically

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -743,7 +743,7 @@ where:
 - `regex_n`: a regex to match the value of `parameter_n` against
 
 Patterns like `…:=~^$` can be used to adjust the priority if a parameter does
-*not* exist or is empty. (Patterns are normally ignored if the parameter they
+_not_ exist or is empty. (Patterns are normally ignored if the parameter they
 refer to does not exist.)
 
 The final priority of a job is the sum of a base priority, defined in the job

--- a/etc/openqa/openqa.ini
+++ b/etc/openqa/openqa.ini
@@ -106,7 +106,7 @@
 
 ## Causes jobs reported as incomplete by the worker to be cloned automatically when the
 ## reason matches; set to 0 to disable
-#auto_clone_regex = ^(cache failure: |terminated prematurely: |api failure: Failed to register .* 503|backend died: .*VNC.*(timeout|timed out|refused)|QEMU terminated: Failed to allocate KVM HPT of order 25.* Cannot allocate memory)
+#auto_clone_regex = ^(cache failure: |terminated prematurely: |api failure: Failed to register .* 503|backend died: .*VNC.*(timeout|timed out|refused)|QEMU terminated: Failed to allocate KVM HPT of order 25.* Cannot allocate memory|timeout: setup exceeded MAX_SETUP_TIME)
 ## The maximum amount of times a job will be restarted if the auto_clone_regex matches
 #auto_clone_limit = 20
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -2262,7 +2262,10 @@ sub _compute_result_and_reason ($self, $new_val, $result, $reason, $restart) {
         # restart incompletes when the reason matches the configured regex
         my $append_reason = '';
         my $auto_clone_regex = OpenQA::App->singleton->config->{global}->{auto_clone_regex};
-        if ($result eq INCOMPLETE and $auto_clone_regex and $reason =~ $auto_clone_regex) {
+        if (    ($result eq INCOMPLETE || $result eq TIMEOUT_EXCEEDED)
+            and $auto_clone_regex
+            and $reason =~ $auto_clone_regex)
+        {
             my $limit = OpenQA::App->singleton->config->{global}{auto_clone_limit};
             my $ancestors = $self->incomplete_ancestors($limit + 1);
             # how many of those incomplete ancestors had a reason not matching auto_clone?


### PR DESCRIPTION
This re-uses the `auto_clone_regex` which was previously only used for incomplete jobs. That means a job will be restarted up to `auto_clone_limit` times (20 times by default).

Related ticket: https://progress.opensuse.org/issues/205908