### PR TITLE
docs(Installing.md): fix Prettier emphasis style in Installing.md

### DIFF
--- a/docs/Installing.md
+++ b/docs/Installing.md
@@ -743,7 +743,7 @@ where:
 - `regex_n`: a regex to match the value of `parameter_n` against
 
 Patterns like `…:=~^$` can be used to adjust the priority if a parameter does
-*not* exist or is empty. (Patterns are normally ignored if the parameter they
+_not_ exist or is empty. (Patterns are normally ignored if the parameter they
 refer to does not exist.)
 
 The final priority of a job is the sum of a base priority, defined in the job


### PR DESCRIPTION
Use underscore emphasis (_not_) instead of asterisks (*not*) to satisfy the `prettier --check "docs/**/*.md"` lint step, which was failing CI.