### PR TITLE
fix: avoid reloading inactive worker slots via try-reload-or-restart

### DIFF
--- a/dist/rpm/openQA.spec
+++ b/dist/rpm/openQA.spec
@@ -600,7 +600,7 @@ fi
 #        "$1 -ge 1" checks for a package upgrade
 if [ -x /usr/bin/systemctl ] && [ $1 -ge 1 ]; then
     /usr/bin/systemctl daemon-reload || :
-    /usr/bin/systemctl reload-or-restart 'openqa-worker-auto-restart@*.service' || :
+    /usr/bin/systemctl try-reload-or-restart 'openqa-worker-auto-restart@*.service' || :
 fi
 
 %postun auto-update

--- a/systemd/openqa-reload-worker-auto-restart@.service
+++ b/systemd/openqa-reload-worker-auto-restart@.service
@@ -3,5 +3,5 @@ Description=Restart openqa-worker-auto-restart@%i.service ASAP without interrupt
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl reload-or-restart openqa-worker-auto-restart@%i.service
+ExecStart=/usr/bin/systemctl try-reload-or-restart openqa-worker-auto-restart@%i.service
 Slice=openqa-worker.slice


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/203220

Using `reload-or-restart` will reload or start the service if it is not currently running.
By changing this to `try-reload-or-restart`, systemd will only attempt the action if the service is already active, preventing the accidental reload of inactive or disabled worker slots during package upgrades or configuration reloads.