### PR TITLE
Stop checking session_id of MCP client

### DIFF
--- a/t/api/17-mcp.t
+++ b/t/api/17-mcp.t
@@ -32,7 +32,6 @@ subtest 'Authentication' => sub {
 };
 
 subtest 'Start session' => sub {
-    my $result = $client->initialize_session;
     is $result->{serverInfo}{name}, 'openQA', 'server name';
     is $result->{serverInfo}{version}, '1.0.0', 'server version';
     ok $result->{capabilities}, 'has capabilities';

--- a/t/api/17-mcp.t
+++ b/t/api/17-mcp.t
@@ -32,12 +32,10 @@ subtest 'Authentication' => sub {
 };
 
 subtest 'Start session' => sub {
-    is $client->session_id, undef, 'no session id';
     my $result = $client->initialize_session;
     is $result->{serverInfo}{name}, 'openQA', 'server name';
     is $result->{serverInfo}{version}, '1.0.0', 'server version';
     ok $result->{capabilities}, 'has capabilities';
-    ok $client->session_id, 'session id set';
 };
 
 subtest 'List tools' => sub {


### PR DESCRIPTION
That API is no longer available in future versions and also not needed anymore.

Fixes: https://progress.opensuse.org/issues/206058