### PR TITLE
test: Drop subtest covering MCP client initialization

### DIFF
--- a/t/api/17-mcp.t
+++ b/t/api/17-mcp.t
@@ -31,15 +31,6 @@ subtest 'Authentication' => sub {
     $t->get_ok('/mcp')->status_is(405);
 };
 
-subtest 'Start session' => sub {
-    is $client->session_id, undef, 'no session id';
-    my $result = $client->initialize_session;
-    is $result->{serverInfo}{name}, 'openQA', 'server name';
-    is $result->{serverInfo}{version}, '1.0.0', 'server version';
-    ok $result->{capabilities}, 'has capabilities';
-    ok $client->session_id, 'session id set';
-};
-
 subtest 'List tools' => sub {
     my $result = $client->list_tools;
     is scalar @{$result->{tools}}, 3, 'three tools available';


### PR DESCRIPTION
That API is no longer available in future versions.

Note that this makes the test fail with older versions.

Fixes: https://progress.opensuse.org/issues/206058