### PR TITLE
audit_log: Fix audit log help visibility

### DIFF
--- a/templates/webapi/admin/audit_log/index.html.ep
+++ b/templates/webapi/admin/audit_log/index.html.ep
@@ -25,28 +25,26 @@
                 By default, the filter will only consider the <em>Event data</em> column.
                 The following key words can be used to filter the other columns:
             </p>
-            <table class="table">
-                <tr>
-                    <td><code>older:yyyy/mm/dd</code></td>
-                    <td>events older than the specified date</td>
-                </tr>
-                <tr>
-                    <td><code>newer:yyyy/mm/dd</code></td>
-                    <td>events newer than the specified date</td>
-                </tr>
-                <tr>
-                    <td><code>user:string</code></td>
-                    <td><em>User</em> column</td>
-                </tr>
-                <tr>
-                    <td><code>event:string</code></td>
-                    <td><em>Event</em> column</td>
-                </tr>
-                <tr>
-                    <td><code>data:string</code></td>
-                    <td><em>Event data</em> column</td>
-                </tr>
-            </table>
+            <p>
+                <code>older:yyyy/mm/dd</code>:<br>
+                events older than the specified date
+            </p>
+            <p>
+                <code>newer:yyyy/mm/dd</code>:<br>
+                events newer than the specified date
+            </p>
+            <p>
+                <code>user:string</code>:<br>
+                <em>User</em> column
+            </p>
+            <p>
+                <code>event:string</code>:<br>
+                <em>Event</em> column
+            </p>
+            <p>
+                <code>data:string</code>:<br>
+                <em>Event data</em> column
+            </p>
             <p>
                 <strong>Example</strong><br>
                 <code>user:Demo newer:15 days older:2016/12/14 event:job_restart</code>


### PR DESCRIPTION
Current audit log table in clickable help was not visible (tested on Chromium and Firefox):

<img width="542" height="305" alt="auditlog-broken-help" src="https://github.com/user-attachments/assets/25edbd62-07cc-4cf1-befe-16e1098aa58a" />

Convert `<table>` to `<p>`, with `<code>`, `<strong>` and `<br>` (the HTML used in example below, which is visible).

@Martchus @okurz Could you please test this? I don't have working instance where I could test it.