### PR TITLE
fix(openqa-clone-job): Avoid error when checking incident repos

### DIFF
--- a/lib/OpenQA/Script/CloneJobSUSE.pm
+++ b/lib/OpenQA/Script/CloneJobSUSE.pm
@@ -46,7 +46,8 @@ sub verify_incident_repos ($url_handler, $incident_repos, $unexpanded = []) {
 sub detect_maintenance_update ($jobid, $url_handler, $settings) {
     return undef if $settings->{SKIP_MAINTENANCE_UPDATES};
     my $urls = collect_incident_repos($url_handler, $settings);
-    die "Current job $jobid will fail, because the repositories for the below updates are unavailable\n" . pp($urls)
+    die sprintf "Current job $jobid will fail, because the repositories for the below updates are unavailable:\n%s\n",
+      (join "\n", @$urls)
       if @$urls;
 }
 

--- a/lib/OpenQA/Script/CloneJobSUSE.pm
+++ b/lib/OpenQA/Script/CloneJobSUSE.pm
@@ -29,7 +29,7 @@ sub collect_incident_repos ($url_handler, $settings) {
 
 sub verify_incident_repos ($url_handler, $incident_repos, $unexpanded = []) {
     my @incident_urls;
-    my $ua = $url_handler->{ua};
+    my $ua = $url_handler->{remote};
     foreach my $incident (split /,/, $incident_repos) {
         my @vars = grep { $incident =~ /%\Q$_\E%/ } @$unexpanded;
         if (@vars) {
@@ -38,7 +38,7 @@ sub verify_incident_repos ($url_handler, $incident_repos, $unexpanded = []) {
 "URL '$incident' contains unexpanded variables: $vars_str. Specify the necessary variables at the command line for expansion. Skipping verification.\n";
             next;
         }
-        push @incident_urls, $incident unless $ua->get($incident)->is_success;
+        push @incident_urls, $incident unless $ua->get($incident)->res->is_success;
     }
     return \@incident_urls;
 }

--- a/t/35-script_clone_job_suse.t
+++ b/t/35-script_clone_job_suse.t
@@ -13,20 +13,28 @@ use OpenQA::Script::CloneJobSUSE qw(detect_maintenance_update);
 use Mojo::URL;
 
 # define fake client
-package Test::FakeLWPUserAgentMirrorResult {
+package Test::FakeUserAgentRes {
     use Mojo::Base -base, -signatures;
     has is_success => 1;
 }    # uncoverable statement
 
-package Test::FakeLWPUserAgent {
+package Test::FakeUserAgentTxn {
+    use Mojo::Base -base, -signatures;
+    has res => sub { Test::FakeUserAgentRes->new };
+}    # uncoverable statement
+
+package Test::FakeUserAgent {
     use Mojo::Base -base, -signatures;
     has is_validrepo => 1;
-    sub get ($self, $url) { Test::FakeLWPUserAgentMirrorResult->new(is_success => $self->is_validrepo) }
+
+    sub get ($self, $url) {
+        Test::FakeUserAgentTxn->new(res => Test::FakeUserAgentRes->new(is_success => $self->is_validrepo));
+    }
 }    # uncoverable statement
 
 sub create_mock () {
-    my $fake_ua = Test::FakeLWPUserAgent->new;
-    my %url_handler = (remote_url => Mojo::URL->new('http://foo'), ua => $fake_ua);
+    my $fake_ua = Test::FakeUserAgent->new;
+    my %url_handler = (remote_url => Mojo::URL->new('http://foo'), remote => $fake_ua);
     return ($fake_ua, \%url_handler);
 }
 


### PR DESCRIPTION
* Use the `Mojo::UserAgent` from `$url_handler->{remote}` as the LWP user agent from `$url_handler->{ua}` no longer exists

Related ticket: https://progress.opensuse.org/issues/206076