### PR TITLE
feat: Add "Strict scenario" checkbox on "Investigation" tab

### DIFF
--- a/assets/javascripts/test_result.js
+++ b/assets/javascripts/test_result.js
@@ -444,6 +444,20 @@ function setupTabHandling() {
       deactivateTab(tabNameForNavElement(e.relatedTarget));
     }
   });
+  const strictToggle = document.getElementById('investigation_strict');
+  if (strictToggle) {
+    strictToggle.checked = parseQueryParams().investigation_strict?.[0] !== '0';
+    strictToggle.addEventListener('change', function () {
+      const p = parseQueryParams();
+      if (strictToggle.checked) {
+        delete p.investigation_strict;
+      } else {
+        p.investigation_strict = ['0'];
+      }
+      updateQueryParams(p);
+      loadTabPanelElement('investigation', tabConfiguration.investigation);
+    });
+  }
   // show relevant nav elements from the start
   showRelevantTabNavElements();
   // change tab when the hash changes and process initial hash
@@ -557,11 +571,24 @@ function loadTabPanelElement(tabName, tabConfig) {
   if (!tabPanelElement) {
     return false;
   }
-  const ajaxUrl = tabPanelElement.dataset.src;
+  let ajaxUrl = tabPanelElement.dataset.src;
   if (!ajaxUrl) {
     return false;
   }
-  tabConfig.panelElement = tabPanelElement; // for easier access in custom renderers
+  let container = tabPanelElement;
+  if (tabName === 'investigation') {
+    const contentContainer = document.getElementById('investigation_content');
+    if (contentContainer) {
+      container = contentContainer;
+    }
+    const strictToggle = document.getElementById('investigation_strict');
+    if (strictToggle) {
+      const url = new URL(ajaxUrl, window.location.origin);
+      url.searchParams.set('strict', strictToggle.checked ? '1' : '0');
+      ajaxUrl = url.pathname + url.search;
+    }
+  }
+  tabConfig.panelElement = container; // for easier access in custom renderers
   if (tabConfig._abortController) {
     tabConfig._abortController.abort();
   }
@@ -587,12 +614,12 @@ function loadTabPanelElement(tabName, tabConfig) {
       if (customRenderer) {
         return customRenderer.call(tabConfig, error);
       }
-      tabPanelElement.innerHTML = '';
-      tabPanelElement.appendChild(
+      container.innerHTML = '';
+      container.appendChild(
         document.createTextNode(`Unable to load ${tabConfig.descriptiveName || tabName}: ${error}`)
       );
     });
-  tabPanelElement.innerHTML =
+  container.innerHTML =
     '<p style="text-align: center;"><i class="fa-solid fa-spinner fa-spin fa-lg"></i> Loading ' +
     (tabConfig.descriptiveName || tabName) +
     '…</p>';

--- a/docs/UsersGuide.md
+++ b/docs/UsersGuide.md
@@ -162,10 +162,10 @@ for two jobs to share a history:
 - explicit keys (e.g. `_HISTORY_ISOLATION_KEYS=PR_ID,SUBMISSION_ID`): exactly
   those keys, overriding or extending the default.
 
-Carry-over and investigation isolate on all declared keys automatically. The
-"Next & Previous" tab keeps showing the generalized history by default and
-offers a switch to the isolated ("strict") view when a job has isolation keys
-in effect.
+Carry-over isolates on all declared keys automatically. The "Investigation" tab
+(which isolates by default) and the "Next & Previous" tab (which shows the
+generalized history by default) both offer a "Strict scenario" checkbox when
+isolation keys are in effect, allowing you to easily toggle history isolation.
 
 ### Test Suites
 

--- a/lib/OpenQA/Schema/Result/Jobs.pm
+++ b/lib/OpenQA/Schema/Result/Jobs.pm
@@ -1987,7 +1987,8 @@ good" job in the same scenario.
 sub investigate ($self, %args) {
     # isolate on all declared history isolation keys so "last good" refers to
     # this job's own isolated history (e.g. the same PR), not an unrelated one
-    my @previous = $self->_previous_scenario_jobs(undef, {}, undef);
+    my $isolation_keys = exists $args{isolation_keys} ? $args{isolation_keys} : undef;
+    my @previous = $self->_previous_scenario_jobs(undef, {}, $isolation_keys);
     return {error => 'No previous job in this scenario, cannot provide hints'} unless @previous;
     my %inv;
     return {error => 'No result directory available for current job'} unless $self->result_dir();

--- a/lib/OpenQA/WebAPI/Controller/Test.pm
+++ b/lib/OpenQA/WebAPI/Controller/Test.pm
@@ -1246,7 +1246,9 @@ sub dependencies ($self) {
 sub investigate ($self) {
     return $self->reply->not_found unless my $job = $self->_get_current_job;
     my $git_limit = OpenQA::App->singleton->config->{global}->{job_investigate_git_log_limit} // HTTP_OK;
-    my $investigation = $job->investigate(git_limit => $git_limit);
+    my $strict = $self->param('strict') // '1';
+    my $isolation_keys = $strict && $strict ne '0' ? undef : [];
+    my $investigation = $job->investigate(git_limit => $git_limit, isolation_keys => $isolation_keys);
     $self->render(json => $investigation);
 }
 

--- a/t/10-jobs.t
+++ b/t/10-jobs.t
@@ -944,11 +944,7 @@ subtest 'AMQP event emission for job restarts within Minion tasks' => sub {
     my @event_body;
     my $io_loop_mock = Test::MockModule->new('Mojo::IOLoop');
     $io_loop_mock->redefine(start => sub { });
-    $plugin_mock->redefine(
-        publish_amqp => sub ($self, $topic, $data) {
-            $published{$topic} = $data;
-            Mojo::IOLoop->next_tick(sub { OpenQA::Events->singleton->emit('amqp_handled'); });
-        });
+    $plugin_mock->redefine(publish_amqp => sub ($self, $topic, $data) { $published{$topic} = $data });
 
     my $events_mock = Test::MockModule->new('OpenQA::Events');
     $events_mock->redefine(
@@ -985,6 +981,10 @@ subtest 'AMQP event emission for job restarts within Minion tasks' => sub {
     ok exists $data->{result}->{$job_id}, 'old job id is in result';
     $job->discard_changes;
     is $job->clone_id, $data->{result}->{$job_id}, 'clone_id points to reported id';
+
+    OpenQA::Events->singleton->unsubscribe("openqa_$_")
+      for
+      qw(job_create job_delete job_cancel job_restart job_update_result job_done comment_create comment_update comment_delete);
 };
 
 subtest '"race" between status updates and stale job detection' => sub {
@@ -1313,6 +1313,15 @@ subtest 'history isolation keys separate the scenario history' => sub {
         $cur->create_result_dir;
         my $inv = $cur->investigate;
         is $inv->{last_good}{link}, '/tests/' . $good_same->id, 'last good is the same-PR job, not the newer other PR';
+
+        my $inv_non_strict = $cur->investigate(isolation_keys => []);
+        is $inv_non_strict->{last_good}{link}, '/tests/' . $good_other->id,
+          'non-strict investigation picks the newer other PR';
+
+        $t->get_ok('/tests/' . $cur->id . '/investigation_ajax')->status_is(200);
+        $t->json_is('/last_good/link' => '/tests/' . $good_same->id);
+        $t->get_ok('/tests/' . $cur->id . '/investigation_ajax?strict=0')->status_is(200);
+        $t->json_is('/last_good/link' => '/tests/' . $good_other->id);
     };
 };
 

--- a/t/ui/18-tests-details.t
+++ b/t/ui/18-tests-details.t
@@ -17,7 +17,7 @@ use Mojo::IOLoop;
 use Mojo::URL;
 use OpenQA::Test::TimeLimit '40';
 use OpenQA::Test::Case;
-use OpenQA::Test::Utils qw(prepare_clean_needles_dir prepare_default_needle);
+use OpenQA::Test::Utils qw(prepare_clean_needles_dir prepare_default_needle wait_for);
 use OpenQA::Client;
 use OpenQA::Jobs::Constants;
 use OpenQA::SeleniumTest;
@@ -983,6 +983,30 @@ subtest 'test duration' => sub {
     );
     my $duration = $t->app->format_time_duration($end - $start);
     like $duration, qr/2 days 02:30 hours/, 'duration formatted';
+};
+
+subtest 'strict scenario toggle on investigation tab' => sub {
+    my $job = $jobs->find(99940);
+    $job->settings->create({key => 'SUBMISSION_ID', value => 'abc'});
+    $job->discard_changes;
+
+    $driver->get('/tests/99940');
+    wait_for_ajax msg => 'details tab for job 99940 loaded';
+    $driver->find_element_by_link_text('Investigation')->click;
+    wait_for_element selector => '#investigation_status_entry', desc => 'investigation tab contents loaded';
+
+    my $toggle = wait_for_element selector => '#investigation_strict', desc => 'strict toggle present';
+    ok $toggle->is_selected, 'strict scenario checkbox is checked by default';
+
+    $toggle->click;
+    wait_for_url qr/investigation_strict=0/, 'URL reflects the non-strict view';
+    ok !$toggle->is_selected, 'strict scenario checkbox is unchecked';
+    wait_for_element selector => '#investigation_status_entry', desc => 'investigation tab contents re-loaded';
+
+    $toggle->click;
+    wait_for { $driver->get_current_url !~ qr/investigation_strict/ } 'investigation reloaded after enabling strict';
+    unlike $driver->get_current_url, qr/investigation_strict/, 'URL does not contain investigation_strict anymore';
+    ok $toggle->is_selected, 'strict scenario checkbox is checked';
 };
 
 kill_driver();

--- a/templates/webapi/test/job_next_previous.html.ep
+++ b/templates/webapi/test/job_next_previous.html.ep
@@ -34,15 +34,7 @@
         </div>
     </div>
 </div>
-% my $isolation_keys = $job->history_isolation_keys;
-% if ($isolation_keys && @$isolation_keys) {
-    <div class="form-check form-switch mb-2">
-        <input class="form-check-input" type="checkbox" role="switch" id="next_previous_strict">
-        <label class="form-check-label" for="next_previous_strict">
-            Strict scenario (isolate history by <%= join ', ', @$isolation_keys %>)
-        </label>
-    </div>
-% }
+%= include 'test/strict_scenario_checkbox', id => 'next_previous_strict', checked => 0
 <div>
     <table id="job_next_previous_table" class="overview table table-striped no-wrap" style="width: 100%"
       data-ajax-url="<%= url_for('job_next_previous_ajax', testid => $testid) %>">

--- a/templates/webapi/test/result.html.ep
+++ b/templates/webapi/test/result.html.ep
@@ -89,7 +89,10 @@
                     <div role="tabpanel" class="tab-pane" id="dependencies" data-src="<%= url_for('test_dependencies', testid => $testid) %>" data-current-job-id="<%= $testid %>"></div>
                 % }
                 % if ($show_investigation) {
-                    <div role="tabpanel" class="tab-pane" id="investigation" data-src="<%= url_for('test_investigation', testid => $testid) %>"></div>
+                    <div role="tabpanel" class="tab-pane" id="investigation" data-src="<%= url_for('test_investigation', testid => $testid) %>">
+                        %= include 'test/strict_scenario_checkbox', id => 'investigation_strict', checked => 1
+                        <div id="investigation_content"></div>
+                    </div>
                 % }
                 <div role="tabpanel" class="tab-pane" id="comments" data-src="<%= url_for('test_comments', testid => $testid) %>"></div>
                 <div role="tabpanel" class="tab-pane" id="next_previous">

--- a/templates/webapi/test/strict_scenario_checkbox.html.ep
+++ b/templates/webapi/test/strict_scenario_checkbox.html.ep
@@ -1,0 +1,9 @@
+% my $isolation_keys = $job->history_isolation_keys;
+% if ($isolation_keys && @$isolation_keys) {
+    <div class="form-check form-switch mb-2">
+        <input class="form-check-input" type="checkbox" role="switch" id="<%= $id %>"<%= ($checked // 0) ? ' checked' : '' %>>
+        <label class="form-check-label" for="<%= $id %>">
+            Strict scenario (isolate history by <%= join ', ', @$isolation_keys %>)
+        </label>
+    </div>
+% }


### PR DESCRIPTION
This checkbox is already present on the "Next & previous" tab. For the "Investigation" tab it behaves similarly and decides how the last good job is computed. With this change, the strict history is enabled by default on the "Investigation" tab.

Related ticket: https://progress.opensuse.org/issues/205947