### PR TITLE
perf(search): Fetch only needed columns

### DIFF
--- a/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
+++ b/lib/OpenQA/WebAPI/Controller/API/V1/Search.pm
@@ -117,7 +117,6 @@ sub _search_job_modules ($self, $keywords, $limit) {
             join => 'job',
             group_by =>
               ['me.id', 'job.DISTRI', 'job.VERSION', 'job.FLAVOR', 'job.TEST', 'job.ARCH', 'job.MACHINE', 'job.id'],
-            prefetch => [qw(job)],
             select => [qw(me.id me.script me.job_id job.DISTRI job.VERSION job.FLAVOR job.ARCH job.BUILD job.TEST)],
             order_by => {-desc => 'job_id'}})->slice(0, $limit);
     while (my $job_module = $job_modules->next) {


### PR DESCRIPTION
My optimization in 64d6e00064a997f2e512637b2c8e851f591c7f66 got it wrong; The `prefetch` should not be there; the columns will already be prefetched via the `select` option.

The `prefetch` would fetch all `job` columns regardless of the `select` option.

Related issue: https://progress.opensuse.org/issues/205890