### PR TITLE
Allow fetchneedles to run fully unattended if needed

### DIFF
--- a/script/fetchneedles
+++ b/script/fetchneedles
@@ -17,6 +17,7 @@
 
 : "${updateall:="0"}"
 : "${force:="0"}"
+: "${interactive:="1"}"
 
 if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
     printf "Get %s tests and needles from:\n\t\t%s\n" "${dist_name}" "${giturl}"
@@ -31,6 +32,12 @@ if [[ $# -gt 0 && $1 != -* ]]; then
     # this script doesn't take non-option arguments currently
     echo "Unknown command: $1"
     exit 1
+fi
+
+if [[ $interactive -eq 0 ]]; then
+    noninteractive_regex_replace='s|(http[s]*://)|\1:@|g'
+    giturl="$(echo "$giturl" | sed -E "$noninteractive_regex_replace")"
+    needles_giturl="$(echo "$needles_giturl" | sed -E "$noninteractive_regex_replace")"
 fi
 
 dir="${OPENQA_BASEDIR:-/var/lib}/openqa/share/tests"


### PR DESCRIPTION
By adding an empty username and password to the clone URLs, we can ensure that git exits and does not interactively prompt them if credentials are requested from the remote.This behaviour has to be enabled explicitly by setting `interactive=0`.

I'm aware that [fetchneedles is supposed to be deprecated](https://progress.opensuse.org/issues/180854)  but at  least `openqa_install_multimachine` currently still requires it.