### PR TITLE
feat: Generalize NGINX template for rate limiting

### DIFF
--- a/etc/nginx/vhosts.d/openqa-endpoints.inc
+++ b/etc/nginx/vhosts.d/openqa-endpoints.inc
@@ -67,6 +67,11 @@ location /liveviewhandler/ {
 }
 
 location / {
+#    # Apply optional rate limiting (needs zone definition, see `openqa.conf.template`)
+#    limit_req zone=webui_limit burst=10 nodelay;
+#    limit_req_status 429;
+#    add_header Retry-After 5 always;
+
     proxy_pass "http://webui";
 }
 
@@ -76,12 +81,23 @@ location ~ /tests/[0-9]+/(livelog|liveterminal)$ {
     proxy_buffering off;
 }
 
-# Optional rate limiting of certain routes, e.g.:
-#location ~ ^/tests/[0-9]+/details_ajax$ {
-#    # Apply rate limiting to details_ajax (needs zone definition, see `openqa.conf.template`)
-#    limit_req zone=details_ajax_limit burst=10 nodelay;
+# Optional more restrictive rate limiting for heavy routes
+#location ~ ^(/search|/tests/[0-9]+/(investigation|dependencies)_ajax)/?$ {
+#    # Apply rate limiting (needs zone definition, see `openqa.conf.template`)
+#    limit_req zone=webui_heavy_limit burst=10 nodelay;
 #    limit_req_status 429;
 #    add_header Retry-After 5 always;
+#
+#    # Backend settings are inherited from the server block
+#    proxy_pass "http://webui";
+#}
+
+# Optional less restrictive rate limiting for lightweight routes that potentially need to be queried frequently
+#location ~ ^(/api/v1/jobs/[0-9]+/(mutex|barrier)) {
+#    # Apply rate limiting (needs zone definition, see `openqa.conf.template`)
+#    limit_req zone=webui_light_limit burst=10 nodelay;
+#    limit_req_status 429;
+#    add_header Retry-After 1 always;
 #
 #    # Backend settings are inherited from the server block
 #    proxy_pass "http://webui";

--- a/etc/nginx/vhosts.d/openqa.conf.template
+++ b/etc/nginx/vhosts.d/openqa.conf.template
@@ -1,7 +1,12 @@
 include vhosts.d/openqa-upstreams.inc;
 
-# Define rate limiting zone for details_ajax endpoint (10MB zone allows ~160,000 IPs)
-#limit_req_zone $binary_remote_addr zone=details_ajax_limit:10m rate=5r/s;
+# Define rate limiting zone for web UI endpoints (10MB zone allows ~160,000 IPs)
+# 5 requests per second by default
+#limit_req_zone $binary_remote_addr zone=webui_limit:10m rate=5r/s;
+# 30 per minute for heavy routes
+#limit_req_zone $binary_remote_addr zone=webui_heavy_limit:10m rate=30r/m;
+# 20 requests per second by default
+#limit_req_zone $binary_remote_addr zone=webui_light_limit:10m rate=20r/s;
 
 server {
     listen       80 default_server;


### PR DESCRIPTION
* Apply rate limiting to all routes (not just `details_ajax`)
* Add further zones and configuration blocks to treat heavy and lightweight routes differently

Related ticket: https://progress.opensuse.org/issues/205719