### PR TITLE
fix: unattended installation file for workers

### DIFF
--- a/contrib/agama-openqa-worker.jsonnet
+++ b/contrib/agama-openqa-worker.jsonnet
@@ -1,12 +1,30 @@
 local agama = import 'hw.libsonnet';
 
+// Extract release version from /etc/os-release
+local os_release = importstr '/etc/os-release';
+local os_release_lines = std.split(os_release, '\n');
+local version_id_lines = std.filter(function(l) std.startsWith(l, 'VERSION_ID='), os_release_lines);
+local releasever = if std.length(version_id_lines) > 0 then std.strReplace(std.strReplace(version_id_lines[0], 'VERSION_ID=', ''), '"', '') else error 'VERSION_ID not found in /etc/os-release';
+
 // --- DISK DETECTION ---
 local disks = agama.selectByClass(agama.lshw, 'disk');
-local disks_with_size = std.filter(function(d) std.objectHas(d, 'size'), disks);
-local min_os_disk_size = 12 * 1024 * 1024 * 1024; 
-local eligible_os_disks = std.filter(function(d) d.size >= min_os_disk_size, disks_with_size);
-local sorted_eligible_disks = std.sort(eligible_os_disks, function(x) x.size);
-local os_disk = if std.length(sorted_eligible_disks) > 0 then sorted_eligible_disks[0].logicalname else null;
+// Filter disks that have a size greater than 0 to ignore empty devices and exclude cdroms (/dev/sr*)
+local valid_disks = std.filter(
+  function(d) std.objectHas(d, 'size') && d.size > 0 && !std.startsWith(d.logicalname, '/dev/sr'),
+  disks
+);
+local sorted_disks = std.sort(valid_disks, function(x) x.size);
+local num_disks = std.length(sorted_disks);
+
+local min_size = if num_disks > 0 then sorted_disks[0].size else 0;
+local max_size = if num_disks > 0 then sorted_disks[num_disks - 1].size else 0;
+
+local os_disks = std.filter(function(d) d.size == min_size, sorted_disks);
+// Only separate openQA disks if we have a mix of disk sizes
+local openqa_disks = if max_size > min_size then std.filter(function(d) d.size == max_size, sorted_disks) else [];
+
+local os_logicalnames = std.map(function(d) d.logicalname, os_disks);
+local openqa_logicalnames = std.map(function(d) d.logicalname, openqa_disks);
 
 // --- NETWORK DETECTION ---
 local network_devices = agama.selectByClass(agama.lshw, 'network');
@@ -18,57 +36,97 @@ local has_multiple_ifaces = std.length(net_ifaces) >= 2;
 local primary_iface = if has_multiple_ifaces then net_ifaces[0] else null;
 local secondary_iface = if has_multiple_ifaces then net_ifaces[1] else null;
 
-// Extract just the logical names of the extra disks
-local extra_disks = std.map(
-  function(x) x.logicalname, 
-  std.filter(function(d) d.logicalname != os_disk, disks_with_size)
+// Helper functions to create unique, safe aliases from the device names
+local os_raid_alias = function(dev_name) "os-raid-" + std.strReplace(dev_name, "/dev/", "");
+local openqa_raid_alias = function(dev_name) "oqa-raid-" + std.strReplace(dev_name, "/dev/", "");
+
+local has_multiple_os_disks = std.length(os_logicalnames) > 1;
+local has_multiple_openqa_disks = std.length(openqa_logicalnames) > 1;
+
+// 1. Build the OS drives config dynamically
+local os_drives_config = std.map(
+  function(disk) {
+    search: disk,
+    ptableType: 'gpt',
+    [if has_multiple_os_disks && disk == os_logicalnames[0] then 'alias']: 'boot_disk',
+    partitions: [
+      { search: '*', delete: true }
+    ] + (
+      // Create a dedicated /boot outside the array to prevent GRUB rescue on RAID 0
+      if has_multiple_os_disks && disk == os_logicalnames[0] then
+        [{ id: 'linux', size: '1 GiB', filesystem: { type: 'ext4', path: '/boot' } }]
+      else
+        []
+    ) + [
+      // If we have 2+ OS disks, prep them for RAID. Otherwise, prep as OS drive.
+      if has_multiple_os_disks then
+        { alias: os_raid_alias(disk), id: 'raid' }
+      else
+        { generate: 'default' }
+    ]
+  },
+  os_logicalnames
 );
 
-// Helper function to create a unique, safe alias from the device name
-local raid_alias = function(dev_name) "raid-" + std.strReplace(dev_name, "/dev/", "");
-
-// Check if we actually have enough extra disks to form a RAID 0
-local has_enough_disks_for_raid = std.length(extra_disks) >= 2;
-
-// 1. Build the OS drive config
-local os_drive_config = if os_disk != null then [{
-  search: os_disk,
-  partitions: [{ search: {}, delete: true }, { generate: 'default' }],
-}] else [];
-
-// 2. Build the extra drives config dynamically
-local extra_drives_config = std.map(
+// 2. Build the openQA data drives config dynamically
+local openqa_drives_config = std.map(
   function(disk) {
     search: disk,
     ptableType: 'gpt',
     partitions: [
-      { search: {}, delete: true },
-      // If we have 2+ disks, prep them for RAID. Otherwise, prep as a standard Linux partition.
-      if has_enough_disks_for_raid then
-        { alias: raid_alias(disk), id: 'raid' }
+      { search: '*', delete: true }
+    ] + [
+      // If we have 2+ openQA disks, prep them for RAID. Otherwise, prep as a standard Linux partition.
+      if has_multiple_openqa_disks then
+        { alias: openqa_raid_alias(disk), id: 'raid' }
       else
-        { id: 'linux' }
+        { id: 'linux', filesystem: { type: 'ext2', path: '/var/lib/openqa' } }
     ]
   },
-  extra_disks
+  openqa_logicalnames
 );
 
-// 3. Build the mdRaids config ONLY if we have at least 2 disks
-local mdraids =
-  if has_enough_disks_for_raid then
+// 3. Build the mdRaids config for OS and/or openQA if needed
+local os_mdraid =
+  if has_multiple_os_disks then
     [{
-      devices: std.map(raid_alias, extra_disks),
+      devices: std.map(os_raid_alias, os_logicalnames),
       level: "raid0",
-      name: "openqa"
+      name: "openqa_os",
+      ptableType: 'gpt',
+      partitions: [
+        { search: '*', delete: true },
+        { generate: 'default' }
+      ]
     }]
   else [];
+
+local openqa_mdraid =
+  if has_multiple_openqa_disks then
+    [{
+      devices: std.map(openqa_raid_alias, openqa_logicalnames),
+      level: "raid0",
+      name: "openqa_data",
+      ptableType: 'gpt',
+      partitions: [
+        { search: '*', delete: true },
+        { id: 'linux', filesystem: { type: 'ext2', path: '/var/lib/openqa' } }
+      ]
+    }]
+  else [];
+
+local mdraids = os_mdraid + openqa_mdraid;
 
 {
   product: {
     id: 'openSUSE_Leap'
   },
   storage: {
-      drives: os_drive_config + extra_drives_config,
+      [if has_multiple_os_disks then 'boot']: {
+        configure: true,
+        device: 'boot_disk'
+      },
+      drives: os_drives_config + openqa_drives_config,
       // If mdraids is empty, Agama will just ignore it safely
       mdRaids: mdraids
   },
@@ -87,11 +145,13 @@ local mdraids =
       extraRepositories: [
         {
             alias: "devel_openQA",
-            url: "http://download.opensuse.org/repositories/devel:/openQA/$releasever/"
+            url: "http://download.opensuse.org/repositories/devel:/openQA/" + releasever + "/",
+            gpgFingerprints: ["A99A 72E3 06F2 0929 E6DE E378 5B12 1667 CBDF 5E8F"]
         },
         {
             alias: "devel_openQA_Modules",
-            url: "http://download.opensuse.org/repositories/devel:/openQA:/Leap:/$releasever/$releasever/"
+            url: "http://download.opensuse.org/repositories/devel:/openQA:/Leap:/" + releasever + "/" + releasever + "/",
+            gpgFingerprints: ["A99A 72E3 06F2 0929 E6DE E378 5B12 1667 CBDF 5E8F"]
         }
       ]
   }


### PR DESCRIPTION
The changes fix the follwing issues:
- The partitioning fails with "Mandatory partition not found" if the disks are blank, but not if it has been partitioned already.
- Some repositories were not found because the $releasever variable was not set, but we can extract it from /etc/os-release.
- The partitioning scheme did no longer correspond to the current requirements where we want the biggest disk(s) for mounting /var/lib/openqa, see https://progress.opensuse.org/issues/186948.

The new partitioning scheme is explained in the related ticket: https://progress.opensuse.org/issues/190032#note-29

NOTE: we could use salt for partitioning instead, see  https://progress.opensuse.org/issues/190032#note-32, but regardless, the current formatting scheme needs to be changed either here or in salt because it does not allow to use the largest NVME(s) as it is now.