### PR TITLE
style: Reduce max_elsif for perlcritic rule ProhibitCascadingIfElse

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -70,7 +70,7 @@ max_mccabe = 83
 
 [ControlStructures::ProhibitCascadingIfElse]
 # Reduce me!
-max_elsif = 5
+max_elsif = 3
 
 [Subroutines::ProhibitExcessComplexity]
 # Reduce me!

--- a/lib/OpenQA/Parser.pm
+++ b/lib/OpenQA/Parser.pm
@@ -71,14 +71,11 @@ sub reset ($self) {
 sub gen_tree_el ($el) {
     return {DATA_FIELD() => $el} unless blessed $el;
 
+    return {DATA_FIELD() => $el, TYPE_FIELD() => ref $el} if $el->isa('OpenQA::Parser');
+    return $el->gen_tree_el if $el->can('gen_tree_el');
+
     my $el_ref;
-    if ($el->isa('OpenQA::Parser')) {
-        $el_ref = $el;
-    }
-    elsif ($el->can('gen_tree_el')) {
-        return $el->gen_tree_el;
-    }
-    elsif ($el->can('to_hash')) {
+    if ($el->can('to_hash')) {
         $el_ref = $el->to_hash;
     }
     elsif ($el->can('to_array')) {

--- a/lib/OpenQA/Worker.pm
+++ b/lib/OpenQA/Worker.pm
@@ -822,20 +822,8 @@ sub _handle_job_status_changed ($self, $job, $event_data) {
         die "Received job status update for job $job_id ($status) which is not the current one.";
     }
 
-    if ($status eq 'accepting') {
-        log_debug("Accepting job $job_id from $webui_host.");
-    }
-    elsif ($status eq 'accepted') {
+    if ($status eq 'accepted') {
         $job->start();
-    }
-    elsif ($status eq 'setup') {
-        log_debug("Setting job $job_id from $webui_host up");
-    }
-    elsif ($status eq 'running') {
-        log_debug("Running job $job_id from $webui_host: $job_name.");
-    }
-    elsif ($status eq 'stopping') {
-        log_debug("Stopping job $job_id from $webui_host: $job_name - reason: $reason");
     }
     elsif ($status eq 'stopped') {
         log_debug("Job $job_id from $webui_host finished - reason: $reason");
@@ -867,6 +855,15 @@ sub _handle_job_status_changed ($self, $job, $event_data) {
             # stop if we can not accept/skip the next job (e.g. because there's no further job) if that's configured
             $self->stop(WORKER_COMMAND_QUIT) if $self->settings->global_settings->{TERMINATE_AFTER_JOBS_DONE};
         }
+    }
+    else {
+        my %log_message = (
+            accepting => sub { "Accepting job $job_id from $webui_host." },
+            setup => sub { "Setting job $job_id from $webui_host up" },
+            running => sub { "Running job $job_id from $webui_host: $job_name." },
+            stopping => sub { "Stopping job $job_id from $webui_host: $job_name - reason: $reason" },
+        );
+        if (my $message = $log_message{$status}) { log_debug($message->()) }
     }
     return undef;
 }

--- a/t/14-grutasks-git.t
+++ b/t/14-grutasks-git.t
@@ -74,40 +74,29 @@ subtest 'git clone' => sub {
             (undef, $path) = splice @$cmd, 1, 2 if $cmd->[1] eq '-C';
             my $action = $cmd->[1];
             my $return_code = 0;
-            if ($action eq 'remote') {
-                if ($clone_dirs->{$path}) {
-                    $stdout = $clone_dirs->{$path} =~ s/#.*//r;
-                }
-                elsif ($path =~ m/opensuse/) {
-                    $stdout = 'http://osado';
-                }
-                elsif ($path =~ m/wrong-url/) {
-                    $stdout = 'http://other';
-                }
-            }
-            elsif ($action eq 'ls-remote') {
-                $stdout = "ref: refs/heads/master\tHEAD";
-                $stdout = 'ref: something' if "@$cmd" =~ m/nodefault/;
-            }
-            elsif ($action eq 'branch') {
-                $stdout = 'master';
-            }
-            elsif ($action eq 'diff') {
-                $return_code = 1 if $path =~ m/dirty-status/;
-                $return_code = 2 if $path =~ m/dirty-error/;
-            }
-            elsif ($action eq 'rev-parse') {
-                if ($path =~ m/sha1/) {
-                    $return_code = 0;
-                    $stdout = 'abcdef123456';
-                }
-                if ($path =~ m/sha-branchname/) {
-                    $return_code = 0;
-                    $stdout = 'abcdef123456789';
-                }
-                $return_code = 1 if $path =~ m/sha2/;
-                $return_code = 2 if $path =~ m/sha-error/;
-            }
+            my %handle_action = (
+                remote => sub {
+                    if ($clone_dirs->{$path}) { $stdout = $clone_dirs->{$path} =~ s/#.*//r }
+                    elsif ($path =~ m/opensuse/) { $stdout = 'http://osado' }
+                    elsif ($path =~ m/wrong-url/) { $stdout = 'http://other' }
+                },
+                'ls-remote' => sub {
+                    $stdout = "ref: refs/heads/master\tHEAD";
+                    $stdout = 'ref: something' if "@$cmd" =~ m/nodefault/;
+                },
+                branch => sub { $stdout = 'master' },
+                diff => sub {
+                    $return_code = 1 if $path =~ m/dirty-status/;
+                    $return_code = 2 if $path =~ m/dirty-error/;
+                },
+                'rev-parse' => sub {
+                    if ($path =~ m/sha1/) { $return_code = 0; $stdout = 'abcdef123456' }
+                    if ($path =~ m/sha-branchname/) { $return_code = 0; $stdout = 'abcdef123456789' }
+                    $return_code = 1 if $path =~ m/sha2/;
+                    $return_code = 2 if $path =~ m/sha-error/;
+                },
+            );
+            if (my $handler = $handle_action{$action}) { $handler->() }
             return {
                 status => $return_code == 0,
                 return_code => $return_code,

--- a/t/lib/OpenQA/Test/Utils.pm
+++ b/t/lib/OpenQA/Test/Utils.pm
@@ -161,45 +161,41 @@ sub fake_asset_server () {
                 $c->res->headers->content_length(10);
                 $c->res->headers->content_type('text/plain');
                 $c->res->body('Six!!!');
-                $c->rendered(200);
+                return $c->rendered(200);
             }
 
-            elsif (my ($size) = ($filename =~ /sle-12-SP3-x86_64-0368-200_?([0-9]+)?\@/)) {
+            if (my ($size) = ($filename =~ /sle-12-SP3-x86_64-0368-200_?([0-9]+)?\@/)) {
                 my $our_etag = 'andi $a3, $t1, 41399';
 
                 my $browser_etag = $c->req->headers->header('If-None-Match');
                 if ($browser_etag && $browser_etag eq $our_etag) {
                     $c->res->body('');
-                    $c->rendered(304);
+                    return $c->rendered(304);
                 }
-                else {
-                    $c->res->headers->content_length($size // 1024);
-                    $c->res->headers->content_type('text/plain');
-                    $c->res->headers->header('ETag' => $our_etag);
-                    $c->res->body("\0" x ($size // 1024));
-                    $c->rendered(200);
-                }
+                $c->res->headers->content_length($size // 1024);
+                $c->res->headers->content_type('text/plain');
+                $c->res->headers->header('ETag' => $our_etag);
+                $c->res->body("\0" x ($size // 1024));
+                return $c->rendered(200);
             }
 
-            elsif ($filename =~ /sle-12-SP3-x86_64-0368-200_client_error/) {
-                $c->render(text => 'Client error!', status => 404);
-            }
+            return $c->render(text => 'Client error!', status => 404)
+              if $filename =~ /sle-12-SP3-x86_64-0368-200_client_error/;
 
-            elsif ($filename =~ /sle-12-SP3-x86_64-0368-200_server_error/) {
-                $c->render(text => 'Server error!', status => 500);
-            }
+            return $c->render(text => 'Server error!', status => 500)
+              if $filename =~ /sle-12-SP3-x86_64-0368-200_server_error/;
 
-            elsif ($filename =~ /sle-12-SP3-x86_64-0368-200_close/) {
+            if ($filename =~ /sle-12-SP3-x86_64-0368-200_close/) {
                 my $stream = Mojo::IOLoop->stream($c->tx->connection);
-                Mojo::IOLoop->next_tick(sub { $stream->close });
+                return Mojo::IOLoop->next_tick(sub { $stream->close });
             }
 
-            elsif ($filename =~ /sle-12-SP3-x86_64-0368-200_#:/) {
+            if ($filename =~ /sle-12-SP3-x86_64-0368-200_#:/) {
                 $c->res->headers->content_length(20);
                 $c->res->headers->content_type('text/plain');
                 $c->res->headers->header('ETag' => '123456789');
                 $c->res->body('this is a test for character check');
-                $c->rendered(200);
+                return $c->rendered(200);
             }
         });
     return $mock;


### PR DESCRIPTION
https://metacpan.org/pod/Perl::Critic::Policy::ControlStructures::ProhibitCascadingIfElse

Lower the max_elsif threshold from 5 to 3 and refactor the code that violated the stricter limit.

Policy description:
> Long if-elsif chains are hard to digest, especially if they are longer
> than a single page or screen. If testing for equality, use a hash lookup
> instead.

Issue: https://progress.opensuse.org/issues/201318