### PR TITLE
style: Reduce max_mccabe for perlcritic rule ProhibitExcessMainComplexity

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -63,11 +63,13 @@ allow = redefine
 # BuiltinFunctions::ProhibitComplexMappings
 
 # The following thresholds should ideally be reduced
-# https://progress.opensuse.org/issues/201318
+# https://progress.opensuse.org/issues/206793
 [Modules::ProhibitExcessMainComplexity]
 # Reduce me!
-max_mccabe = 83
+max_mccabe = 40
 
+# The following thresholds should ideally be reduced
+# https://progress.opensuse.org/issues/201318
 [ControlStructures::ProhibitCascadingIfElse]
 # Reduce me!
 max_elsif = 5

--- a/t/04-scheduler.t
+++ b/t/04-scheduler.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env perl    ## no critic (Modules::ProhibitExcessMainComplexity)
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/t/05-scheduler-dependencies.t
+++ b/t/05-scheduler-dependencies.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env perl    ## no critic (Modules::ProhibitExcessMainComplexity)
 
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/t/14-grutasks.t
+++ b/t/14-grutasks.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env perl    ## no critic (Modules::ProhibitExcessMainComplexity)
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/t/24-worker-jobs.t
+++ b/t/24-worker-jobs.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env perl    ## no critic (Modules::ProhibitExcessMainComplexity)
 
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/t/api/02-iso.t
+++ b/t/api/02-iso.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env perl    ## no critic (Modules::ProhibitExcessMainComplexity)
 # Copyright SUSE LLC
 # Copyright 2016 Red Hat
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/t/api/04-jobs.t
+++ b/t/api/04-jobs.t
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env perl    ## no critic (Modules::ProhibitExcessMainComplexity)
 
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/t/api/08-jobtemplates.t
+++ b/t/api/08-jobtemplates.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl    ## no critic (Modules::ProhibitExcessMainComplexity)
+
 # Copyright SUSE LLC
 # SPDX-License-Identifier: GPL-2.0-or-later
 


### PR DESCRIPTION
https://metacpan.org/pod/Perl::Critic::Policy::Modules::ProhibitExcessMainComplexity

Lower the `max_mccabe` threshold from 83 to 40. Some test files exceed the stricter limit so a
`## no critic (Modules::ProhibitExcessMainComplexity)` annotation has been added.

Policy description:
> This Policy scores the total complexity of all the code that is outside of
> any subroutine declaration. [...] Research has shown that a McCabe score
> higher than 20 is a sign of high-risk, potentially untestable code.

Issue: https://progress.opensuse.org/issues/201318