### PR TITLE
style: Reduce max_arguments for perlcritic rule ProhibitManyArgs

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -78,6 +78,6 @@ max_mccabe = 63
 
 [Subroutines::ProhibitManyArgs]
 # Reduce me!
-max_arguments = 10
+max_arguments = 8
 # Ignore first arg if called $self or $class
 skip_object = 1

--- a/lib/OpenQA/Schema/Result/JobGroups.pm
+++ b/lib/OpenQA/Schema/Result/JobGroups.pm
@@ -456,21 +456,27 @@ sub _parse_job_template_products ($yaml_products_for_arch, $yaml_defaults_for_ar
 
             $machine_names = [$machine_names] if ref($machine_names) ne 'ARRAY';
             my $ret = _parse_job_template_machines(
-                $machine_names, $job_template_names, $prio, $arch, $product_name,
-                $yaml_products, $job_template_name, $testsuite_name, $settings, $description
-            );
+                $machine_names,
+                $job_template_names,
+                {
+                    prio => $prio,
+                    arch => $arch,
+                    product_name => $product_name,
+                    product_spec => $yaml_products->{$product_name},
+                    job_template_name => $job_template_name,
+                    testsuite_name => $testsuite_name,
+                    settings => $settings,
+                    description => $description,
+                });
             return $ret if defined $ret;
         }
     }
     return undef;
 }
 
-sub _parse_job_template_machines (
-    $machine_names, $job_template_names, $prio, $arch, $product_name,
-    $yaml_products, $job_template_name, $testsuite_name, $settings, $description
-  )
-{
-
+sub _parse_job_template_machines ($machine_names, $job_template_names, $scenario) {
+    my ($arch, $product_name, $job_template_name, $testsuite_name, $description)
+      = @$scenario{qw(arch product_name job_template_name testsuite_name description)};
     foreach my $machine_name (@{$machine_names}) {
         my $job_template_key
           = $arch . $product_name . $machine_name . ($testsuite_name // '') . ($job_template_name // '');
@@ -481,14 +487,14 @@ sub _parse_job_template_machines (
             return {error => $error};
         }
         $job_template_names->{$job_template_key} = {
-            prio => $prio,
+            prio => $scenario->{prio},
             machine_name => $machine_name,
             arch => $arch,
             product_name => $product_name,
-            product_spec => $yaml_products->{$product_name},
+            product_spec => $scenario->{product_spec},
             job_template_name => $job_template_name,
             testsuite_name => $testsuite_name,
-            settings => $settings,
+            settings => $scenario->{settings},
             length $description ? (description => $description) : (),
         };
     }


### PR DESCRIPTION
https://metacpan.org/pod/Perl::Critic::Policy::Subroutines::ProhibitManyArgs

Lower the max_arguments threshold from 10 to 8 and refactor the code that violated this limit

Policy description:
> Subroutines that expect large numbers of arguments are notoriously
> difficult to use because programmers routinely forget the order of the
> arguments. Instead of expecting a long list of arguments, consider
> putting all the arguments in a hash. This is really handy when there
> are many optional arguments.

Issue: https://progress.opensuse.org/issues/201318