### PR TITLE
fix(worker): Detect cgroup slice on pure cgroup v2 hosts

### DIFF
--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -356,17 +356,14 @@ sub _configure_cgroupv2 ($job_info) {
     if (!defined $cgroup_slice) {
         # determine cgroup slice of the current process
         try {
-            my $pid = $$;
-            if (defined $pid) {
-                my @cgroup_lines = split /\n/, path('/proc', $pid, 'cgroup')->slurp;
-                # pure cgroup v2 unified hierarchy, e.g. "0::/system.slice/foo.service" (no named
-                # "systemd" hierarchy line exists in this case, see poo#205902/GH#7475)
-                ($cgroup_slice) = map { /^0::(.*)/ } @cgroup_lines;
-                unless (defined $cgroup_slice) {
-                    # legacy/hybrid cgroup v1 with a named "systemd" hierarchy
-                    $cgroup_slice = (grep { /name=$cgroup_name:/ } @cgroup_lines)[0];
-                    $cgroup_slice =~ s/^.*name=$cgroup_name:/$cgroup_name/g if defined $cgroup_slice;
-                }
+            my @cgroup_lines = split /\n/, path('/proc', $$, 'cgroup')->slurp;
+            # pure cgroup v2 unified hierarchy, e.g. "0::/system.slice/foo.service" (no named
+            # "systemd" hierarchy line exists in this case, see poo#205902/GH#7475)
+            ($cgroup_slice) = map { /^0::(.*)/ } @cgroup_lines;
+            unless (defined $cgroup_slice) {
+                # legacy/hybrid cgroup v1 with a named "systemd" hierarchy
+                $cgroup_slice = (grep { /name=$cgroup_name:/ } @cgroup_lines)[0];
+                $cgroup_slice =~ s/^.*name=$cgroup_name:/$cgroup_name/g if defined $cgroup_slice;
             }
         }
         catch ($e) { }

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -357,9 +357,17 @@ sub _configure_cgroupv2 ($job_info) {
         # determine cgroup slice of the current process
         try {
             my $pid = $$;
-            $cgroup_slice = (grep { /name=$cgroup_name:/ } split /\n/, path('/proc', $pid, 'cgroup')->slurp)[0]
-              if defined $pid;
-            $cgroup_slice =~ s/^.*name=$cgroup_name:/$cgroup_name/g if defined $cgroup_slice;
+            if (defined $pid) {
+                my @cgroup_lines = split /\n/, path('/proc', $pid, 'cgroup')->slurp;
+                # pure cgroup v2 unified hierarchy, e.g. "0::/system.slice/foo.service" (no named
+                # "systemd" hierarchy line exists in this case, see poo#205902/GH#7475)
+                ($cgroup_slice) = map { /^0::(.*)/ } @cgroup_lines;
+                unless (defined $cgroup_slice) {
+                    # legacy/hybrid cgroup v1 with a named "systemd" hierarchy
+                    $cgroup_slice = (grep { /name=$cgroup_name:/ } @cgroup_lines)[0];
+                    $cgroup_slice =~ s/^.*name=$cgroup_name:/$cgroup_name/g if defined $cgroup_slice;
+                }
+            }
         }
         catch ($e) { }
     }

--- a/lib/OpenQA/Worker/Engines/isotovideo.pm
+++ b/lib/OpenQA/Worker/Engines/isotovideo.pm
@@ -361,7 +361,8 @@ sub _configure_cgroupv2 ($job_info) {
             # "systemd" hierarchy line exists in this case, see poo#205902/GH#7475)
             ($cgroup_slice) = map { /^0::(.*)/ } @cgroup_lines;
             unless (defined $cgroup_slice) {
-                # legacy/hybrid cgroup v1 with a named "systemd" hierarchy
+                # fall back to the named "systemd" hierarchy line format reported on hosts
+                # where systemd hasn't switched to the unified hierarchy
                 $cgroup_slice = (grep { /name=$cgroup_name:/ } @cgroup_lines)[0];
                 $cgroup_slice =~ s/^.*name=$cgroup_name:/$cgroup_name/g if defined $cgroup_slice;
             }

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -591,15 +591,20 @@ subtest 'cgroup slice detection on pure cgroup v2 hosts (poo#205902)' => sub {
     # slice detection must therefore also understand the "0::" format, otherwise it silently
     # disables cgroup usage entirely (see GH#7475 which attempted a fix but was reverted as GH#7493
     # because it broke cgroup cleanup on aarch64 workers).
-    my $file_mock = Test::MockModule->new('Mojo::File');
-    $file_mock->noop('make_path');
-
+    # each case below creates and mocks its own Test::MockModule object entirely within its own
+    # leaf subtest. Sharing one mock object across sibling subtests (created in the outer scope,
+    # redefined inside nested ones) looks equivalent but under Devel::Cover instrumentation (as
+    # used by CI) breaks Test::MockModule's DESTROY-based auto-restore, leaving make_path/slurp
+    # mocked for the rest of the test file (it silently passed locally without coverage).
     subtest 'pure cgroup v2 unified hierarchy' => sub {
+        my $file_mock = Test::MockModule->new('Mojo::File');
+        $file_mock->noop('make_path');
+        my $orig_slurp = $file_mock->original('slurp');
         $file_mock->redefine(
             slurp => sub ($self, @args) {
                 return $self =~ m{/cgroup$}
                   ? "0::/system.slice/openqa-worker-auto-restart\@16.service\n"
-                  : $file_mock->original('slurp')->($self, @args);
+                  : $orig_slurp->($self, @args);
             });
         combined_like { OpenQA::Worker::Engines::isotovideo::_configure_cgroupv2({id => 42}) }
         qr|Using cgroup /sys/fs/cgroup/system\.slice/openqa-worker-auto-restart\@16\.service/42|,
@@ -607,11 +612,14 @@ subtest 'cgroup slice detection on pure cgroup v2 hosts (poo#205902)' => sub {
     };
 
     subtest 'legacy/hybrid cgroup v1 with a named "systemd" hierarchy' => sub {
+        my $file_mock = Test::MockModule->new('Mojo::File');
+        $file_mock->noop('make_path');
+        my $orig_slurp = $file_mock->original('slurp');
         $file_mock->redefine(
             slurp => sub ($self, @args) {
                 return $self =~ m{/cgroup$}
                   ? "12:name=systemd:/user.slice/user-1000.slice/session-1.scope\n11:pids:/user.slice\n"
-                  : $file_mock->original('slurp')->($self, @args);
+                  : $orig_slurp->($self, @args);
             });
         combined_like { OpenQA::Worker::Engines::isotovideo::_configure_cgroupv2({id => 42}) }
         qr|Using cgroup /sys/fs/cgroup/systemd/user\.slice/user-1000\.slice/session-1\.scope/42|,

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -585,6 +585,40 @@ subtest 'using cgroupv2' => sub {
     qr|Using cgroup /sys/fs/cgroup/.*/42|, 'use of cgroup logged';
 };
 
+subtest 'cgroup slice detection on pure cgroup v2 hosts (poo#205902)' => sub {
+    # On hosts using the pure cgroup v2 unified hierarchy /proc/$pid/cgroup contains a single
+    # "0::/…" line and no "name=systemd:" line (that only exists on cgroup v1/hybrid hosts). The
+    # slice detection must therefore also understand the "0::" format, otherwise it silently
+    # disables cgroup usage entirely (see GH#7475 which attempted a fix but was reverted as GH#7493
+    # because it broke cgroup cleanup on aarch64 workers).
+    my $file_mock = Test::MockModule->new('Mojo::File');
+    $file_mock->noop('make_path');
+
+    subtest 'pure cgroup v2 unified hierarchy' => sub {
+        $file_mock->redefine(
+            slurp => sub ($self, @args) {
+                return $self =~ m{/cgroup$}
+                  ? "0::/system.slice/openqa-worker-auto-restart\@16.service\n"
+                  : $file_mock->original('slurp')->($self, @args);
+            });
+        combined_like { OpenQA::Worker::Engines::isotovideo::_configure_cgroupv2({id => 42}) }
+        qr|Using cgroup /sys/fs/cgroup/system\.slice/openqa-worker-auto-restart\@16\.service/42|,
+          'slice parsed from the "0::" unified hierarchy line and used for the cgroup path';
+    };
+
+    subtest 'legacy/hybrid cgroup v1 with a named "systemd" hierarchy' => sub {
+        $file_mock->redefine(
+            slurp => sub ($self, @args) {
+                return $self =~ m{/cgroup$}
+                  ? "12:name=systemd:/user.slice/user-1000.slice/session-1.scope\n11:pids:/user.slice\n"
+                  : $file_mock->original('slurp')->($self, @args);
+            });
+        combined_like { OpenQA::Worker::Engines::isotovideo::_configure_cgroupv2({id => 42}) }
+        qr|Using cgroup /sys/fs/cgroup/systemd/user\.slice/user-1000\.slice/session-1\.scope/42|,
+          'slice parsed from the legacy "name=systemd:" line and used for the cgroup path';
+    };
+};
+
 subtest '_construct_isotovideo_cmd' => sub {
     local $OpenQA::Worker::Engines::isotovideo::CA_DIRS = [];
 

--- a/t/24-worker-engine.t
+++ b/t/24-worker-engine.t
@@ -587,10 +587,10 @@ subtest 'using cgroupv2' => sub {
 
 subtest 'cgroup slice detection on pure cgroup v2 hosts (poo#205902)' => sub {
     # On hosts using the pure cgroup v2 unified hierarchy /proc/$pid/cgroup contains a single
-    # "0::/…" line and no "name=systemd:" line (that only exists on cgroup v1/hybrid hosts). The
-    # slice detection must therefore also understand the "0::" format, otherwise it silently
-    # disables cgroup usage entirely (see GH#7475 which attempted a fix but was reverted as GH#7493
-    # because it broke cgroup cleanup on aarch64 workers).
+    # "0::/…" line and no "name=systemd:" line (that only appears when systemd hasn't switched to
+    # the unified hierarchy). The slice detection must therefore also understand the "0::" format,
+    # otherwise it silently disables cgroup usage entirely (see GH#7475 which attempted a fix but
+    # was reverted as GH#7493 because it broke cgroup cleanup on aarch64 workers).
     # each case below creates and mocks its own Test::MockModule object entirely within its own
     # leaf subtest. Sharing one mock object across sibling subtests (created in the outer scope,
     # redefined inside nested ones) looks equivalent but under Devel::Cover instrumentation (as
@@ -611,7 +611,7 @@ subtest 'cgroup slice detection on pure cgroup v2 hosts (poo#205902)' => sub {
           'slice parsed from the "0::" unified hierarchy line and used for the cgroup path';
     };
 
-    subtest 'legacy/hybrid cgroup v1 with a named "systemd" hierarchy' => sub {
+    subtest 'named "systemd" hierarchy line format (systemd not on the unified hierarchy)' => sub {
         my $file_mock = Test::MockModule->new('Mojo::File');
         $file_mock->noop('make_path');
         my $orig_slurp = $file_mock->original('slurp');


### PR DESCRIPTION
On hosts using the pure cgroup v2 unified hierarchy, `/proc/PID/cgroup` contains only a `0::/...` line and never the `name=systemd:` line the slice detection looked for, so the slice was never found and cgroup creation fell back to the non-delegated `/sys/fs/cgroup/systemd` path, failing with "Permission denied" and silently disabling cgroup usage for the whole job.

Seen on aarch64 workers (worker-arm1/worker-arm3 on openqa.suse.de), tracked as [poo#205902](https://progress.opensuse.org/issues/205902), and also flagged as a possible factor in [poo#205797](https://progress.opensuse.org/issues/205797).

#7475 attempted a fix but also restructured the `cgroupv2()` call itself and was reverted as #7493 after breaking cgroup cleanup on aarch64 workers. This instead only extends the slice-detection regex to also understand the `0::` format, leaving the existing `cgroupv2(name => ...)->from(...)->child(...)->create` call — and therefore whatever the cleanup path expects from it — unchanged.

Verified locally by loading `OpenQA::Worker::Engines::isotovideo` standalone and mocking `Mojo::File::slurp` to return both the pure-v2 and legacy/hybrid-v1 `/proc/PID/cgroup` formats; added as proper test coverage in `t/24-worker-engine.t` since there was none before for this branch of the slice-detection logic (which is likely why the #7475 regression wasn't caught before reaching production).