### PR TITLE
style: Reduce max_mccabe for perlcritic rule ProhibitExcessComplexity

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -74,7 +74,7 @@ max_elsif = 5
 
 [Subroutines::ProhibitExcessComplexity]
 # Reduce me!
-max_mccabe = 63
+max_mccabe = 39
 
 [Subroutines::ProhibitManyArgs]
 # Reduce me!

--- a/lib/OpenQA/BuildResults.pm
+++ b/lib/OpenQA/BuildResults.pm
@@ -62,6 +62,72 @@ sub _get_latest_job_ids ($jobs_resultset, $version, $buildnr, $group_ids) {
         {select => [{max => 'id'}], as => ['id'], group_by => [qw(TEST ARCH FLAVOR MACHINE)]})->all;
 }
 
+sub _categorize_job_result ($stat) {
+    if ($stat->state eq OpenQA::Jobs::Constants::DONE) {
+        return 'passed' if $stat->result eq OpenQA::Jobs::Constants::PASSED;
+        return 'softfailed' if $stat->result eq OpenQA::Jobs::Constants::SOFTFAILED;
+        return 'skipped' if any { $stat->result eq $_ } OpenQA::Jobs::Constants::ABORTED_RESULTS;
+        return 'failed' if any { $stat->result eq $_ } OpenQA::Jobs::Constants::NOT_OK_RESULTS;
+    }
+    elsif ($stat->state eq OpenQA::Jobs::Constants::CANCELLED) { return 'skipped' }
+    return 'unfinished';
+}
+
+sub _aggregate_build_stats ($jobs_resultset, $latest_ids, $jr, $newest, $version, $buildnr) {
+    my $stats_rs = $jobs_resultset->search(
+        {id => {-in => $latest_ids}},
+        {
+            select => [qw(state result DISTRI group_id), {count => '*'}, {($newest ? 'max' : 'min') => 't_created'}],
+            as => [qw(state result DISTRI group_id count t_created_agg)],
+            group_by => [qw(state result DISTRI group_id)],
+        });
+    while (my $stat = $stats_rs->next) {
+        my $count = $stat->get_column('count');
+        $jr->{total} += $count;
+        $jr->{distris}->{$stat->DISTRI} = 1;
+        my $t_agg = $stat->get_column('t_created_agg');
+        $t_agg = DateTime::Format::Pg->parse_datetime($t_agg) if $t_agg && !ref $t_agg;
+        if ($newest) {
+            $jr->{oldest_newest} = $t_agg if !$jr->{oldest_newest} || $t_agg > $jr->{oldest_newest};
+        }
+        else {
+            $jr->{oldest_newest} = $t_agg if !$jr->{oldest_newest} || $t_agg < $jr->{oldest_newest};
+        }
+        my $cat = _categorize_job_result($stat);
+        $jr->{$cat} += $count;
+        if ($jr->{children} && (my $child = $jr->{children}->{$stat->group_id})) {
+            $child->{total} += $count;
+            $child->{$cat} += $count;
+            $child->{distris}->{$stat->DISTRI} = 1;
+            $child->{version} //= $version;
+            $child->{build} //= $buildnr;
+        }
+    }
+}
+
+sub _aggregate_comment_stats ($group, $jobs_resultset, $latest_ids, $jr) {
+    my $failed_rs = $jobs_resultset->search(
+        {
+            id => {-in => $latest_ids},
+            state => OpenQA::Jobs::Constants::DONE,
+            result => {in => [OpenQA::Jobs::Constants::FAILED, OpenQA::Jobs::Constants::NOT_COMPLETE_RESULTS]},
+        },
+        {select => [qw(id group_id)]});
+    my $failed_id_to_group = {map { $_->id => $_->group_id } $failed_rs->all};
+    return unless keys %$failed_id_to_group;
+    my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs($failed_rs);
+    for my $id (keys %$comment_data) {
+        my $cd = $comment_data->{$id};
+        next unless $cd->{reviewed} || $cd->{comments};
+        $jr->{labeled}++ if $cd->{reviewed};
+        $jr->{comments}++ if $cd->{comments} || $cd->{reviewed};
+        if ($jr->{children} && (my $child = $jr->{children}->{$failed_id_to_group->{$id}})) {
+            $child->{labeled}++ if $cd->{reviewed};
+            $child->{comments}++ if $cd->{comments} || $cd->{reviewed};
+        }
+    }
+}
+
 sub compute_build_results (
     $group, $limit, $time_limit_days, $tags, $subgroup_filter, $show_tags,
     $max_jobs_limit = undef,
@@ -161,70 +227,8 @@ sub compute_build_results (
         );
         init_job_figures(\%jr);
         init_job_figures($jr{children}->{$_->id} = {}) for @$children;
-        my $stats_rs = $jobs_resultset->search(
-            {id => {-in => \@latest_ids}},
-            {
-                select =>
-                  [qw(state result DISTRI group_id), {count => '*'}, {($newest ? 'max' : 'min') => 't_created'}],
-                as => [qw(state result DISTRI group_id count t_created_agg)],
-                group_by => [qw(state result DISTRI group_id)],
-            });
-        while (my $stat = $stats_rs->next) {
-            my $count = $stat->get_column('count');
-            $jr{total} += $count;
-            $jr{distris}->{$stat->DISTRI} = 1;
-            my $t_agg = $stat->get_column('t_created_agg');
-            if ($t_agg && !ref $t_agg) {
-                $t_agg = DateTime::Format::Pg->parse_datetime($t_agg);
-            }
-            if ($newest) {
-                $jr{oldest_newest} = $t_agg if !$jr{oldest_newest} || $t_agg > $jr{oldest_newest};
-            }
-            else {
-                $jr{oldest_newest} = $t_agg if !$jr{oldest_newest} || $t_agg < $jr{oldest_newest};
-            }
-            my $cat = 'unfinished';
-            if ($stat->state eq OpenQA::Jobs::Constants::DONE) {
-                if ($stat->result eq OpenQA::Jobs::Constants::PASSED) { $cat = 'passed' }
-                elsif ($stat->result eq OpenQA::Jobs::Constants::SOFTFAILED) { $cat = 'softfailed' }
-                elsif (any { $stat->result eq $_ } OpenQA::Jobs::Constants::ABORTED_RESULTS) {
-                    $cat = 'skipped';
-                }
-                elsif (any { $stat->result eq $_ } OpenQA::Jobs::Constants::NOT_OK_RESULTS) {
-                    $cat = 'failed';
-                }
-            }
-            elsif ($stat->state eq OpenQA::Jobs::Constants::CANCELLED) { $cat = 'skipped' }
-            $jr{$cat} += $count;
-            if ($jr{children} && (my $child = $jr{children}->{$stat->group_id})) {
-                $child->{total} += $count;
-                $child->{$cat} += $count;
-                $child->{distris}->{$stat->DISTRI} = 1;
-                $child->{version} //= $version;
-                $child->{build} //= $buildnr;
-            }
-        }
-        my $failed_rs = $jobs_resultset->search(
-            {
-                id => {-in => \@latest_ids},
-                state => OpenQA::Jobs::Constants::DONE,
-                result => {in => [OpenQA::Jobs::Constants::FAILED, OpenQA::Jobs::Constants::NOT_COMPLETE_RESULTS]},
-            },
-            {select => [qw(id group_id)]});
-        my $failed_id_to_group = {map { $_->id => $_->group_id } $failed_rs->all};
-        if (keys %$failed_id_to_group) {
-            my $comment_data = $group->result_source->schema->resultset('Comments')->comment_data_for_jobs($failed_rs);
-            for my $id (keys %$comment_data) {
-                my $cd = $comment_data->{$id};
-                next unless $cd->{reviewed} || $cd->{comments};
-                $jr{labeled}++ if $cd->{reviewed};
-                $jr{comments}++ if $cd->{comments} || $cd->{reviewed};
-                if ($jr{children} && (my $child = $jr{children}->{$failed_id_to_group->{$id}})) {
-                    $child->{labeled}++ if $cd->{reviewed};
-                    $child->{comments}++ if $cd->{comments} || $cd->{reviewed};
-                }
-            }
-        }
+        _aggregate_build_stats($jobs_resultset, \@latest_ids, \%jr, $newest, $version, $buildnr);
+        _aggregate_comment_stats($group, $jobs_resultset, \@latest_ids, \%jr);
         add_review_badge($_) for values %{$jr{children} // {}};
         $total_jobs_seen += $jr{total};
         $jr{date} = delete $jr{oldest_newest};

--- a/lib/OpenQA/WebAPI/Plugin/Helpers.pm
+++ b/lib/OpenQA/WebAPI/Plugin/Helpers.pm
@@ -29,17 +29,7 @@ sub register ($self, $app, $config) {
             return $timedate->strftime($format);
         });
 
-    $app->helper(
-        format_time_duration => sub ($c, $timedate = undef) {
-            return unless $timedate;
-            if ($timedate->days() > 0) {
-                return sprintf '%d days %02d:%02d hours', $timedate->days(), $timedate->hours(), $timedate->minutes();
-            }
-            elsif ($timedate->hours() > 0) {
-                return sprintf '%02d:%02d hours', $timedate->hours(), $timedate->minutes();
-            }
-            return sprintf '%02d:%02d minutes', $timedate->minutes(), $timedate->seconds();
-        });
+    $app->helper(format_time_duration => \&_format_time_duration);
 
     $app->helper(bugurl_for => sub ($c, $bugref = undef) { bugurl($bugref) });
 
@@ -87,38 +77,7 @@ sub register ($self, $app, $config) {
 
     $app->helper(rendered_refs_no_shortening => sub ($c, $text) { render_escaped_refs($text) });
 
-    $app->helper(
-        current_job_group => sub ($c) {
-            my $job = $c->stash('job') or return;
-            my $distri = $c->stash('distri');
-            my $build = $c->stash('build');
-            my $version = $c->stash('version');
-            my $group_id = $job->group_id;
-            return if !$group_id && !($distri && $build && $version);
-
-            my %query = (build => $build, distri => $distri, version => $version);
-            my ($crumbs, $overview_text);
-            if ($group_id) {
-                $query{groupid} = $group_id;
-                $crumbs .= "\n<li id='current-group-overview'>";
-                $crumbs
-                  .= $c->link_to($c->url_for('group_overview', groupid => $group_id) => (class => 'dropdown-item') =>
-                      sub { return $job->group->name . ' (current)' });
-                $crumbs .= '</li>';
-                $overview_text = 'Build ' . $job->BUILD;
-            }
-            else {
-                $overview_text = "Build $build\@$distri $version";
-            }
-            my $overview_url = $c->url_for('tests_overview')->query(%query);
-
-            $crumbs .= "\n<li id='current-build-overview'>";
-            $crumbs .= $c->link_to($overview_url => (class => 'dropdown-item') =>
-                  sub { '<i class="fa-solid fa-arrow-right"></i> ' . $overview_text });
-            $crumbs .= '</li>';
-            $crumbs .= "\n<li role='separator' class='dropdown-divider'></li>\n";
-            return Mojo::ByteStream->new($crumbs);
-        });
+    $app->helper(current_job_group => \&_current_job_group);
 
     $app->helper(current_job => sub ($c) { $c->stash('job') });
     $app->helper(current_theme => sub ($c) { $c->session->{theme} || 'light' });
@@ -144,17 +103,7 @@ sub register ($self, $app, $config) {
             return $c->url_for(assetpack => $icon_asset->TO_JSON);
         });
 
-    $app->helper(
-        favicon_url => sub ($c, $suffix) {
-            if (my $job = $c->stash('job')) {
-                my $status = $job->status;
-                return $c->icon_url("logo-$status$suffix");
-            }
-            if (my $agg_status = $c->stash('aggregate_status')) {
-                return $c->icon_url("logo-aggregate-$agg_status$suffix") if $agg_status ne 'none';
-            }
-            return $c->icon_url("logo$suffix");
-        });
+    $app->helper(favicon_url => \&_favicon_url);
 
     $app->helper(
         # generate popover help button with title, content and optional details_url
@@ -283,27 +232,7 @@ sub register ($self, $app, $config) {
                 });
         });
 
-    $app->helper(
-        populate_hash_with_needle_timestamps_and_urls => sub ($c, $needle, $hash) {
-            $hash->{last_seen} = $needle ? $needle->last_seen_time_fmt : 'unknown';
-            $hash->{last_match} = $needle ? $needle->last_matched_time_fmt : 'unknown';
-            return $hash unless $needle;
-            if (my $last_seen_module_id = $needle->last_seen_module_id) {
-                $hash->{last_seen_link} = $c->url_for(
-                    'admin_needle_module',
-                    module_id => $last_seen_module_id,
-                    needle_id => $needle->id
-                );
-            }
-            if (my $last_matched_module_id = $needle->last_matched_module_id) {
-                $hash->{last_match_link} = $c->url_for(
-                    'admin_needle_module',
-                    module_id => $last_matched_module_id,
-                    needle_id => $needle->id
-                );
-            }
-            return $hash;
-        });
+    $app->helper(populate_hash_with_needle_timestamps_and_urls => \&_populate_hash_with_needle_timestamps_and_urls);
 
     $app->helper(
         popover_link => sub ($c, $text, $url = undef) {
@@ -346,31 +275,107 @@ sub register ($self, $app, $config) {
             $c->res->headers->links($links);
         });
 
-    $app->helper(
-        regex_problem => sub ($c, $regexes, $context = undef) {
-            my $regex_problem;
-            for my $regex_string (@$regexes) {
-                # treat regex warnings as fatal as apparently not all problems are fatal errors
-                # note: We should not leave those warnings unhandled as they would end up in the log.
-                #       An example for such a warning is "$* matches null string many times in regex".
-                use warnings FATAL => 'regexp';
-                # test regex compilation and matching as some problems are only warned about when matching
-                try { '' =~ qr/$regex_string/ }
-                catch ($e) {
-                    # strip last part of error/warning as it does not contain anything useful for the user
-                    $regex_problem = $e;
-                    $regex_problem =~ s{/ at .*}{}s;
-                    last;
-                }
-            }
-            return $regex_problem && $context ? "$context: $regex_problem" : $regex_problem;
-        });
+    $app->helper(regex_problem => \&_regex_problem);
 
     $app->helper(
         log_url => sub ($c, $testid, $resultfile, $is_userfile = 1) {
             my $url = $c->url_for('test_file', testid => $testid, filename => $resultfile);
             return _domain_url_for($c, $url, $is_userfile);
         });
+}
+
+sub _format_time_duration ($c, $timedate = undef) {
+    return undef unless $timedate;
+    if ($timedate->days() > 0) {
+        return sprintf '%d days %02d:%02d hours', $timedate->days(), $timedate->hours(), $timedate->minutes();
+    }
+    elsif ($timedate->hours() > 0) {
+        return sprintf '%02d:%02d hours', $timedate->hours(), $timedate->minutes();
+    }
+    return sprintf '%02d:%02d minutes', $timedate->minutes(), $timedate->seconds();
+}
+
+sub _current_job_group ($c) {
+    my $job = $c->stash('job') or return undef;
+    my $distri = $c->stash('distri');
+    my $build = $c->stash('build');
+    my $version = $c->stash('version');
+    my $group_id = $job->group_id;
+    return undef if !$group_id && !($distri && $build && $version);
+
+    my %query = (build => $build, distri => $distri, version => $version);
+    my ($crumbs, $overview_text);
+    if ($group_id) {
+        $query{groupid} = $group_id;
+        $crumbs .= "\n<li id='current-group-overview'>";
+        $crumbs
+          .= $c->link_to($c->url_for('group_overview', groupid => $group_id) => (class => 'dropdown-item') =>
+              sub { return $job->group->name . ' (current)' });
+        $crumbs .= '</li>';
+        $overview_text = 'Build ' . $job->BUILD;
+    }
+    else {
+        $overview_text = "Build $build\@$distri $version";
+    }
+    my $overview_url = $c->url_for('tests_overview')->query(%query);
+
+    $crumbs .= "\n<li id='current-build-overview'>";
+    $crumbs .= $c->link_to($overview_url => (class => 'dropdown-item') =>
+          sub { '<i class="fa-solid fa-arrow-right"></i> ' . $overview_text });
+    $crumbs .= '</li>';
+    $crumbs .= "\n<li role='separator' class='dropdown-divider'></li>\n";
+    return Mojo::ByteStream->new($crumbs);
+}
+
+sub _favicon_url ($c, $suffix) {
+    if (my $job = $c->stash('job')) {
+        my $status = $job->status;
+        return $c->icon_url("logo-$status$suffix");
+    }
+    if (my $agg_status = $c->stash('aggregate_status')) {
+        return $c->icon_url("logo-aggregate-$agg_status$suffix") if $agg_status ne 'none';
+    }
+    return $c->icon_url("logo$suffix");
+}
+
+sub _populate_hash_with_needle_timestamps_and_urls ($c, $needle, $hash) {
+    $hash->{last_seen} = $needle ? $needle->last_seen_time_fmt : 'unknown';
+    $hash->{last_match} = $needle ? $needle->last_matched_time_fmt : 'unknown';
+    return $hash unless $needle;
+    if (my $last_seen_module_id = $needle->last_seen_module_id) {
+        $hash->{last_seen_link} = $c->url_for(
+            'admin_needle_module',
+            module_id => $last_seen_module_id,
+            needle_id => $needle->id
+        );
+    }
+    if (my $last_matched_module_id = $needle->last_matched_module_id) {
+        $hash->{last_match_link} = $c->url_for(
+            'admin_needle_module',
+            module_id => $last_matched_module_id,
+            needle_id => $needle->id
+        );
+    }
+    return $hash;
+}
+
+sub _regex_problem ($c, $regexes, $context = undef) {
+    my $regex_problem;
+    for my $regex_string (@$regexes) {
+        # treat regex warnings as fatal as apparently not all problems are fatal errors
+        # note: We should not leave those warnings unhandled as they would end up in the log.
+        #       An example for such a warning is "$* matches null string many times in regex".
+        use warnings FATAL => 'regexp';
+        # test regex compilation and matching as some problems are only warned about when matching
+        try { '' =~ qr/$regex_string/ }
+        catch ($e) {
+            # strip last part of error/warning as it does not contain anything useful for the user
+            $regex_problem = $e;
+            $regex_problem =~ s{/ at .*}{}s;
+            last;
+        }
+    }
+    return $regex_problem && $context ? "$context: $regex_problem" : $regex_problem;
 }
 
 sub _domain_url_for ($c, $url, $is_userfile) {


### PR DESCRIPTION
https://metacpan.org/pod/Perl::Critic::Policy::Subroutines::ProhibitExcessComplexity

Lower the max_mccabe threshold from 63 to 39 and refactor the two subroutines

Policy description:
> The McCabe complexity, or cyclomatic complexity, is a measure of the
> number of possible paths through a section of code. As the number of
> conditional statements and loops increases, so does the number of paths,
> making the code harder to test and maintain.

Issue: https://progress.opensuse.org/issues/201318