### PR TITLE
fix(bci-bugs): Initialize build variable

### DIFF
--- a/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseBCIbug.pm
+++ b/lib/OpenQA/WebAPI/Plugin/IssueReporter/OpenSuseBCIbug.pm
@@ -20,6 +20,7 @@ sub actions ($c) {
     my $latest = $c->url_for('latest')->query($job->scenario_hash)->to_abs;
     my ($build, $image) = split /_/, $ctx->{build}, 2;
     $image //= 'NaN';
+    $build //= 'NaN';
 
     # CONTAINER_IMAGE_TO_TEST is required only for sles
     # opensuse container links are handled internally by BCI framework
@@ -104,5 +105,13 @@ Target: <%= $target %>
 
 ## Useful links
 
+% if ($raw_distri eq 'opensuse') {
+
 Last good: <%= $last_good %> (or more recent)
 The latest result in this scenario: <%= $latest %>
+% } else {
+== EDIT ==
+Manually enter last good result of sle BCI results
+==========
+% }
+


### PR DESCRIPTION
```
Use of uninitialized value $build in concatenation (.) or string at line 71.
```

Remove fetched useful links as this does not work in sle bci test results. The containers share the flavors, therefore the links point to unrelated test results and have to be manually edited.

- ticket: https://progress.opensuse.org/issues/205533